### PR TITLE
SW-4837: replace the use of ros service to retrieve sensor metadata with latched topics foxy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ ouster_ros(2)
 * fixed a potential issue of time values within generated point clouds that could result in a value
   overflow
 * Removed ``rviz_common/Time`` from ``viz.rviz`` config file
+* added a new ``/ouster/metadata`` topic that is consumed by os_cloud and os_image nodes and save it
+  to the bag file on record
+* make specifying metadata file optional during record and replay modes as of package version 8.1
 
 ouster_client
 -------------

--- a/README.md
+++ b/README.md
@@ -129,18 +129,25 @@ ros2 launch ouster_ros sensor.launch.xml    \
 ```
 
 #### Recording Mode
+> Note
+> As of package version 8.1, specifiying metadata file is optional since the introduction of the
+> metadata topic
 ```bash
 ros2 launch ouster_ros record.launch.xml    \
     sensor_hostname:=<sensor host name>     \
-    metadata:=<json file name>              \
-    bag_file:=<optional bag file name>
+    bag_file:=<optional bag file name>      \
+    metadata:=<json file name>              # optional
 ```
 
 #### Replay Mode
+> Note
+> As of package version 8.1, specifiying metadata file is optional if the bag file being replayed
+> already contains the metadata topic
+
 ```bash
 ros2 launch ouster_ros replay.launch.xml    \
-    metadata:=<json file name>              \
-    bag_file:=<path to rosbag file>
+    bag_file:=<path to rosbag file>         \
+    metadata:=<json file name>              # optional if bag file has /metadata topic
 ```
 
 #### Multicast Mode (experimental)

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(ouster_msgs REQUIRED)
@@ -29,7 +30,6 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
-
 
 set(_ouster_ros_INCLUDE_DIRS
   include
@@ -102,6 +102,7 @@ function(create_ros2_component
     class_loader
     rclcpp_components
     rclcpp_lifecycle
+    std_msgs
     sensor_msgs
     geometry_msgs
     ${additonal_dependencies}

--- a/ouster-ros/config/metadata-qos-override.yaml
+++ b/ouster-ros/config/metadata-qos-override.yaml
@@ -1,0 +1,5 @@
+/ouster/metadata:
+  history: keep_last
+  depth: 1
+  reliability: reliable
+  durability: transient_local

--- a/ouster-ros/include/ouster_ros/os_processing_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_processing_node_base.h
@@ -11,8 +11,7 @@
 
 #include <chrono>
 #include <rclcpp/rclcpp.hpp>
-
-#include "ouster_srvs/srv/get_metadata.hpp"
+#include <std_msgs/msg/string.hpp>
 
 namespace ouster_ros {
 
@@ -22,11 +21,9 @@ class OusterProcessingNodeBase : public rclcpp::Node {
                                       const rclcpp::NodeOptions& options)
         : rclcpp::Node(name, options) {}
 
-   protected:
-    bool spin_till_attempts_exahused(const std::string& log_msg,
-                                     std::function<bool(void)> lambda);
-
-    std::string get_metadata();
+    void create_metadata_subscriber(
+        std::function<void(const std_msgs::msg::String::ConstSharedPtr&)>
+            on_sensor_metadata);
 
     int get_n_returns();
 
@@ -36,10 +33,7 @@ class OusterProcessingNodeBase : public rclcpp::Node {
     }
 
    protected:
-    // TODO: Add as node parameters?
-    static const std::chrono::seconds wait_time_per_attempt;
-    static constexpr auto total_attempts = 10;
-
+    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr metadata_sub;
     ouster::sensor::sensor_info info;
 };
 

--- a/ouster-ros/include/ouster_ros/os_processing_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_processing_node_base.h
@@ -22,7 +22,7 @@ class OusterProcessingNodeBase : public rclcpp::Node {
         : rclcpp::Node(name, options) {}
 
     void create_metadata_subscriber(
-        std::function<void(const std_msgs::msg::String::ConstSharedPtr&)>
+        std::function<void(const std_msgs::msg::String::ConstSharedPtr)>
             on_sensor_metadata);
 
     int get_n_returns();

--- a/ouster-ros/include/ouster_ros/os_processing_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_processing_node_base.h
@@ -25,9 +25,9 @@ class OusterProcessingNodeBase : public rclcpp::Node {
         std::function<void(const std_msgs::msg::String::ConstSharedPtr)>
             on_sensor_metadata);
 
-    int get_n_returns();
+    int get_n_returns() const;
 
-    std::string topic_for_return(std::string base, int idx) {
+    static std::string topic_for_return(std::string base, int idx) {
         if (idx == 0) return base;
         return base + std::to_string(idx + 1);
     }

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -84,7 +84,8 @@ sensor_msgs::msg::Imu packet_to_imu_msg(const ouster_msgs::msg::PacketMsg& pm,
 [[deprecated("use the 2nd version of scan_to_cloud_f")]] void scan_to_cloud_f(
     ouster::PointsF& points, const ouster::PointsF& lut_direction,
     const ouster::PointsF& lut_offset, std::chrono::nanoseconds scan_ts,
-    const ouster::LidarScan& lidar_scan, ouster_ros::Cloud& cloud, int return_index);
+    const ouster::LidarScan& lidar_scan, ouster_ros::Cloud& cloud,
+    int return_index);
 
 /**
  * Populate a PCL point cloud from a LidarScan.
@@ -101,8 +102,8 @@ sensor_msgs::msg::Imu packet_to_imu_msg(const ouster_msgs::msg::PacketMsg& pm,
 void scan_to_cloud_f(ouster::PointsF& points,
                      const ouster::PointsF& lut_direction,
                      const ouster::PointsF& lut_offset, uint64_t scan_ts,
-                     const ouster::LidarScan& lidar_scan, ouster_ros::Cloud& cloud,
-                     int return_index);
+                     const ouster::LidarScan& lidar_scan,
+                     ouster_ros::Cloud& cloud, int return_index);
 
 /**
  * Serialize a PCL point cloud to a ROS message

--- a/ouster-ros/include/ouster_ros/os_sensor_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_sensor_node_base.h
@@ -11,8 +11,10 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <std_msgs/msg/string.hpp>
 
 #include "ouster_srvs/srv/get_metadata.hpp"
+
 
 namespace ouster_ros {
 
@@ -23,11 +25,15 @@ class OusterSensorNodeBase : public rclcpp_lifecycle::LifecycleNode {
         : rclcpp_lifecycle::LifecycleNode(name, options) {}
 
    protected:
-    bool is_arg_set(const std::string& arg) {
+    bool is_arg_set(const std::string& arg) const {
         return arg.find_first_not_of(' ') != std::string::npos;
     }
 
     void create_get_metadata_service();
+
+    void create_metadata_publisher();
+
+    void publish_metadata();
 
     void display_lidar_info(const ouster::sensor::sensor_info& info);
 
@@ -35,6 +41,7 @@ class OusterSensorNodeBase : public rclcpp_lifecycle::LifecycleNode {
     ouster::sensor::sensor_info info;
     rclcpp::Service<ouster_srvs::srv::GetMetadata>::SharedPtr get_metadata_srv;
     std::string cached_metadata;
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr metadata_pub;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/include/ouster_ros/os_sensor_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_sensor_node_base.h
@@ -15,7 +15,6 @@
 
 #include "ouster_srvs/srv/get_metadata.hpp"
 
-
 namespace ouster_ros {
 
 class OusterSensorNodeBase : public rclcpp_lifecycle::LifecycleNode {

--- a/ouster-ros/launch/record.independent.launch.xml
+++ b/ouster-ros/launch/record.independent.launch.xml
@@ -48,6 +48,8 @@
     <node pkg="ouster_ros" exec="os_sensor" name="os_sensor" output="screen">
       <param name="sensor_hostname" value="$(var sensor_hostname)"/>
       <param name="udp_dest" value="$(var udp_dest)"/>
+      <param name="mtp_dest" value=""/>
+      <param name="mtp_main" value="false"/>
       <param name="lidar_port" value="$(var lidar_port)"/>
       <param name="imu_port" value="$(var imu_port)"/>
       <param name="udp_profile_lidar" value="$(var udp_profile_lidar)"/>
@@ -81,11 +83,14 @@
 
   <executable if="$(var _use_bag_file_name)" output="screen"
     cmd="ros2 bag record --output $(var bag_file)
-         /$(var ouster_ns)/imu_packets
-         /$(var ouster_ns)/lidar_packets
-         /$(var ouster_ns)/metadata"/>
+      /$(var ouster_ns)/imu_packets
+      /$(var ouster_ns)/lidar_packets
+      /$(var ouster_ns)/metadata"/>
 
   <executable unless="$(var _use_bag_file_name)" output="screen"
-    cmd="ros2 bag record /$(var ouster_ns)/imu_packets /$(var ouster_ns)/lidar_packets"/>
+    cmd="ros2 bag record
+      /$(var ouster_ns)/imu_packets
+      /$(var ouster_ns)/lidar_packets
+      /$(var ouster_ns)/metadata"/>
 
 </launch>

--- a/ouster-ros/launch/record.independent.launch.xml
+++ b/ouster-ros/launch/record.independent.launch.xml
@@ -81,7 +81,9 @@
 
   <executable if="$(var _use_bag_file_name)" output="screen"
     cmd="ros2 bag record --output $(var bag_file)
-         /$(var ouster_ns)/imu_packets /$(var ouster_ns)/lidar_packets"/>
+         /$(var ouster_ns)/imu_packets
+         /$(var ouster_ns)/lidar_packets
+         /$(var ouster_ns)/metadata"/>
 
   <executable unless="$(var _use_bag_file_name)" output="screen"
     cmd="ros2 bag record /$(var ouster_ns)/imu_packets /$(var ouster_ns)/lidar_packets"/>

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -20,11 +20,11 @@
     description="optional rviz config file"/>
   <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
 
-  <let name="_use_metadata_file" value="$(eval '\'$(var metadata)\' != \'b\'')"/>
+  <let name="_use_metadata_file" value="$(eval '\'$(var metadata)\' != \'\'')"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
-    <node unless="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
+    <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
@@ -36,9 +36,11 @@
 
   <!-- HACK: configure and activate the replay node via a process execute since state
     transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_replay configure"
+  <executable if="$(var _use_metadata_file)"
+    cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_replay configure"
     launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_replay activate"
+  <executable if="$(var _use_metadata_file)"
+    cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_replay activate"
     launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -51,6 +51,8 @@
 
   <executable if="$(var _use_bag_file_name)" output="screen"
     launch-prefix="bash -c 'sleep 3; $0 $@'"
-    cmd="ros2 bag play $(var bag_file) --clock"/>
+    cmd="ros2 bag play $(var bag_file) --clock
+      --qos-profile-overrides-path 
+      $(find-pkg-share ouster_ros)/config/metadata-qos-override.yaml"/>
 
 </launch>

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -10,7 +10,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="metadata"
+  <arg name="metadata" default=""
     description="path to write metadata file when receiving sensor data"/>
   <arg name="bag_file"
     description="file name to use for the recorded bag file"/>
@@ -20,9 +20,11 @@
     description="optional rviz config file"/>
   <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
 
+  <let name="_use_metadata_file" value="$(eval '\'$(var metadata)\' != \'b\'')"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
-    <node pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
+    <node unless="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
@@ -49,6 +51,6 @@
 
   <executable if="$(var _use_bag_file_name)" output="screen"
     launch-prefix="bash -c 'sleep 3; $0 $@'"
-    cmd="ros2 bag play $(var bag_file)"/>
+    cmd="ros2 bag play $(var bag_file) --clock"/>
 
 </launch>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.8.0</version>
+  <version>0.8.1</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2_ros</depend>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -85,8 +85,18 @@ class OusterCloud : public OusterProcessingNodeBase {
     void on_init() {
         declare_parameters();
         parse_parameters();
-        auto metadata = get_metadata();
-        info = sensor::parse_metadata(metadata);
+        create_metadata_subscriber(
+            [this](const std_msgs::msg::String::ConstSharedPtr& msg) {
+                metadata_handler(msg);
+            });
+        RCLCPP_INFO(get_logger(), "OusterCloud: node initialized!");
+    }
+
+    void metadata_handler(
+        const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
+        RCLCPP_INFO(get_logger(),
+                    "OusterCloud: retrieved new sensor metadata!");
+        info = sensor::parse_metadata(metadata_msg->data);
         n_returns = get_n_returns();
         create_lidarscan_objects();
         compute_scan_ts = [this](const auto& ts_v) {

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -86,9 +86,7 @@ class OusterCloud : public OusterProcessingNodeBase {
         declare_parameters();
         parse_parameters();
         create_metadata_subscriber(
-            [this](const std_msgs::msg::String::ConstSharedPtr& msg) {
-                metadata_handler(msg);
-            });
+            [this](const auto msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterCloud: node initialized!");
     }
 

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -29,7 +29,6 @@
 
 namespace sensor = ouster::sensor;
 using ouster_msgs::msg::PacketMsg;
-using ouster_srvs::srv::GetMetadata;
 
 namespace {
 

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -53,9 +53,7 @@ class OusterImage : public OusterProcessingNodeBase {
    private:
     void on_init() {
         create_metadata_subscriber(
-            [this](const std_msgs::msg::String::ConstSharedPtr& msg) {
-                metadata_handler(msg);
-            });
+            [this](const auto msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
     }
 

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -36,7 +36,6 @@
 
 namespace sensor = ouster::sensor;
 namespace viz = ouster::viz;
-using ouster_srvs::srv::GetMetadata;
 
 using pixel_type = uint16_t;
 const size_t pixel_value_max = std::numeric_limits<pixel_type>::max();
@@ -53,8 +52,17 @@ class OusterImage : public OusterProcessingNodeBase {
 
    private:
     void on_init() {
-        auto metadata = get_metadata();
-        info = sensor::parse_metadata(metadata);
+        create_metadata_subscriber(
+            [this](const std_msgs::msg::String::ConstSharedPtr& msg) {
+                metadata_handler(msg);
+            });
+        RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
+    }
+
+    void metadata_handler(const std_msgs::msg::String::ConstPtr& metadata_msg) {
+        RCLCPP_INFO(get_logger(),
+                    "OusterImage: retrieved new sensor metadata!");
+        info = sensor::parse_metadata(metadata_msg->data);
         create_cloud_object();
         const int n_returns = get_n_returns();
         create_publishers(n_returns);

--- a/ouster-ros/src/os_processing_node_base.cpp
+++ b/ouster-ros/src/os_processing_node_base.cpp
@@ -8,57 +8,18 @@
 
 #include "ouster_ros/os_processing_node_base.h"
 
-using namespace std::chrono_literals;
 using ouster::sensor::UDPProfileLidar;
-using ouster_srvs::srv::GetMetadata;
-using rclcpp::FutureReturnCode;
 
 namespace ouster_ros {
 
-bool OusterProcessingNodeBase::spin_till_attempts_exahused(
-    const std::string& log_msg, std::function<bool(void)> lambda) {
-    int remaining_attempts = total_attempts;
-    bool done;
-    do {
-        RCLCPP_INFO_STREAM(get_logger(),
-                           log_msg << "; attempt no: "
-                                   << total_attempts - remaining_attempts + 1
-                                   << "/" << total_attempts);
-        done = lambda();
-    } while (rclcpp::ok() && !done && --remaining_attempts > 0);
-    return done;
-}
-
-std::string OusterProcessingNodeBase::get_metadata() {
-    auto client = create_client<GetMetadata>("get_metadata");
-    if (!spin_till_attempts_exahused(
-            "contacting get_metadata service", [this, &client]() -> bool {
-                return client->wait_for_service(wait_time_per_attempt);
-            })) {
-        auto error_msg = "get_metadata service is unavailable";
-        RCLCPP_ERROR_STREAM(get_logger(), error_msg);
-        throw std::runtime_error(error_msg);
-    }
-    auto request = std::make_shared<GetMetadata::Request>();
-    auto result = client->async_send_request(request);
-
-    rclcpp::FutureReturnCode return_code;
-    spin_till_attempts_exahused(
-        "waiting for get_metadata service to respond",
-        [this, &return_code, &result]() -> bool {
-            return_code = rclcpp::spin_until_future_complete(
-                get_node_base_interface(), result, wait_time_per_attempt);
-            return return_code != FutureReturnCode::TIMEOUT;
-        });
-
-    if (return_code != FutureReturnCode::SUCCESS) {
-        auto error_msg = "get_metadata service timed out or interrupted";
-        RCLCPP_ERROR_STREAM(get_logger(), error_msg);
-        throw std::runtime_error(error_msg);
-    }
-
-    RCLCPP_INFO(get_logger(), "retrieved sensor metadata!");
-    return result.get()->metadata;
+void OusterProcessingNodeBase::create_metadata_subscriber(
+    std::function<void(const std_msgs::msg::String::ConstSharedPtr&)>
+        on_sensor_metadata) {
+    auto latching_qos = rclcpp::QoS(rclcpp::KeepLast(1));
+    latching_qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    latching_qos.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    metadata_sub = create_subscription<std_msgs::msg::String>(
+        "metadata", latching_qos, on_sensor_metadata);
 }
 
 int OusterProcessingNodeBase::get_n_returns() {

--- a/ouster-ros/src/os_processing_node_base.cpp
+++ b/ouster-ros/src/os_processing_node_base.cpp
@@ -22,7 +22,7 @@ void OusterProcessingNodeBase::create_metadata_subscriber(
         std::string("metadata"), latching_qos, on_sensor_metadata);
 }
 
-int OusterProcessingNodeBase::get_n_returns() {
+int OusterProcessingNodeBase::get_n_returns() const {
     return info.format.udp_profile_lidar ==
                    UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL
                ? 2

--- a/ouster-ros/src/os_processing_node_base.cpp
+++ b/ouster-ros/src/os_processing_node_base.cpp
@@ -13,13 +13,13 @@ using ouster::sensor::UDPProfileLidar;
 namespace ouster_ros {
 
 void OusterProcessingNodeBase::create_metadata_subscriber(
-    std::function<void(const std_msgs::msg::String::ConstSharedPtr&)>
+    std::function<void(const std_msgs::msg::String::ConstSharedPtr)>
         on_sensor_metadata) {
     auto latching_qos = rclcpp::QoS(rclcpp::KeepLast(1));
     latching_qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
     latching_qos.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
     metadata_sub = create_subscription<std_msgs::msg::String>(
-        "metadata", latching_qos, on_sensor_metadata);
+        std::string("metadata"), latching_qos, on_sensor_metadata);
 }
 
 int OusterProcessingNodeBase::get_n_returns() {
@@ -29,6 +29,4 @@ int OusterProcessingNodeBase::get_n_returns() {
                : 1;
 }
 
-const std::chrono::seconds OusterProcessingNodeBase::wait_time_per_attempt = std::chrono::seconds(10);
-    
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_replay_node.cpp
+++ b/ouster-ros/src/os_replay_node.cpp
@@ -30,7 +30,9 @@ class OusterReplay : public OusterSensorNodeBase {
 
         try {
             auto meta_file = parse_parameters();
-            populate_metadata_from_json(meta_file);
+            create_metadata_publisher();
+            load_metadata_from_file(meta_file);
+            publish_metadata();
             create_get_metadata_service();
             RCLCPP_INFO(get_logger(), "Running in replay mode");
         } catch (const std::exception& ex) {
@@ -110,7 +112,7 @@ class OusterReplay : public OusterSensorNodeBase {
         return meta_file;
     }
 
-    void populate_metadata_from_json(const std::string& meta_file) {
+    void load_metadata_from_file(const std::string& meta_file) {
         try {
             std::ifstream in_file(meta_file);
             std::stringstream buffer;
@@ -129,7 +131,6 @@ class OusterReplay : public OusterSensorNodeBase {
     void cleanup() {
         get_metadata_srv.reset();
     }
-
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -63,7 +63,9 @@ class OusterSensor : public OusterSensorNodeBase {
             sensor_client = create_sensor_client(sensor_hostname, config);
             if (!sensor_client)
                 return LifecycleNodeInterface::CallbackReturn::FAILURE;
+            create_metadata_publisher();
             update_config_and_metadata(*sensor_client);
+            publish_metadata();
             save_metadata();
             create_reset_service();
             create_get_metadata_service();
@@ -342,6 +344,7 @@ class OusterSensor : public OusterSensorNodeBase {
         connection_loop_timer->cancel();
         reset_last_init_id = init_id_reset;
         update_config_and_metadata(*sensor_client);
+        publish_metadata();
         save_metadata();
         auto request_transitions = std::vector<uint8_t>{
             lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE,

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -90,7 +90,7 @@ class OusterSensor : public OusterSensorNodeBase {
         LifecycleNode::on_activate(state);
         lidar_packet_pub->on_activate();
         imu_packet_pub->on_activate();
-       
+
         allocate_buffers();
         if (!connection_loop_timer) {
             // TOOD: replace with a thread instead?

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -28,6 +28,20 @@ void OusterSensorNodeBase::create_get_metadata_service() {
     RCLCPP_INFO(get_logger(), "get_metadata service created");
 }
 
+void OusterSensorNodeBase::create_metadata_publisher() {
+    auto latching_qos = rclcpp::QoS(rclcpp::KeepLast(1));
+    latching_qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    latching_qos.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    metadata_pub =
+        create_publisher<std_msgs::msg::String>("metadata", latching_qos);
+}
+
+void OusterSensorNodeBase::publish_metadata() {
+    std_msgs::msg::String metadata_msg;
+    metadata_msg.data = cached_metadata;
+    metadata_pub->publish(metadata_msg);
+}
+
 void OusterSensorNodeBase::display_lidar_info(const sensor::sensor_info& info) {
     auto lidar_profile = info.format.udp_profile_lidar;
     RCLCPP_INFO_STREAM(


### PR DESCRIPTION
## Related Issues & PRs
- Related #102 

## Summary of Changes
* added a new `/ouster/metadata` topic that is consumed by os_cloud and os_image nodes and save it to the bag file on record
* make specifying metadata file optional during record and replay modes as of package version 8.1

## Validation
all functionality maintained