### PR TITLE
Implement a technique to estimate scan_ts when packets are missing at beginning of a lidar scan

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ ouster_ros(1)
 * bugfix: Address an issue causing the driver to warn about missing non-legacy fields even they exist
   in the original metadata file.
 * added a new launch file ``sensor_mtp.launch`` for multicast use case (experimental).
+* added a technique to estimate the the value of the lidar scan timestamp when it is missing packets
+  at the beginning
 
 ouster_ros(2)
 -------------

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -35,6 +35,7 @@ using sensor::UDPProfileLidar;
 using namespace std::chrono_literals;
 
 namespace {
+
 template <typename T, typename UnaryPredicate>
 int find_if_reverse(const Eigen::Array<T, -1, 1>& array,
                     UnaryPredicate predicate) {
@@ -53,9 +54,11 @@ Y linear_interpolate(X x0, Y y0, X x1, Y y1, X x) {
 template <typename T>
 uint64_t ulround(T value) {
     T rounded_value = std::round(value);
-    return std::max(static_cast<T>(0),
-                    std::min(rounded_value, static_cast<T>(ULLONG_MAX)));
+    if (rounded_value < 0) return 0ULL;
+    if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
+    return static_cast<uint64_t>(rounded_value);
 }
+
 }  // namespace
 
 namespace nodelets_os {

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -179,15 +179,15 @@ class OusterCloud : public nodelet::Nodelet {
 
     uint64_t impute_value(int last_scan_last_nonzero_idx,
                           uint64_t last_scan_last_nonzero_value,
-                          int curr_scan_first_nonzero_index,
+                          int curr_scan_first_nonzero_idx,
                           uint64_t curr_scan_first_nonzero_value,
                           int scan_width) {
-        assert(scan_width + curr_scan_first_nonzero_index >
+        assert(scan_width + curr_scan_first_nonzero_idx >
                last_scan_last_nonzero_idx);
         double interpolated_value = linear_interpolate(
             last_scan_last_nonzero_idx,
             static_cast<double>(last_scan_last_nonzero_value),
-            scan_width + curr_scan_first_nonzero_index,
+            scan_width + curr_scan_first_nonzero_idx,
             static_cast<double>(curr_scan_first_nonzero_value), scan_width);
         return ulround(interpolated_value);
     }

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -287,8 +287,8 @@ class OusterCloud : public nodelet::Nodelet {
                                    const ros::Time current_time) {
         auto curr_scan_first_arrived_idx = packet_col_index(lidar_buf);
         auto delta_time = ros::Duration(
-            0, static_cast<int32_t>(std::round(scan_col_ts_spacing_ns *
-                                               curr_scan_first_arrived_idx)));
+            0,
+            std::lround(scan_col_ts_spacing_ns * curr_scan_first_arrived_idx));
         return current_time - delta_time;
     }
 

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -46,9 +46,8 @@ int find_if_reverse(const Eigen::Array<T, -1, 1>& array,
     return -1;
 }
 
-template <typename X, typename Y>
-Y linear_interpolate(X x0, Y y0, X x1, Y y1, X x) {
-    return y0 + (x - x0) * (y1 - y0) / (x1 - x0);
+uint64_t linear_interpolate(int x0, uint64_t y0, int x1, uint64_t y1, int x) {
+    return y0 + (x - x0) * static_cast<double>(y1 - y0) / (x1 - x0);
 }
 
 template <typename T>
@@ -199,10 +198,9 @@ class OusterCloud : public nodelet::Nodelet {
         assert(scan_width + curr_scan_first_nonzero_idx >
                last_scan_last_nonzero_idx);
         double interpolated_value = linear_interpolate(
-            last_scan_last_nonzero_idx,
-            static_cast<double>(last_scan_last_nonzero_value),
+            last_scan_last_nonzero_idx, last_scan_last_nonzero_value,
             scan_width + curr_scan_first_nonzero_idx,
-            static_cast<double>(curr_scan_first_nonzero_value), scan_width);
+            curr_scan_first_nonzero_value, scan_width);
         return ulround(interpolated_value);
     }
 
@@ -278,7 +276,8 @@ class OusterCloud : public nodelet::Nodelet {
                                    const ros::Time current_time) {
         auto curr_scan_first_arrived_idx = packet_col_index(lidar_buf);
         auto delta_time = ros::Duration(
-            0, scan_col_ts_spacing_ns * curr_scan_first_arrived_idx);
+            0, static_cast<int32_t>(std::round(scan_col_ts_spacing_ns *
+                                               curr_scan_first_arrived_idx)));
         return current_time - delta_time;
     }
 

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -47,7 +47,18 @@ int find_if_reverse(const Eigen::Array<T, -1, 1>& array,
 }
 
 uint64_t linear_interpolate(int x0, uint64_t y0, int x1, uint64_t y1, int x) {
-    return y0 + (x - x0) * static_cast<double>(y1 - y0) / (x1 - x0);
+    uint64_t min_v, max_v;
+    double sign;
+    if (y1 > y0) {
+        min_v = y0;
+        max_v = y1;
+        sign = +1;
+    } else {
+        min_v = y1;
+        max_v = y0;
+        sign = -1;
+    }
+    return y0 + (x - x0) * sign * (max_v - min_v) / (x1 - x0);
 }
 
 template <typename T>

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -196,7 +196,7 @@ class OusterCloud : public nodelet::Nodelet {
         const ouster::LidarScan::Header<uint64_t>& ts_v) {
         auto idx = std::find_if(ts_v.data(), ts_v.data() + ts_v.size(),
                                 [](uint64_t h) { return h != 0; });
-        assert(idx != ts_v.data() + ts_v.size());
+        assert(idx != ts_v.data() + ts_v.size());  // should never happen
         int curr_scan_first_nonzero_idx = idx - ts_v.data();
         uint64_t curr_scan_first_nonzero_value = *idx;
         static int last_scan_last_nonzero_idx =
@@ -212,6 +212,7 @@ class OusterCloud : public nodelet::Nodelet {
                                               static_cast<int>(ts_v.size()));
         last_scan_last_nonzero_idx =
             find_if_reverse(ts_v, [](uint64_t h) -> bool { return h != 0; });
+        assert(last_scan_last_nonzero_idx >= 0);  // should never happen
         last_scan_last_nonzero_value = ts_v(last_scan_last_nonzero_idx);
         return std::chrono::nanoseconds(scan_ns);
     }


### PR DESCRIPTION
## Related Issues & PRs
Closes #47 
Related #46 

## Summary of Changes
* Implement a technique to estimate `frame_ts` and `scan_ts` when packets are missing at beginning of a LIDAR scan
* The technique utilizes linear interpolation to impute the value of the frame time
  - The timestamp of the very first frame is extrapolated based on column time spacing
![image](https://user-images.githubusercontent.com/606033/221019663-b0b87873-c016-47ea-a81e-684b2e39853b.png)

> **Note**
> The `TIME_FROM_ROS_TIME` case extrapolates frame time based on the reception time of the first packet/column to arrive of a given frame.

## Validation
* Launch with a live sensor and observe that the timestamp of point cloud messages stays timestamps consistent regardless of the existence of the missing packets.