### PR TITLE
SW-4278: ros driver doesn't use correct udp_dest given by user during launch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Changelog
 =========
 
-[Unreleased]
+[unreleased]
 ============
-* Update LICENSE installation.
+* correct LICENSE file installation path.
+* bug fix: ros driver doesn't use correct udp_dest given by user during launch
 
 [20221004]
 ==========

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -11,7 +11,7 @@
     RNG19_RFL8_SIG16_NIR16,
     RNG15_RFL8_NIR8
     }"/>
-  <arg name="lidar_mode" default=" " doc="resolution and rate; possible vaules: {
+  <arg name="lidar_mode" default=" " doc="resolution and rate; possible values: {
     512x10,
     512x20,
     1024x10,

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -11,7 +11,7 @@
     RNG19_RFL8_SIG16_NIR16,
     RNG15_RFL8_NIR8
     }"/>
-  <arg name="lidar_mode" default=" " doc="resolution and rate; possible vaules: {
+  <arg name="lidar_mode" default=" " doc="resolution and rate; possible values: {
     512x10,
     512x20,
     1024x10,

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -31,11 +31,12 @@ class OusterSensor : public OusterClientBase {
     virtual void onInit() override {
         auto& pnh = getPrivateNodeHandle();
         hostname = pnh.param("sensor_hostname", std::string{});
-        auto lidar_port = pnh.param("lidar_port", 0);
-        auto imu_port = pnh.param("imu_port", 0);
         auto sensor_conf = create_sensor_config_rosparams(pnh);
         configure_sensor(hostname, sensor_conf.first, sensor_conf.second);
-        sensor_client = create_client(hostname, lidar_port, imu_port);
+        auto udp_dest = pnh.param("udp_dest", std::string{});
+        auto lidar_port = pnh.param("lidar_port", 0);
+        auto imu_port = pnh.param("imu_port", 0);
+        sensor_client = create_client(hostname, udp_dest, lidar_port, imu_port);
         update_config_and_metadata(*sensor_client);
         save_metadata(pnh);
         OusterClientBase::onInit();
@@ -139,6 +140,7 @@ class OusterSensor : public OusterClientBase {
     }
 
     std::shared_ptr<sensor::client> create_client(const std::string& hostname,
+                                                  const std::string& udp_dest,
                                                   int lidar_port,
                                                   int imu_port) {
         if (hostname.empty()) {
@@ -152,7 +154,7 @@ class OusterSensor : public OusterClientBase {
 
         // use no-config version of init_client to allow for random ports
         auto cli =
-            sensor::init_client(hostname, "", sensor::MODE_UNSPEC,
+            sensor::init_client(hostname, udp_dest, sensor::MODE_UNSPEC,
                                 sensor::TIME_FROM_UNSPEC, lidar_port, imu_port);
 
         if (!cli) {


### PR DESCRIPTION
## Related Issues & PRs
Closes #20  

## Summary of Changes
- Feed `udp_dest` value set by the user from either `sensor.launch` or `record.launch`
- Fix minor typos

## Validation
* Rest the sensor udp dest to local
* Execute the following launch sequence
```bash
# SENSOR_HOSTNAME=<sensor hostname>
# UDP_DEST=<udp dest ip>
roslaunch ouster_ros sensor.launch sensor_hostname:=$SENSOR_HOSTNAME udp_dest:=$UDP_DEST
```
* Observe that the sensor now uses the selected `$UDP_DEST` value specified during launch