### PR TITLE
Replace tf_prefix by sensor_frame, lidar_frame and imu_frame parameters

### DIFF
--- a/ouster-ros/config/parameters.yaml
+++ b/ouster-ros/config/parameters.yaml
@@ -10,5 +10,4 @@ ouster/os_sensor:
     imu_port: 0
 ouster/os_cloud:
   ros__parameters:
-    tf_prefix: ''
     timestamp_mode: ''

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -39,7 +39,6 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -55,7 +54,6 @@
         <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
-        <param name="tf_prefix" value="$(var tf_prefix)"/>
         <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image"/>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -39,7 +39,6 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -54,7 +53,6 @@
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
-      <param name="tf_prefix" value="$(var tf_prefix)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen"/>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -46,7 +46,6 @@ class OusterCloud : public OusterProcessingNodeBase {
     }
 
     void on_init() {
-        declare_parameters();
         parse_parameters();
         auto metadata = get_metadata();
         info = sensor::parse_metadata(metadata);
@@ -56,20 +55,13 @@ class OusterCloud : public OusterProcessingNodeBase {
         create_subscriptions();
     }
 
-    void declare_parameters() {
-        declare_parameter<std::string>("tf_prefix");
-        declare_parameter<std::string>("timestamp_mode");
-    }
-
     void parse_parameters() {
-        auto tf_prefix = get_parameter("tf_prefix").as_string();
-        if (is_arg_set(tf_prefix) && tf_prefix.back() != '/')
-            tf_prefix.append("/");
-        sensor_frame = tf_prefix + "os_sensor";
-        imu_frame = tf_prefix + "os_imu";
-        lidar_frame = tf_prefix + "os_lidar";
-        auto timestamp_mode_arg = get_parameter("timestamp_mode").as_string();
-        use_ros_time = timestamp_mode_arg == "TIME_FROM_ROS_TIME";
+        sensor_frame = declare_parameter("sensor_frame", "os_sensor");
+        lidar_frame = declare_parameter("lidar_frame", "lidar_frame");
+        imu_frame = declare_parameter("imu_frame", "os_imu");
+        std::string timestamp_mode = declare_parameter("timestamp_mode", "");
+
+        use_ros_time = timestamp_mode == "TIME_FROM_ROS_TIME";
     }
 
     void create_lidarscan_objects() {


### PR DESCRIPTION
## Related Issues & PRs

- Related #65
- Closes #95

## Summary of Changes
- This PR removes `tf_prefix` from `os_cloud` node and replaces it with `sensor_frame`, `lidar_frame` and `imu_frame` parameters.
- These parameters are initialized with the same default value as sensor_frame, lidar_frame and imu_frame variable were before, and at the same time they are read (not need for the double get_parameter/declare_parameter call). Hence allowing them to be optionally set by the user.

## Validation
...