### PR TITLE
SW-4007: State default argument in the ros launch files for optional ones

### DIFF
--- a/include/ouster_ros/os_client_base_nodelet.h
+++ b/include/ouster_ros/os_client_base_nodelet.h
@@ -19,6 +19,10 @@ class OusterClientBase : public nodelet::Nodelet {
     virtual void onInit() override;
 
    protected:
+    bool is_arg_set(const std::string& arg) {
+        return arg.find_first_not_of(' ') != std::string::npos;
+    }
+
     void display_lidar_info(const ouster::sensor::sensor_info& info);
 
    protected:

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -1,10 +1,10 @@
 <launch>
 
-  <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
-  <arg name="viz" default="false" doc="whether to run a rviz"/>
-  <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
-  <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
-  <arg name="timestamp_mode" default=""/>
+  <arg name="ouster_ns" doc="Override the default namespace of all ouster nodes"/>
+  <arg name="viz" doc="whether to run a rviz"/>
+  <arg name="rviz_config" doc="optional rviz config file"/>
+  <arg name="tf_prefix" doc="namespace for tf transforms"/>
+  <arg name="timestamp_mode" doc="method used to timestamp measurements"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -2,16 +2,16 @@
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="sensor_hostname" default="" doc="hostname or IP in dotted decimal form of the sensor"/>
-  <arg name="udp_dest" default="" doc="hostname or IP where the sensor will send data packets"/>
+  <arg name="udp_dest" default=" " doc="hostname or IP where the sensor will send data packets"/>
   <arg name="lidar_port" default="0" doc="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="0" doc="port to which the sensor should send imu data"/>
-  <arg name="udp_profile_lidar" default="" doc="lidar packet profile; possible values: {
+  <arg name="udp_profile_lidar" default=" " doc="lidar packet profile; possible values: {
     LEGACY,
     RNG19_RFL8_SIG16_NIR16_DUAL,
     RNG19_RFL8_SIG16_NIR16,
     RNG15_RFL8_NIR8
     }"/>
-  <arg name="lidar_mode" default="" doc="resolution and rate; possible vaules: {
+  <arg name="lidar_mode" default=" " doc="resolution and rate; possible vaules: {
     512x10,
     512x20,
     1024x10,
@@ -19,7 +19,7 @@
     2048x10,
     4096x5
     }"/>
-  <arg name="timestamp_mode" default="" doc="method used to timestamp measurements; possible values: {
+  <arg name="timestamp_mode" default=" " doc="method used to timestamp measurements; possible values: {
     TIME_FROM_INTERNAL_OSC,
     TIME_FROM_SYNC_PULSE_IN,
     TIME_FROM_PTP_1588,
@@ -29,7 +29,7 @@
   <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
-  <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
+  <arg name="tf_prefix" default=" " doc="namespace for tf transforms"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
-  <arg name="sensor_hostname" default="" doc="hostname or IP in dotted decimal form of the sensor"/>
+  <arg name="sensor_hostname" doc="hostname or IP in dotted decimal form of the sensor"/>
   <arg name="udp_dest" default=" " doc="hostname or IP where the sensor will send data packets"/>
   <arg name="lidar_port" default="0" doc="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="0" doc="port to which the sensor should send imu data"/>
@@ -25,8 +25,8 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="metadata" default="" doc="path to write metadata file when receiving sensor data"/>
-  <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
+  <arg name="metadata" doc="path to write metadata file when receiving sensor data"/>
+  <arg name="bag_file" doc="file name to use for the recorded bag file"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
   <arg name="tf_prefix" default=" " doc="namespace for tf transforms"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -26,7 +26,7 @@
     TIME_FROM_ROS_TIME
     }"/>
   <arg name="metadata" doc="path to write metadata file when receiving sensor data"/>
-  <arg name="bag_file" doc="file name to use for the recorded bag file"/>
+  <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
   <arg name="tf_prefix" default=" " doc="namespace for tf transforms"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -2,7 +2,7 @@
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" doc="path to read metadata file when replaying sensor data"/>
-  <arg name="bag_file" doc="file name to use for the recorded bag file"/>
+  <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="timestamp_mode" default=" " doc="A parameter that allows you to override the timestamp measurements;
     possible values: {
     TIME_FROM_ROS_TIME

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -1,8 +1,12 @@
 <launch>
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
-  <arg name="metadata" default="" doc="path to read metadata file when replaying sensor data"/>
-  <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
+  <arg name="metadata" doc="path to read metadata file when replaying sensor data"/>
+  <arg name="bag_file" doc="file name to use for the recorded bag file"/>
+  <arg name="timestamp_mode" default=" " doc="A parameter that allows you to override the timestamp measurements;
+    possible values: {
+    TIME_FROM_ROS_TIME
+    }"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
   <arg name="tf_prefix" default=" " doc="namespace for tf transforms"/>
@@ -24,10 +28,11 @@
   </group>
 
   <include file="$(find ouster_ros)/launch/common.launch">
-    <arg name="ouster_ns" default="$(arg ouster_ns)"/>
-    <arg name="viz" default="$(arg viz)"/>
-    <arg name="rviz_config" default="$(arg rviz_config)"/>
-    <arg name="tf_prefix" default="$(arg tf_prefix)"/>
+    <arg name="ouster_ns" value="$(arg ouster_ns)"/>
+    <arg name="viz" value="$(arg viz)"/>
+    <arg name="rviz_config" value="$(arg rviz_config)"/>
+    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
+    <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -2,9 +2,10 @@
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" default="" doc="path to read metadata file when replaying sensor data"/>
+  <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
-  <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
+  <arg name="tf_prefix" default=" " doc="namespace for tf transforms"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
-  <arg name="sensor_hostname" default="" doc="hostname or IP in dotted decimal form of the sensor"/>
+  <arg name="sensor_hostname" doc="hostname or IP in dotted decimal form of the sensor"/>
   <arg name="udp_dest" default=" " doc="hostname or IP where the sensor will send data packets"/>
   <arg name="lidar_port" default="0" doc="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="0" doc="port to which the sensor should send imu data"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -2,16 +2,16 @@
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="sensor_hostname" default="" doc="hostname or IP in dotted decimal form of the sensor"/>
-  <arg name="udp_dest" default="" doc="hostname or IP where the sensor will send data packets"/>
+  <arg name="udp_dest" default=" " doc="hostname or IP where the sensor will send data packets"/>
   <arg name="lidar_port" default="0" doc="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="0" doc="port to which the sensor should send imu data"/>
-  <arg name="udp_profile_lidar" default="" doc="lidar packet profile; possible values: {
+  <arg name="udp_profile_lidar" default=" " doc="lidar packet profile; possible values: {
     LEGACY,
     RNG19_RFL8_SIG16_NIR16_DUAL,
     RNG19_RFL8_SIG16_NIR16,
     RNG15_RFL8_NIR8
     }"/>
-  <arg name="lidar_mode" default="" doc="resolution and rate; possible vaules: {
+  <arg name="lidar_mode" default=" " doc="resolution and rate; possible vaules: {
     512x10,
     512x20,
     1024x10,
@@ -19,16 +19,16 @@
     2048x10,
     4096x5
     }"/>
-  <arg name="timestamp_mode" default="" doc="method used to timestamp measurements; possible values: {
+  <arg name="timestamp_mode" default=" " doc="method used to timestamp measurements; possible values: {
     TIME_FROM_INTERNAL_OSC,
     TIME_FROM_SYNC_PULSE_IN,
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="metadata" default="" doc="path to write metadata file when receiving sensor data"/>
+  <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
-  <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
+  <arg name="tf_prefix" default=" " doc="namespace for tf transforms"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -45,7 +45,7 @@ class OusterCloud : public nodelet::Nodelet {
         imu_frame = tf_prefix + "os_imu";
         lidar_frame = tf_prefix + "os_lidar";
         auto timestamp_mode_arg = pnh.param("timestamp_mode", std::string{});
-        use_ros_time = (timestamp_mode_arg == "TIME_FROM_ROS_TIME");
+        use_ros_time = timestamp_mode_arg == "TIME_FROM_ROS_TIME";
 
         auto& nh = getNodeHandle();
         ouster_ros::GetMetadata metadata{};

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -31,11 +31,15 @@ using namespace std::chrono_literals;
 namespace nodelets_os {
 class OusterCloud : public nodelet::Nodelet {
    private:
+
+    bool is_arg_set(const std::string& arg) {
+        return arg.find_first_not_of(' ') != std::string::npos;
+    }
+
     virtual void onInit() override {
         auto& pnh = getPrivateNodeHandle();
-
         auto tf_prefix = pnh.param("tf_prefix", std::string{});
-        if (!tf_prefix.empty() && tf_prefix.back() != '/')
+        if (is_arg_set(tf_prefix) && tf_prefix.back() != '/')
             tf_prefix.append("/");
         sensor_frame = tf_prefix + "os_sensor";
         imu_frame = tf_prefix + "os_imu";

--- a/src/os_replay_nodelet.cpp
+++ b/src/os_replay_nodelet.cpp
@@ -20,7 +20,7 @@ class OusterReplay : public OusterClientBase {
     virtual void onInit() override {
         auto& pnh = getPrivateNodeHandle();
         auto meta_file = pnh.param("metadata", std::string{});
-        if (!meta_file.size()) {
+        if (is_arg_set(meta_file)) {
             NODELET_ERROR("Must specify metadata file in replay mode");
             throw std::runtime_error("metadata no specificed");
         }

--- a/src/os_replay_nodelet.cpp
+++ b/src/os_replay_nodelet.cpp
@@ -20,7 +20,7 @@ class OusterReplay : public OusterClientBase {
     virtual void onInit() override {
         auto& pnh = getPrivateNodeHandle();
         auto meta_file = pnh.param("metadata", std::string{});
-        if (is_arg_set(meta_file)) {
+        if (!is_arg_set(meta_file)) {
             NODELET_ERROR("Must specify metadata file in replay mode");
             throw std::runtime_error("metadata no specificed");
         }

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -79,7 +79,7 @@ class OusterSensor : public OusterClientBase {
 
     void save_metadata(ros::NodeHandle& nh) {
         auto meta_file = nh.param("metadata", std::string{});
-        if (!meta_file.size()) {
+        if (is_arg_set(meta_file)) {
             meta_file =
                 hostname.substr(0, hostname.rfind('.')) + "-metadata.json";
             NODELET_WARN_STREAM(
@@ -141,7 +141,7 @@ class OusterSensor : public OusterClientBase {
     std::shared_ptr<sensor::client> create_client(const std::string& hostname,
                                                   int lidar_port,
                                                   int imu_port) {
-        if (!hostname.size()) {
+        if (hostname.empty()) {
             auto error_msg = "Must specify a sensor hostname";
             NODELET_ERROR_STREAM(error_msg);
             throw std::runtime_error(error_msg);
@@ -167,16 +167,14 @@ class OusterSensor : public OusterClientBase {
     std::pair<sensor::sensor_config, int> create_sensor_config_rosparams(
         ros::NodeHandle& nh) {
         auto udp_dest = nh.param("udp_dest", std::string{});
-        auto lidar_mode_arg = nh.param("lidar_mode", std::string{});
-        auto timestamp_mode_arg = nh.param("timestamp_mode", std::string{});
         auto lidar_port = nh.param("lidar_port", 0);
         auto imu_port = nh.param("imu_port", 0);
-
-        std::string udp_profile_lidar_arg;
-        nh.param<std::string>("udp_profile_lidar", udp_profile_lidar_arg, "");
+        auto lidar_mode_arg = nh.param("lidar_mode", std::string{});
+        auto timestamp_mode_arg = nh.param("timestamp_mode", std::string{});
+        auto udp_profile_lidar_arg = nh.param("udp_profile_lidar", std::string{});
 
         optional<sensor::UDPProfileLidar> udp_profile_lidar;
-        if (!udp_profile_lidar_arg.empty()) {
+        if (is_arg_set(udp_profile_lidar_arg)) {
             // set lidar profile from param
             udp_profile_lidar =
                 sensor::udp_profile_lidar_of_string(udp_profile_lidar_arg);
@@ -190,7 +188,7 @@ class OusterSensor : public OusterClientBase {
 
         // set lidar mode from param
         sensor::lidar_mode lidar_mode = sensor::MODE_UNSPEC;
-        if (!lidar_mode_arg.empty()) {
+        if (is_arg_set(lidar_mode_arg)) {
             lidar_mode = sensor::lidar_mode_of_string(lidar_mode_arg);
             if (!lidar_mode) {
                 auto error_msg = "Invalid lidar mode: " + lidar_mode_arg;
@@ -201,7 +199,7 @@ class OusterSensor : public OusterClientBase {
 
         // set timestamp mode from param
         sensor::timestamp_mode timestamp_mode = sensor::TIME_FROM_UNSPEC;
-        if (!timestamp_mode_arg.empty()) {
+        if (is_arg_set(timestamp_mode_arg)) {
             // In case the option TIME_FROM_ROS_TIME is set then leave the
             // sensor timestamp_mode unmodified
             if (timestamp_mode_arg == "TIME_FROM_ROS_TIME") {
@@ -230,7 +228,7 @@ class OusterSensor : public OusterClientBase {
 
         uint8_t config_flags = 0;
 
-        if (udp_dest.size()) {
+        if (is_arg_set(udp_dest)) {
             NODELET_INFO("Will send UDP data to %s", udp_dest.c_str());
             config.udp_dest = udp_dest;
         } else {

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -79,7 +79,7 @@ class OusterSensor : public OusterClientBase {
 
     void save_metadata(ros::NodeHandle& nh) {
         auto meta_file = nh.param("metadata", std::string{});
-        if (is_arg_set(meta_file)) {
+        if (!is_arg_set(meta_file)) {
             meta_file =
                 hostname.substr(0, hostname.rfind('.')) + "-metadata.json";
             NODELET_WARN_STREAM(


### PR DESCRIPTION
## Related Issues & PRs
- N/A

## Summary of Changes
- Adjust argument parsing such that it is known which args are required and which are optional
- Allow the user to pass `timestamp_mode` during replay to override the timestamp on IMU and LIDAR packets. 

## Validation
* The following command should reflect the exact requirement of what is considered a required roslaunch file argument as specified in the [usage section](https://github.com/ouster-lidar/ouster-ros#usage) of the repo readme file
```bash
roslaunch ouster_ros sensor.launch --ros-args
roslaunch ouster_ros record.launch --ros-args
roslaunch ouster_ros replay.launch --ros-args
```
* Invoking `roslaunch ouster_ros sensor.launch` without specifying `sensor_hostname` should fail immediately
* Invoking `record.launch` or `replay.launch` without specifying `metadata` should fail immediately.
* It is now possible to specify the `timestamp_mode` parameter value during replay.
  - Setting `timestamp_mode` to **TIME_FROM_ROS_TIME** modifies the timestamp of published IMU and Lidar ROS messages.  
* Functionality is maintained