### PR TITLE
Remove the --clock option in bag play

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ ouster_ros(2)
   to the bag file on record
 * make specifying metadata file optional during record and replay modes as of package version 8.1
 * bugfix: activate metadata topic explicitly
+* bugfix: remove ``--clock`` option when playing bag files in ros-foxy.
 
 ouster_client
 -------------

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -53,7 +53,7 @@
 
   <executable if="$(var _use_bag_file_name)" output="screen"
     launch-prefix="bash -c 'sleep 3; $0 $@'"
-    cmd="ros2 bag play $(var bag_file) --clock
+    cmd="ros2 bag play $(var bag_file)
       --qos-profile-overrides-path 
       $(find-pkg-share ouster_ros)/config/metadata-qos-override.yaml"/>
 

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.8.2</version>
+  <version>0.8.3</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
- N/A

## Summary of Changes
- Drop the `--clock` from the ros2 bag play command under foxy

## Validation
```bash
ros2 launch ouster_ros replay.launch.xml bag_file:=<bag_file> metadata:=<metadata.json>
```