### PR TITLE
ROS1 - Adding latched topic transport config/metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,9 @@ ouster_ros(1)
 * add frame_id to image topics
 * fixed a potential issue of time values within generated point clouds that could result in a value
   overflow
-* added a ``metadata`` topic that is consumed by the cloud and image nodes and record it to bag file
-  by default
+* added a new ``/ouster/metadata`` topic that is consumed by os_cloud and os_image nodelets and
+  save it to the bag file on record
+* make specifying metadata file optinal as of package version 8.1
 
 ouster_ros(2)
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,18 @@ Changelog
 
 ouster_ros(1)
 -------------
+* breaking change: update to ouster_client release 20230403
 * EOL notice: ouster-ros driver will drop support for ``ROS melodic`` by May 2023.
 * bugfix: Address an issue causing the driver to warn about missing non-legacy fields even they exist
   in the original metadata file.
 * added a new launch file ``sensor_mtp.launch`` for multicast use case (experimental).
 * added a technique to estimate the the value of the lidar scan timestamp when it is missing packets
   at the beginning
+* add frame_id to image topics
+* fixed a potential issue of time values within generated point clouds that could result in a value
+  overflow
+* added a ``metadata`` topic that is consumed by the cloud and image nodes and record it to bag file
+  by default
 
 ouster_ros(2)
 -------------
@@ -22,6 +28,11 @@ ouster_ros(2)
 ouster_client
 -------------
 * added a new method ``mtp_init_client`` to init the client with multicast support (experimental).
+* the class ``SensorHttp``  which provides easy access to REST APIs of the sensor has been made public
+  under the ``ouster::sensor::util`` namespace.
+* breaking change: get_metadata defaults to outputting non-legacy metadata
+* add debug five_word profile which will be removed later
+* breaking change: remove deprecations on LidarScan
 
 
 [20230114]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [ROS1 (melodic/noetic)](https://github.com/ouster-lidar/ouster-ros/tree/master) |
 [ROS2 (rolling/humble)](https://github.com/ouster-lidar/ouster-ros/tree/ros2) |
-[ROS2 (foxy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2)
+[ROS2 (foxy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2-foxy)
 
 <p style="float: right;"><img width="20%" src="docs/images/logo.png" /></p>
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 - [Usage](#usage)
   - [Launching Nodes](#launching-nodes)
     - [Sensor Mode](#sensor-mode)
-    - [Replay Mode](#replay-mode)
     - [Recording Mode](#recording-mode)
+    - [Replay Mode](#replay-mode)
     - [Multicast Mode (experimental)](#multicast-mode-experimental)
   - [Invoking Services](#invoking-services)
     - [GetMetadata](#getmetadata)
@@ -102,19 +102,25 @@ roslaunch ouster_ros sensor.launch      \
     metadata:=<json file name>              # metadata is optional
 ```
 
-#### Replay Mode
-```bash
-roslaunch ouster_ros replay.launch      \
-    metadata:=<json file name>          \
-    bag_file:=<path to rosbag file>
-```
-
 #### Recording Mode
+> Note
+> As of package version 8.1, specifiying metadata file is optional since the introduction of the
+> metadata topic
 ```bash
 roslaunch ouster_ros record.launch      \
     sensor_hostname:=<sensor host name> \
-    metadata:=<json file name>          \
     bag_file:=<optional bag file name>
+    metadata:=<json file name>          # optional
+```
+#### Replay Mode
+> Note
+> As of package version 8.1, specifiying metadata file is optional if the bag file being replayed
+> already contains the metadata topic
+
+```bash
+roslaunch ouster_ros replay.launch      \
+    bag_file:=<path to rosbag file>     \
+    metadata:=<json file name>          # optional
 ```
 
 #### Multicast Mode (experimental)

--- a/include/ouster_ros/os_client_base_nodelet.h
+++ b/include/ouster_ros/os_client_base_nodelet.h
@@ -16,19 +16,23 @@ namespace nodelets_os {
 
 class OusterClientBase : public nodelet::Nodelet {
    protected:
-    virtual void onInit() override;
-
-   protected:
-    bool is_arg_set(const std::string& arg) {
+    bool is_arg_set(const std::string& arg) const {
         return arg.find_first_not_of(' ') != std::string::npos;
     }
 
     void display_lidar_info(const ouster::sensor::sensor_info& info);
 
+    void create_get_metadata_service(ros::NodeHandle& nh);
+
+    void create_metadata_publisher(ros::NodeHandle& nh);
+
+    void publish_metadata();
+
    protected:
     ouster::sensor::sensor_info info;
     ros::ServiceServer get_metadata_srv;
     std::string cached_metadata;
+    ros::Publisher metadata_pub;
 };
 
 }  // namespace nodelets_os

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -10,20 +10,17 @@
 #pragma once
 
 #define PCL_NO_PRECOMPILE
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-
-#include <sensor_msgs/Imu.h>
-#include <sensor_msgs/PointCloud2.h>
-
 #include <geometry_msgs/TransformStamped.h>
-
-#include <chrono>
-#include <string>
-
 #include <ouster/client.h>
 #include <ouster/lidar_scan.h>
 #include <ouster/types.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <sensor_msgs/Imu.h>
+#include <sensor_msgs/PointCloud2.h>
+
+#include <chrono>
+#include <string>
 
 #include "ouster_ros/PacketMsg.h"
 #include "ouster_ros/os_point.h"
@@ -89,9 +86,27 @@ sensor_msgs::Imu packet_to_imu_msg(const PacketMsg& pm,
  * @param[out] cloud output pcl pointcloud to populate
  * @param[in] return_index index of return desired starting at 0
  */
-void scan_to_cloud(const ouster::XYZLut& xyz_lut,
-                   ouster::LidarScan::ts_t scan_ts, const ouster::LidarScan& ls,
-                   ouster_ros::Cloud& cloud, int return_index = 0);
+[[deprecated("use the 2nd version of scan_to_cloud_f")]] void scan_to_cloud(
+    const ouster::XYZLut& xyz_lut, std::chrono::nanoseconds scan_ts,
+    const ouster::LidarScan& ls, ouster_ros::Cloud& cloud,
+    int return_index = 0);
+
+/**
+ * Populate a PCL point cloud from a LidarScan.
+ * @param[in, out] points The points parameters is used to store the results of
+ * the cartesian product before it gets packed into the cloud object.
+ * @param[in] lut_direction the direction of the xyz lut (with single precision)
+ * @param[in] lut_offset the offset of the xyz lut (with single precision)
+ * @param[in] scan_ts scan start used to caluclate relative timestamps for
+ * points.
+ * @param[in] ls input lidar data
+ * @param[out] cloud output pcl pointcloud to populate
+ * @param[in] return_index index of return desired starting at 0
+ */
+[[deprecated("use the 2nd version of scan_to_cloud_f")]] void scan_to_cloud_f(
+    ouster::PointsF& points, const ouster::PointsF& lut_direction,
+    const ouster::PointsF& lut_offset, std::chrono::nanoseconds scan_ts,
+    const ouster::LidarScan& ls, ouster_ros::Cloud& cloud, int return_index);
 
 /**
  * Populate a PCL point cloud from a LidarScan.
@@ -106,13 +121,10 @@ void scan_to_cloud(const ouster::XYZLut& xyz_lut,
  * @param[in] return_index index of return desired starting at 0
  */
 void scan_to_cloud_f(ouster::PointsF& points,
-                const ouster::PointsF& lut_direction,
-                const ouster::PointsF& lut_offset,
-                ouster::LidarScan::ts_t scan_ts,
-                const ouster::LidarScan& ls,
-                ouster_ros::Cloud& cloud,
-                int return_index);
-
+                     const ouster::PointsF& lut_direction,
+                     const ouster::PointsF& lut_offset, uint64_t scan_ts,
+                     const ouster::LidarScan& ls, ouster_ros::Cloud& cloud,
+                     int return_index);
 
 /**
  * Serialize a PCL point cloud to a ROS message

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -9,7 +9,6 @@
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
       output="screen" required="true"
-      launch-prefix="bash -c 'sleep 4; $0 $@' "
       args="load nodelets_os/OusterCloud os_nodelet_mgr">
       <param name="~/tf_prefix" type="str" value="$(arg tf_prefix)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
@@ -19,7 +18,6 @@
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="img_node"
       output="screen" required="true"
-      launch-prefix="bash -c 'sleep 4; $0 $@' "
       args="load nodelets_os/OusterImage os_nodelet_mgr">
     </node>
   </group>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -25,7 +25,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="metadata" doc="path to write metadata file when receiving sensor data"/>
+  <arg name="metadata" default="" doc="path to write metadata file when receiving sensor data"/>
   <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
@@ -41,7 +41,7 @@
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_node"
       output="screen" required="true"
-      launch-prefix="bash -c 'sleep 3; $0 $@' "
+      launch-prefix="bash -c 'sleep 1; $0 $@' "
       args="load nodelets_os/OusterSensor os_nodelet_mgr">
       <param name="~/sensor_hostname" type="str" value="$(arg sensor_hostname)"/>
       <param name="~/udp_dest" type="str" value="$(arg udp_dest)"/>
@@ -63,14 +63,18 @@
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>
-  <arg name="_topics_to_record" value="/$(arg ouster_ns)/imu_packets /$(arg ouster_ns)/lidar_packets"/>
+  <arg name="_topics_to_record" value="
+    /$(arg ouster_ns)/imu_packets
+    /$(arg ouster_ns)/lidar_packets
+    /$(arg ouster_ns)/metadata
+  "/>
 
-  <node if="$(arg _use_bag_file_name)" pkg="rosbag" type="record" name="rosbag_record_sensor"
-       output="screen" required="true"
-       args="record -O $(arg bag_file) $(arg _topics_to_record)"/>
+  <node if="$(arg _use_bag_file_name)" pkg="rosbag" type="record"
+    name="rosbag_record_sensor" output="screen" required="true"
+    args="record -O $(arg bag_file) $(arg _topics_to_record)"/>
 
-  <node unless="$(arg _use_bag_file_name)" pkg="rosbag" type="record" name="rosbag_record_sensor"
-       output="screen" required="true"
-       args="record $(arg _topics_to_record)"/>
+  <node unless="$(arg _use_bag_file_name)" pkg="rosbag" type="record"
+    name="rosbag_record_sensor" output="screen" required="true"
+    args="record $(arg _topics_to_record)"/>
 
 </launch>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
-  <arg name="metadata" doc="path to read metadata file when replaying sensor data"/>
+  <arg name="metadata" default ="" doc="path to read metadata file when replaying sensor data"/>
   <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="timestamp_mode" default=" " doc="A parameter that allows you to override the timestamp measurements;
     possible values: {
@@ -18,9 +18,11 @@
       args="manager"/>
   </group>
 
+  <arg name="_use_metadata_file" value="$(eval not (metadata == ''))"/>
+
   <group ns="$(arg ouster_ns)">
-    <node pkg="nodelet" type="nodelet" name="os_node"
-      output="screen" required="true"
+    <node if="$(arg _use_metadata_file)" pkg="nodelet" type="nodelet"
+      name="os_node" output="screen" required="true"
       launch-prefix="bash -c 'sleep 3; $0 $@' "
       args="load nodelets_os/OusterReplay os_nodelet_mgr">
       <param name="~/metadata" value="$(arg metadata)"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -40,7 +40,6 @@
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_node"
       output="screen" required="true"
-      launch-prefix="bash -c 'sleep 3; $0 $@' "
       args="load nodelets_os/OusterSensor os_nodelet_mgr">
       <param name="~/sensor_hostname" type="str" value="$(arg sensor_hostname)"/>
       <param name="~/udp_dest" type="str" value="$(arg udp_dest)"/>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -44,7 +44,6 @@
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_node"
       output="screen" required="true"
-      launch-prefix="bash -c 'sleep 3; $0 $@' "
       args="load nodelets_os/OusterSensor os_nodelet_mgr">
       <param name="~/sensor_hostname" type="str" value="$(arg sensor_hostname)"/>
       <param name="~/udp_dest" type="str" value="$(arg udp_dest)"/>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.7.4</version>
+  <version>0.8.1</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/os_client_base_nodelet.cpp
+++ b/src/os_client_base_nodelet.cpp
@@ -9,6 +9,7 @@
 #include "ouster_ros/os_client_base_nodelet.h"
 
 #include <ouster/impl/build.h>
+#include <std_msgs/String.h>
 
 #include "ouster_ros/GetMetadata.h"
 
@@ -17,8 +18,7 @@ using ouster_ros::GetMetadata;
 
 namespace nodelets_os {
 
-void OusterClientBase::onInit() {
-    auto& nh = getNodeHandle();
+void OusterClientBase::create_get_metadata_service(ros::NodeHandle& nh) {
     get_metadata_srv =
         nh.advertiseService<GetMetadata::Request, GetMetadata::Response>(
             "get_metadata",
@@ -28,6 +28,16 @@ void OusterClientBase::onInit() {
             });
 
     NODELET_INFO("get_metadata service created");
+}
+
+void OusterClientBase::create_metadata_publisher(ros::NodeHandle& nh) {
+    metadata_pub = nh.advertise<std_msgs::String>("metadata", 1, true);
+}
+
+void OusterClientBase::publish_metadata() {
+    std_msgs::String metadata_msg;
+    metadata_msg.data = cached_metadata;
+    metadata_pub.publish(metadata_msg);
 }
 
 void OusterClientBase::display_lidar_info(const sensor::sensor_info& info) {

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -123,10 +123,14 @@ class OusterImage : public nodelet::Nodelet {
         uint32_t H = info.format.pixels_per_column;
         uint32_t W = info.format.columns_per_frame;
 
-        auto range_image = make_image_msg(H, W, m->header.stamp);
-        auto signal_image = make_image_msg(H, W, m->header.stamp);
-        auto reflec_image = make_image_msg(H, W, m->header.stamp);
-        auto nearir_image = make_image_msg(H, W, m->header.stamp);
+        auto range_image =
+            make_image_msg(H, W, m->header.stamp, m->header.frame_id);
+        auto signal_image =
+            make_image_msg(H, W, m->header.stamp, m->header.frame_id);
+        auto reflec_image =
+            make_image_msg(H, W, m->header.stamp, m->header.frame_id);
+        auto nearir_image =
+            make_image_msg(H, W, m->header.stamp, m->header.frame_id);
 
         ouster::img_t<float> nearir_image_eigen(H, W);
         ouster::img_t<float> signal_image_eigen(H, W);
@@ -187,7 +191,8 @@ class OusterImage : public nodelet::Nodelet {
     }
 
     static sensor_msgs::ImagePtr make_image_msg(size_t H, size_t W,
-                                                const ros::Time& stamp) {
+                                                const ros::Time& stamp,
+                                                const std::string& frame) {
         auto msg = boost::make_shared<sensor_msgs::Image>();
         msg->width = W;
         msg->height = H;
@@ -195,6 +200,7 @@ class OusterImage : public nodelet::Nodelet {
         msg->encoding = sensor_msgs::image_encodings::MONO16;
         msg->data.resize(W * H * sizeof(pixel_type));
         msg->header.stamp = stamp;
+        msg->header.frame_id = frame;
         return msg;
     }
 

--- a/src/os_replay_nodelet.cpp
+++ b/src/os_replay_nodelet.cpp
@@ -20,15 +20,24 @@ namespace nodelets_os {
 class OusterReplay : public OusterClientBase {
    private:
     virtual void onInit() override {
+        NODELET_INFO("Running in replay mode");
+        auto meta_file = get_meta_file();
+        create_metadata_publisher(getNodeHandle());
+        read_metadata(meta_file);
+        publish_metadata();
+    }
+
+    std::string get_meta_file() const {
         auto& pnh = getPrivateNodeHandle();
         auto meta_file = pnh.param("metadata", std::string{});
         if (!is_arg_set(meta_file)) {
             NODELET_ERROR("Must specify metadata file in replay mode");
             throw std::runtime_error("metadata no specificed");
         }
+        return meta_file;
+    }
 
-        NODELET_INFO("Running in replay mode");
-
+    void read_metadata(const std::string meta_file) {
         // populate info for config service
         try {
             std::ifstream in_file(meta_file);
@@ -41,8 +50,6 @@ class OusterReplay : public OusterClientBase {
             cached_metadata.clear();
             NODELET_ERROR("Error when running in replay mode: %s", e.what());
         }
-
-        OusterClientBase::onInit();
     }
 };
 

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -2,8 +2,8 @@
  * Copyright (c) 2018-2023, Ouster, Inc.
  * All rights reserved.
  *
- * @file ros.cpp
- * @brief A nodelet that connects to a live ouster sensor
+ * @file os_ros.cpp
+ * @brief A utilty file that contains helper methods
  */
 
 // prevent clang-format from altering the location of "ouster_ros/ros.h", the
@@ -124,8 +124,9 @@ inline ouster::img_t<T> get_or_fill_zero(sensor::ChanField f,
 }
 
 void scan_to_cloud(const ouster::XYZLut& xyz_lut,
-                   ouster::LidarScan::ts_t scan_ts, const ouster::LidarScan& ls,
-                   ouster_ros::Cloud& cloud, int return_index) {
+                   std::chrono::nanoseconds scan_ts,
+                   const ouster::LidarScan& ls, ouster_ros::Cloud& cloud,
+                   int return_index) {
     bool second = (return_index == 1);
     cloud.resize(ls.w * ls.h);
 
@@ -171,19 +172,19 @@ void copy_scan_to_cloud(ouster_ros::Cloud& cloud, const ouster::LidarScan& ls,
                         const ouster::img_t<NearIrT>& near_ir,
                         const ouster::img_t<SignalT>& signal) {
     auto timestamp = ls.timestamp();
-
     const auto rg = range.data();
     const auto rf = reflectivity.data();
     const auto nr = near_ir.data();
     const auto sg = signal.data();
+    const auto t_zero = std::chrono::duration<long int, std::nano>::zero();
 
 #ifdef __OUSTER_UTILIZE_OPENMP__
 #pragma omp parallel for collapse(2)
 #endif
     for (auto u = 0; u < ls.h; u++) {
         for (auto v = 0; v < ls.w; v++) {
-            const auto ts = std::min(
-                std::chrono::nanoseconds(timestamp[v]) - scan_ts, scan_ts);
+            const auto col_ts = std::chrono::nanoseconds(timestamp[v]);
+            const auto ts = col_ts > scan_ts ? col_ts - scan_ts : t_zero;
             const auto idx = u * ls.w + v;
             const auto xyz = points.row(idx);
             cloud.points[idx] = ouster_ros::Point{
@@ -200,10 +201,79 @@ void copy_scan_to_cloud(ouster_ros::Cloud& cloud, const ouster::LidarScan& ls,
     }
 }
 
+template <typename PointT, typename RangeT, typename ReflectivityT,
+          typename NearIrT, typename SignalT>
+void copy_scan_to_cloud(ouster_ros::Cloud& cloud, const ouster::LidarScan& ls,
+                        uint64_t scan_ts, const PointT& points,
+                        const ouster::img_t<RangeT>& range,
+                        const ouster::img_t<ReflectivityT>& reflectivity,
+                        const ouster::img_t<NearIrT>& near_ir,
+                        const ouster::img_t<SignalT>& signal) {
+    auto timestamp = ls.timestamp();
+
+    const auto rg = range.data();
+    const auto rf = reflectivity.data();
+    const auto nr = near_ir.data();
+    const auto sg = signal.data();
+
+#ifdef __OUSTER_UTILIZE_OPENMP__
+#pragma omp parallel for collapse(2)
+#endif
+    for (auto u = 0; u < ls.h; u++) {
+        for (auto v = 0; v < ls.w; v++) {
+            const auto col_ts = timestamp[v];
+            const auto ts = col_ts > scan_ts ? col_ts - scan_ts : 0UL;
+            const auto idx = u * ls.w + v;
+            const auto xyz = points.row(idx);
+            cloud.points[idx] = ouster_ros::Point{
+                {static_cast<float>(xyz(0)), static_cast<float>(xyz(1)),
+                 static_cast<float>(xyz(2)), 1.0f},
+                static_cast<float>(sg[idx]),
+                static_cast<uint32_t>(ts),
+                static_cast<uint16_t>(rf[idx]),
+                static_cast<uint16_t>(u),
+                static_cast<uint16_t>(nr[idx]),
+                static_cast<uint32_t>(rg[idx]),
+            };
+        }
+    }
+}
+
 void scan_to_cloud_f(ouster::PointsF& points,
                      const ouster::PointsF& lut_direction,
                      const ouster::PointsF& lut_offset,
-                     ouster::LidarScan::ts_t scan_ts,
+                     std::chrono::nanoseconds scan_ts,
+                     const ouster::LidarScan& ls, ouster_ros::Cloud& cloud,
+                     int return_index) {
+    bool second = (return_index == 1);
+
+    assert(cloud.width == static_cast<std::uint32_t>(ls.w) &&
+           cloud.height == static_cast<std::uint32_t>(ls.h) &&
+           "point cloud and lidar scan size mismatch");
+
+    // across supported lidar profiles range is always 32-bit
+    auto range_channel_field =
+        second ? sensor::ChanField::RANGE2 : sensor::ChanField::RANGE;
+    ouster::img_t<uint32_t> range = ls.field<uint32_t>(range_channel_field);
+
+    ouster::img_t<uint16_t> reflectivity = get_or_fill_zero<uint16_t>(
+        suitable_return(sensor::ChanField::REFLECTIVITY, second), ls);
+
+    ouster::img_t<uint32_t> signal = get_or_fill_zero<uint32_t>(
+        suitable_return(sensor::ChanField::SIGNAL, second), ls);
+
+    ouster::img_t<uint16_t> near_ir = get_or_fill_zero<uint16_t>(
+        suitable_return(sensor::ChanField::NEAR_IR, second), ls);
+
+    ouster::cartesianT(points, range, lut_direction, lut_offset);
+
+    copy_scan_to_cloud(cloud, ls, scan_ts, points, range, reflectivity, near_ir,
+                       signal);
+}
+
+void scan_to_cloud_f(ouster::PointsF& points,
+                     const ouster::PointsF& lut_direction,
+                     const ouster::PointsF& lut_offset, uint64_t scan_ts,
                      const ouster::LidarScan& ls, ouster_ros::Cloud& cloud,
                      int return_index) {
     bool second = (return_index == 1);

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -318,8 +318,9 @@ class OusterSensor : public OusterClientBase {
             !mtp_main) {
             if (!get_config(hostname, config, true)) {
                 NODELET_ERROR("Error getting active config");
+            } else {
+                NODELET_INFO("Retrived active config of sensor");
             }
-            NODELET_INFO("Retrived active config of sensor");
             return;
         }
 

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -13,6 +13,7 @@
 // clang-format on
 
 #include <pluginlib/class_list_macros.h>
+#include <std_msgs/String.h>
 
 #include <fstream>
 #include <string>
@@ -90,6 +91,10 @@ class OusterSensor : public OusterClientBase {
         populate_metadata_defaults(info, sensor::MODE_UNSPEC);
         display_lidar_info(info);
 
+        config_msg.data = cached_metadata;
+        if (config_pub){
+            config_pub.publish(config_msg);
+        }
         return cached_config.size() > 0 && cached_metadata.size() > 0;
     }
 
@@ -409,6 +414,8 @@ class OusterSensor : public OusterClientBase {
     void create_publishers(ros::NodeHandle& nh) {
         lidar_packet_pub = nh.advertise<PacketMsg>("lidar_packets", 1280);
         imu_packet_pub = nh.advertise<PacketMsg>("imu_packets", 100);
+        config_pub = nh.advertise<std_msgs::String>("config", 1, true);
+        config_pub.publish(config_msg);
     }
 
     void start_connection_loop() {
@@ -449,8 +456,10 @@ class OusterSensor : public OusterClientBase {
    private:
     PacketMsg lidar_packet;
     PacketMsg imu_packet;
+    std_msgs::String config_msg;
     ros::Publisher lidar_packet_pub;
     ros::Publisher imu_packet_pub;
+    ros::Publisher config_pub;
     std::shared_ptr<sensor::client> sensor_client;
     ros::Timer timer_;
     std::string sensor_hostname;


### PR DESCRIPTION
## Related Issues & PRs
Implements changes for #80 for ros1.
## Summary of Changes
Add a std_msgs/String latched publisher to os_sensor_nodelet.cpp.

In get_metadata() for both os_cloud_nodelet.cpp and os_image_nodelet.cpp:
- Add a std_msgs/String callback and subscriber.
- Manually spin until a service client becomes available or a non-empty config message has arrived. 

## Validation

1. Launched sensor.launch with a live sensor, confirmed that the metadata source is from topic. Confirmed that point-clouds and images are published. 
2. Launched sensor.launch with config topic remapped (making topic unavailable) , confirmed that the metadata source is not from topic (from service). Confirmed that point-clouds and images are published. 
