### PR TITLE
Declare missing curl dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>curl</depend>
 
   <build_depend>boost</build_depend>
   <build_depend>nodelet</build_depend>


### PR DESCRIPTION
## Related Issues & PRs

None.

## Summary of Changes

This declares the curl dependency in the package manifest. On most systems, curl is already installed, so this doesn't make any difference, but if you're building this on a minimal system (docker container, for instance), then you'll have a broken build.

## Validation

I've built the package with and without declaring this, in a docker container that doesn't have curl preinstalled. When declared, rosdep picks it up and all is well.