### PR TITLE
SW-4279: revise ouster-ros set_config/init_client sequence after release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ ouster_ros
   active timestamp mode.
 * breaking change: renamed ``ouster_ros/ros.h`` to ``ouster_ros/os_ros.h`` and
   ``ouster_ros/point.h`` to ``ouster_ros/os_point.h``.
+* validate lidar and imu port values. warn users when assigning random port numbers.
 
 ouster_client
 --------------

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.7.0</version>
+  <version>0.7.1</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -163,8 +163,8 @@ class OusterSensor : public OusterClientBase {
 
         std::shared_ptr<sensor::client> cli;
         if (lidar_port != 0 && imu_port != 0) {
-            // the use no-config version of init_client to bind to
-            // pre-configured ports
+            // use no-config version of init_client to bind to pre-configured
+            // ports
             cli = sensor::init_client(hostname, lidar_port, imu_port);
         } else {
             // use the full init_client to generate and assign random ports to


### PR DESCRIPTION
## Related Issues & PRs
- N/A

## Summary of Changes
- Revise **ouster-ros** `set_config`/`init_client` sequence after release to avoid double set_config invocations
- Validate port numbers before `set_config`
- Inform user when a random port number is going to be assigned
- Refactor code

## Validation
A. Invalid ports case
  1. Negative port value
  ```bash
  roslaunch ouster_ros sensor.launch \
      sensor_hostname:=$SENSOR_HOSTNAME \
      lidar_port:=-1000  # ports can't be assigned a negative value.
  ```
  The client should exit immediately. repeat again with the `imu_port`
  2. Positive but out of range port value
  ```bash
  roslaunch ouster_ros sensor.launch \
      sensor_hostname:=$SENSOR_HOSTNAME \
      lidar_port:=1000000  # ports can't be assigned a value greater than 65535
  ```
B. Zero values 
  1. Assign zero to the lidar_port
  ```bash
  roslaunch ouster_ros sensor.launch \
      sensor_hostname:=$SENSOR_HOSTNAME \
      lidar_port:=0 \ # or leave empty
      imu_port:=7503
  ```
  The client will state that a random port will be assigned for the `lidar_port` but not for the `imu_port`.
  2. Assign zero to the imu_port
  ```bash
  roslaunch ouster_ros sensor.launch \
      sensor_hostname:=$SENSOR_HOSTNAME \
      lidar_port:=7502 \
      imu_port:=0  # or leave empty
  ```
  The client will state that a random port will be assigned for the imu_port but not for the lidar_port.
C. Pass valid port values 
```bash
roslaunch ouster_ros sensor.launch \
    sensor_hostname:=$SENSOR_HOSTNAME \
    lidar_port:=7502 \
    imu_port:=7503
```