### PR TITLE
SW-4250: Update published TF transforms time with senosr or ros time based on the active timestamp mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,12 @@ Changelog
 [unreleased]
 ============
 * correct LICENSE file installation path.
+* update code files copyrights period.
 * bug fix: ros driver doesn't use correct udp_dest given by user during launch
+* update published TF transforms time with senosr or ros time based on the
+  active timestamp mode.
+* breaking change: renamed ``ouster_ros/ros.h`` to ``ouster_ros/os_ros.h`` and
+  ``ouster_ros/point.h`` to ``ouster_ros/os_point.h``.
 
 [20221004]
 ==========

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ include_directories(${_ouster_ros_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 # use only MPL-licensed parts of eigen
 add_definitions(-DEIGEN_MPL2_ONLY)
 
-add_library(ouster_ros src/ros.cpp)
+add_library(ouster_ros src/os_ros.cpp)
 target_link_libraries(ouster_ros PUBLIC ${catkin_LIBRARIES} ouster_build pcl_common PRIVATE
   -Wl,--whole-archive ouster_client -Wl,--no-whole-archive)
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -4,8 +4,8 @@
 ===================================
 Migrating from 20220608 to 20220826
 ===================================
-The ``20220826`` release brought several improvements to the **ouster-ros**, however, these
-improvements included several breaking changes. This guide summarizes these change and how to
+The ``20220826`` release brought several improvements to the **ouster-ros** driver, however, these
+improvements brought also several breaking changes. This guide summarizes these change and how to
 mitigate each one.
 
 Launch Files:

--- a/include/ouster_ros/os_client_base_nodelet.h
+++ b/include/ouster_ros/os_client_base_nodelet.h
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2018, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
  *
- * @file
+ * @file os_client_base_nodelet.h
  * @brief Base class for ouster_ros sensor and replay nodelets
  *
  */
@@ -10,7 +10,7 @@
 #include <nodelet/nodelet.h>
 #include <ros/ros.h>
 
-#include "ouster/types.h"
+#include <ouster/types.h>
 
 namespace nodelets_os {
 

--- a/include/ouster_ros/os_point.h
+++ b/include/ouster_ros/os_point.h
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2018, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
  *
- * @file
+ * @file point.h
  * @brief PCL point datatype for use with ouster sensors
  */
 
@@ -13,7 +13,7 @@
 #include <Eigen/Core>
 #include <chrono>
 
-#include "ouster/lidar_scan.h"
+#include <ouster/lidar_scan.h>
 
 namespace ouster_ros {
 

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2018, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
  *
- * @file
+ * @file os_ros.h
  * @brief Higher-level functions to read data from the ouster sensors as ROS
  * messages
  */
@@ -21,11 +21,12 @@
 #include <chrono>
 #include <string>
 
-#include "ouster/client.h"
-#include "ouster/lidar_scan.h"
-#include "ouster/types.h"
+#include <ouster/client.h>
+#include <ouster/lidar_scan.h>
+#include <ouster/types.h>
+
 #include "ouster_ros/PacketMsg.h"
-#include "ouster_ros/point.h"
+#include "ouster_ros/os_point.h"
 
 namespace ouster_ros {
 
@@ -118,9 +119,11 @@ sensor_msgs::PointCloud2 cloud_to_cloud_msg(const Cloud& cloud,
  * @param[in] mat transformation matrix return by sensor
  * @param[in] frame the parent frame of the published transform
  * @param[in] child_frame the child frame of the published transform
+ * @param[in] timestamp value to set as the timestamp of the generated
+ * TransformStamped message
  * @return ROS message suitable for publishing as a transform
  */
 geometry_msgs::TransformStamped transform_to_tf_msg(
     const ouster::mat4d& mat, const std::string& frame,
-    const std::string& child_frame);
+    const std::string& child_frame, ros::Time timestamp = ros::Time::now());
 }  // namespace ouster_ros

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.5.2</version>
+  <version>0.6.0</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/os_client_base_nodelet.cpp
+++ b/src/os_client_base_nodelet.cpp
@@ -1,14 +1,14 @@
 /**
- * Copyright (c) 2022, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
  *
  * @file os_client_base_nodelet.cpp
- * @brief Implementatin of OusterClientBase
+ * @brief implementation of OusterClientBase interface
  */
 
 #include "ouster_ros/os_client_base_nodelet.h"
 
-#include "ouster/impl/build.h"
+#include <ouster/impl/build.h>
 #include "ouster_ros/GetMetadata.h"
 
 namespace sensor = ouster::sensor;

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
  *
  * @file os_image_nodelet.cpp
@@ -11,7 +11,11 @@
  * vision applications, use higher bit depth values in /os_cloud_node/points
  */
 
-#include "ouster_ros/ros.h"
+// prevent clang-format from altering the location of "ouster_ros/ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
 
 #include <nodelet/nodelet.h>
 #include <pcl/conversions.h>

--- a/src/os_replay_nodelet.cpp
+++ b/src/os_replay_nodelet.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
  *
  * @file os_replay_nodelet.cpp

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -1,9 +1,16 @@
 /**
- * Copyright (c) 2018, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
+ * 
+ * @file ros.cpp
+ * @brief A nodelet that connects to a live ouster sensor
  */
 
-#include "ouster_ros/ros.h"
+// prevent clang-format from altering the location of "ouster_ros/ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
 
 #include <pcl_conversions/pcl_conversions.h>
 #include <ros/ros.h>
@@ -175,13 +182,13 @@ sensor_msgs::PointCloud2 cloud_to_cloud_msg(const Cloud& cloud, ns ts,
 
 geometry_msgs::TransformStamped transform_to_tf_msg(
     const ouster::mat4d& mat, const std::string& frame,
-    const std::string& child_frame) {
+    const std::string& child_frame, ros::Time timestamp) {
     Eigen::Affine3d aff;
     aff.linear() = mat.block<3, 3>(0, 0);
     aff.translation() = mat.block<3, 1>(0, 3) * 1e-3;
 
     geometry_msgs::TransformStamped msg = tf2::eigenToTransform(aff);
-    msg.header.stamp = ros::Time::now();
+    msg.header.stamp = timestamp;
     msg.header.frame_id = frame;
     msg.child_frame_id = child_frame;
 

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -1,12 +1,16 @@
 /**
- * Copyright (c) 2022, Ouster, Inc.
+ * Copyright (c) 2018-2022, Ouster, Inc.
  * All rights reserved.
  *
  * @file os_sensor_nodelet.cpp
  * @brief A nodelet that connects to a live ouster sensor
  */
 
-#include "ouster_ros/ros.h"
+// prevent clang-format from altering the location of "ouster_ros/ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
 
 #include <pluginlib/class_list_macros.h>
 


### PR DESCRIPTION
## Related Issues & PRs
- Closes #9 

## Summary of Changes
- Update published TF transforms time with senosr or ros time based on the active timestamp mode
- Renamed `ros.h` and `point.h` to `os_ros.h` and `point.h`
- Updated code files copyrights period
- Updated driver version to `0.6.0`

## Validation
A. With _timestamp_mode_ set **TIME_FROM_ROS_TIME**
  1. Launch the driver either through live or replay mode with _timestamp_mode_ set to **TIME_FROM_ROS_TIME**
```bash
SENSOR_HOSTNAME=<sensor>
roslaunch ouster_ros sensor.launch \
  sensor_hostname:=$SENSOR_HOSTNAME \
  timestamp_mode:=TIME_FROM_ROS_TIME
```
  2. In a separate terminal, observe the timestamp of both **os_imu** and **os_lidar** frame with respect to **os_sensor**
```bash
rosrun tf tf_echo os_sensor os_imu
rosrun tf tf_echo os_sensor os_lidar
```
  3. The timestamp of both transform messages should be updated on each echo and should match the system clock (reported as epoch time).

B. With _timestamp_mode_ set a value other than **TIME_FROM_ROS_TIME**
  -  Repeat both step 1. and 2. but with _timestamp_mode_ set to any of the values **TIME_FROM_INTERNAL_OSC** or **TIME_FROM_SYNC_PULSE_IN**.
  - The timestamp of both transform messages should be updated on each echo and should match the respective sensor clock (reported as epoch time).

C. [optional] With _timestamp_mode_ set to **TIME_FROM_PTP_1588**
  - Repeat B. but with _timestamp_mode_ set to **TIME_FROM_PTP_1588** 
