### PR TITLE
Explicity set cxx compile standard if the env isn't

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -24,8 +24,11 @@ find_package(tf2_eigen REQUIRED)
 
 # ==== Options ====
 add_compile_options(-Wall -Wextra)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
-
 
 set(_ouster_ros_INCLUDE_DIRS
   include


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes
- Explicity set cxx compile standard if the env isn't

## Validation
Test on agx board
