### PR TITLE
Quick fixes in ROS2 - Foxy 

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -143,7 +143,7 @@ rclcpp_components_register_node(os_cloud_component
 
 # ==== os_image_component ====
 create_ros2_component(os_image_component
-  "src/os_processing_node_base;src/os_image_node.cpp"
+  "src/os_processing_node_base.cpp;src/os_image_node.cpp"
   ""
 )
 rclcpp_components_register_node(os_image_component

--- a/ouster-ros/include/ouster_ros/os_processing_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_processing_node_base.h
@@ -37,7 +37,7 @@ class OusterProcessingNodeBase : public rclcpp::Node {
 
    protected:
     // TODO: Add as node parameters?
-    static constexpr auto wait_time_per_attempt = std::chrono::seconds(10);
+    static const std::chrono::seconds wait_time_per_attempt;
     static constexpr auto total_attempts = 10;
 
     ouster::sensor::sensor_info info;

--- a/ouster-ros/launch/rviz.launch.py
+++ b/ouster-ros/launch/rviz.launch.py
@@ -37,14 +37,14 @@ def generate_launch_description():
         name="stp_sensor_imu",
         namespace=ouster_ns,
         condition=IfCondition(enable_static_tf),
-        arguments=["--frame-id", "os_sensor", "--child-frame-id", "os_imu"])
+        arguments=["0", "0", "0", "0", "0", "0", "os_sensor", "os_imu"])
     sensor_ldr_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",
         name="stp_sensor_lidar",
         namespace=ouster_ns,
         condition=IfCondition(enable_static_tf),
-        arguments=["--frame-id", "os_sensor", "--child-frame-id", "os_lidar"])
+        arguments=["0", "0", "0", "0", "0", "0", "os_sensor", "os_lidar"])
 
     rviz_node = Node(
         package='rviz2',

--- a/ouster-ros/src/os_processing_node_base.cpp
+++ b/ouster-ros/src/os_processing_node_base.cpp
@@ -68,4 +68,6 @@ int OusterProcessingNodeBase::get_n_returns() {
                : 1;
 }
 
+const std::chrono::seconds OusterProcessingNodeBase::wait_time_per_attempt = std::chrono::seconds(10);
+    
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -86,7 +86,9 @@ class OusterSensor : public OusterSensorNodeBase {
         const rclcpp_lifecycle::State& state) {
         RCLCPP_DEBUG(get_logger(), "on_activate() is called.");
         LifecycleNode::on_activate(state);
-
+        lidar_packet_pub->on_activate();
+        imu_packet_pub->on_activate();
+       
         allocate_buffers();
         if (!connection_loop_timer) {
             // TOOD: replace with a thread instead?
@@ -763,8 +765,8 @@ class OusterSensor : public OusterSensorNodeBase {
     std::shared_ptr<sensor::client> sensor_client;
     PacketMsg lidar_packet;
     PacketMsg imu_packet;
-    rclcpp::Publisher<PacketMsg>::SharedPtr lidar_packet_pub;
-    rclcpp::Publisher<PacketMsg>::SharedPtr imu_packet_pub;
+    rclcpp_lifecycle::LifecyclePublisher<PacketMsg>::SharedPtr lidar_packet_pub;
+    rclcpp_lifecycle::LifecyclePublisher<PacketMsg>::SharedPtr imu_packet_pub;
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr reset_srv;
     rclcpp::Service<GetConfig>::SharedPtr get_config_srv;
     rclcpp::Service<SetConfig>::SharedPtr set_config_srv;


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes
Minor fixes of some issues that merged during testing of ros2-foxy branch.

- Fixed missing .cpp file extension in ouster-ros CMakeLists.txt
- Fixed arguments of `static_transform_publishers` in `rviz.launch.py`
- Definition of `wait_time_per_attempt` was moved to `ouster-ros/src/os_processing_node_base.cpp` since it was causing undefined symbol error while loading library os_image_component and os_cloud_component library
- Publishers `lidar_packet_pub` and `imu_packet_pub` were converted to LifecyclePublishers and activated in `on_activate` callback. Otherwise I was getting `Trying to publish message on the topic 'XXX', but the publisher is not activated`

## Validation
- Tested on Ubuntu 20.04, ROS2 foxy and Ouster OS0-128-U with FW 2.3.1 launching `sensor.independent.launch.py` since `sensor.launch.xml` points to `sensor.composite.launch.xml` that contains `node_container` which is not supported in foxy.




