### PR TITLE
Update ouster-sdk to the 20230114 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog
 =========
 
-[unreleased]
-============
+[20230114]
+==========
 
 ouster_ros
 ----------
@@ -37,9 +37,12 @@ ouster_client
 * added a new method ``init_logger()`` to provide control over the logs emitted by ``ouster_client``.
 * add parsing for new FW 3.0 thermal features shot_limiting and thermal_shutdown statuses and countdowns
 * add frame_status to LidarScan
-* introduce a new method ``cartesianT()`` which speeds up the computation of point projecion from range
+* introduced a new method ``cartesianT()`` which speeds up the computation of point projecion from range
   image, the method also can process the cartesian product with single float precision. A new unit test
   ``cartesian_test`` which shows achieved speed up gains by the number of valid returns in lidar scan.
+* added ``RAW_HEADERS`` ChanField to LidarScan for packing headers and footer (alpha version, may be
+  changed/removed without notice in the future)
+
 
 [20221004]
 ==========

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.7.2</version>
+  <version>0.7.3</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
- https://github.com/ouster-lidar/ouster_example/pull/476
- https://github.com/ouster-lidar/ouster_example/pull/477

## Summary of Changes
* ouster_client changes
  - Bump versions for official release
  - Signal multiplier bugfix for FW 3.0
  - Metadata parsing robustification
  - preliminary RAW_HEADERS support
  - Update Changelog unreleased to release date

## Validation
N/A