### PR TITLE
SW-4641: set-frame-id-of-published-images

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ ouster_ros(1)
 * added a new launch file ``sensor_mtp.launch`` for multicast use case (experimental).
 * added a technique to estimate the the value of the lidar scan timestamp when it is missing packets
   at the beginning
+* add frame_id to image topics
 
 ouster_ros(2)
 -------------

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -125,10 +125,10 @@ class OusterImage : public nodelet::Nodelet {
         uint32_t H = info.format.pixels_per_column;
         uint32_t W = info.format.columns_per_frame;
 
-        auto range_image = make_image_msg(H, W, m->header.stamp);
-        auto signal_image = make_image_msg(H, W, m->header.stamp);
-        auto reflec_image = make_image_msg(H, W, m->header.stamp);
-        auto nearir_image = make_image_msg(H, W, m->header.stamp);
+        auto range_image = make_image_msg(H, W, m->header.stamp, m->header.frame_id);
+        auto signal_image = make_image_msg(H, W, m->header.stamp, m->header.frame_id);
+        auto reflec_image = make_image_msg(H, W, m->header.stamp, m->header.frame_id);
+        auto nearir_image = make_image_msg(H, W, m->header.stamp, m->header.frame_id);
 
         ouster::img_t<float> nearir_image_eigen(H, W);
         ouster::img_t<float> signal_image_eigen(H, W);
@@ -189,7 +189,8 @@ class OusterImage : public nodelet::Nodelet {
     }
 
     static sensor_msgs::ImagePtr make_image_msg(size_t H, size_t W,
-                                                const ros::Time& stamp) {
+                                                const ros::Time& stamp,
+                                                const std::string& frame) {
         auto msg = boost::make_shared<sensor_msgs::Image>();
         msg->width = W;
         msg->height = H;
@@ -197,6 +198,7 @@ class OusterImage : public nodelet::Nodelet {
         msg->encoding = sensor_msgs::image_encodings::MONO16;
         msg->data.resize(W * H * sizeof(pixel_type));
         msg->header.stamp = stamp;
+        msg->header.frame_id = frame;
         return msg;
     }
 


### PR DESCRIPTION
## Related Issues & PRs
Addresses #65

## Summary of Changes
- added `frame_id` information to image topics

## Validation
- launch an ouster sensor node
- in a separate terminal use the command `rostopic echo --noarr` on any of the image topics
- The topic header should have the proper frame_id set 