### PR TITLE
Change informational prints from WARN to INFO

### DIFF
--- a/src/os_client_base_nodelet.cpp
+++ b/src/os_client_base_nodelet.cpp
@@ -30,9 +30,9 @@ void OusterClientBase::onInit() {
 }
 
 void OusterClientBase::display_lidar_info(const sensor::sensor_info& info) {
-    NODELET_WARN("Client version: %s", ouster::SDK_VERSION_FULL);
-    NODELET_WARN("Using lidar_mode: %s", sensor::to_string(info.mode).c_str());
-    NODELET_WARN("%s sn: %s firmware rev: %s", info.prod_line.c_str(),
+    NODELET_INFO("Client version: %s", ouster::SDK_VERSION_FULL);
+    NODELET_INFO("Using lidar_mode: %s", sensor::to_string(info.mode).c_str());
+    NODELET_INFO("%s sn: %s firmware rev: %s", info.prod_line.c_str(),
                  info.sn.c_str(), info.fw_rev.c_str());
 }
 

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -98,7 +98,7 @@ class OusterSensor : public OusterClientBase {
         if (!is_arg_set(meta_file)) {
             meta_file = sensor_hostname.substr(0, sensor_hostname.rfind('.')) +
                         "-metadata.json";
-            NODELET_WARN_STREAM(
+            NODELET_INFO_STREAM(
                 "No metadata file was specified, using: " << meta_file);
         }
 
@@ -304,7 +304,7 @@ class OusterSensor : public OusterClientBase {
             throw;
         }
 
-        NODELET_WARN_STREAM("Sensor " << hostname
+        NODELET_INFO_STREAM("Sensor " << hostname
                                       << " configured successfully");
     }
 


### PR DESCRIPTION
Hi!

The code has some WARN level prints that really aren't warnings. I've changed these to INFO level prints.

I'm guessing they were made WARN so that they are easier to find in a long list of output, but I still think they're better off as INFO level statements. Having warnings in the log makes me think something is wrong and needs to be fixed. My brain automatically parses orange text as something bad, so I reckon it's best to avoid orange warnings when everything is good.

If you agree, feel free to merge.