### PR TITLE
SW-4785: ros-2 driver fails to start on jetsons (arm)

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -24,6 +24,10 @@ find_package(tf2_eigen REQUIRED)
 
 # ==== Options ====
 add_compile_options(-Wall -Wextra)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
 
 


### PR DESCRIPTION
## Related Issues & PRs
- closes #79 

## Summary of Changes
- Explicity set cxx compile standard if the env isn't