### PR TITLE
SW-4328: Update ouster-sdk to 2.5/3.0 FW release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 [unreleased]
 ============
+
+ouster_ros
+----------
 * correct LICENSE file installation path.
 * update code files copyrights period.
 * bug fix: ros driver doesn't use correct udp_dest given by user during launch
@@ -11,6 +14,22 @@ Changelog
   active timestamp mode.
 * breaking change: renamed ``ouster_ros/ros.h`` to ``ouster_ros/os_ros.h`` and
   ``ouster_ros/point.h`` to ``ouster_ros/os_point.h``.
+
+ouster_client
+--------------
+* breaking change: signal multiplier type changed to double to support new FW values of signal
+  multiplier.
+* breaking change: make_xyz_lut takes mat4d beam_to_lidar_transform instead of
+  lidar_origin_to_beam_origin_mm double to accomodate new FWs. Old reference Python implementation
+  was kept, but new reference was also added.
+* address an issue that could cause the processed frame being dropped in favor or the previous
+  frame when the frame_id wraps-around.
+* added a new flag ``CONFIG_FORCE_REINIT`` for ``set_config()`` method, to force the sensor to reinit
+  even when config params have not changed.
+* breaking change: drop defaults parameters from the shortform ``init_client()`` method.
+* added a new method ``init_logger()`` to provide control over the logs emitted by ``ouster_client``.
+* add parsing for new FW 3.0 thermal features shot_limiting and thermal_shutdown statuses and countdowns
+* add frame_status to LidarScan
 
 [20221004]
 ==========

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,15 @@ RUN set -xue \
 # Turn off installing extra packages globally to slim down rosdep install
 && echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommend \
 && apt-get update \
-&& apt-get install -y \
- build-essential cmake \
- fakeroot dpkg-dev debhelper \
- $PY-rosdep $PY-rospkg $PY-bloom
-
-RUN apt-get install -y curl libcurl4-openssl-dev
+&& apt-get install -y       \
+    build-essential         \
+    cmake                   \
+    fakeroot                \
+    dpkg-dev                \
+    debhelper               \
+    $PY-rosdep              \
+    $PY-rospkg              \
+    $PY-bloom
 
 # Set up non-root build user
 ARG BUILD_UID=1000

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ sudo apt install -y \
     build-essential \
     libeigen3-dev   \
     libjsoncpp-dev  \
+    libspdlog-dev   \
     cmake
 ```
 

--- a/package.xml
+++ b/package.xml
@@ -12,8 +12,6 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>curl</depend>
-  <depend>spdlog</depend>
 
   <build_depend>boost</build_depend>
   <build_depend>nodelet</build_depend>
@@ -21,13 +19,17 @@
   <build_depend>eigen</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>tf2_eigen</build_depend>
-  <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>libpcl-common</build_depend>
   <build_depend>pcl_conversions</build_depend>
+  <build_depend>curl</build_depend>
+  <build_depend>spdlog</build_depend>
   
   <exec_depend>nodelet</exec_depend>
   <exec_depend>libjsoncpp</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>curl</exec_depend>
+  <exec_depend>spdlog</exec_depend>
 
   <test_depend>gtest</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   <build_depend>eigen</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>tf2_eigen</build_depend>
-  <build_depend>libpcl-common</build_depend>
+  <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>curl</build_depend>
   <build_depend>spdlog</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>curl</depend>
+  <depend>spdlog</depend>
 
   <build_depend>boost</build_depend>
   <build_depend>nodelet</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
https://github.com/ouster-lidar/ouster_example/pull/456

## Summary of Changes
- Propagating ouster-sdk release to ouster-ros
- ouster-sdk changes:
  - Additions:
    - Add init_logger() method to control logs emitted by ouster_client
    - Parsing for FW 3.0/2.5 thermal features
    - convenience string output functions for LidarScan
    - new flag CONFIG_FORCE_REINIT for set_config() method to force reinit
    - improvements to the ouster_viz library
  - Breaking changes:
    - signal multiplier type changed to double
    - make_xyz_lut takes mat4d instead of double to handle tf from beam to lidar frame
    - drop default parameters from shortform init_client()
    - drop default parameters of Python client.Sensor() constructor
    - change Python Scans interface timeout to default to 1 second instead of None
  - Bug Fixes:
    - Address processed frame drop when frame_id wraps around

## Validation
- N/A