### PR TITLE
FSW-4177: update cmake install lines for ouster ros

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+[Unreleased]
+============
+* Update LICENSE installation.
+
 [20221004]
 ==========
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,8 +105,7 @@ install(
 
 install(
   FILES
-    ../LICENSE
-    ../LICENSE-bin
+    LICENSE
     nodelets_os.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN set -xe \
 FROM build-env
 
 ENV CXXFLAGS="-Werror -Wno-deprecated-declarations"
-RUN /opt/ros/$ROS_DISTRO/env.sh catkin_make -DCMAKE_BUILD_TYPE=Release
+RUN /opt/ros/$ROS_DISTRO/env.sh catkin_make -DCMAKE_BUILD_TYPE=Release \
+&& /opt/ros/$ROS_DISTRO/env.sh catkin_make install
 
 # Entrypoint for running Ouster ros:
 #

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -16,7 +16,8 @@
     512x20,
     1024x10,
     1024x20,
-    2048x10
+    2048x10,
+    4096x5
     }"/>
   <arg name="timestamp_mode" default="" doc="method used to timestamp measurements; possible values: {
     TIME_FROM_INTERNAL_OSC,

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -16,7 +16,8 @@
     512x20,
     1024x10,
     1024x20,
-    2048x10
+    2048x10,
+    4096x5
     }"/>
   <arg name="timestamp_mode" default="" doc="method used to timestamp measurements; possible values: {
     TIME_FROM_INTERNAL_OSC,


### PR DESCRIPTION
## Related PRs & Issues
* Closes #3 

## Summary of Changes
* Update `LICENSE` file installation instructions
* Removed the installation of `LICENSE-bin` as deemed unnecessary.
* Update `Dockerfile` to check for installation errors
* Add 4096x5 lidar mode to launch files

## Validation
Use catkin_make command to build and install the project 
```bash
catkin_make
catkin_make install
```
