### PR TITLE
SW-4924: Replace tf_prefix by sensor_frame lidar_frame and imu_frame parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ ouster_ros(2)
 * added a new ``/ouster/metadata`` topic that is consumed by os_cloud and os_image nodes and save it
   to the bag file on record
 * make specifying metadata file optional during record and replay modes as of package version 8.1
+* replace ``tf_prefix`` from ``os_cloud`` with ``sensor_frame``, ``lidar_frame`` and ``imu_frame``
+  launch parameters.
 
 ouster_client
 -------------

--- a/ouster-ros/config/parameters.yaml
+++ b/ouster-ros/config/parameters.yaml
@@ -12,5 +12,4 @@ ouster/os_sensor:
     imu_port: 0
 ouster/os_cloud:
   ros__parameters:
-    tf_prefix: ''
     timestamp_mode: ''

--- a/ouster-ros/config/parameters.yaml
+++ b/ouster-ros/config/parameters.yaml
@@ -12,4 +12,7 @@ ouster/os_sensor:
     imu_port: 0
 ouster/os_cloud:
   ros__parameters:
+    sensor_frame: 'os_sensor'
+    lidar_frame: 'os_lidar'
+    imu_frame: 'os_imu'
     timestamp_mode: ''

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -82,6 +82,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
   <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'b\'')"/>

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -41,7 +41,10 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -59,7 +62,9 @@
         <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
-        <param name="tf_prefix" value="$(var tf_prefix)"/>
+        <param name="sensor_frame" value="$(var sensor_frame)"/>
+        <param name="lidar_frame" value="$(var lidar_frame)"/>
+        <param name="imu_frame" value="$(var imu_frame)"/>
         <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -18,7 +18,10 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
   <let name="_use_metadata_file" value="$(eval '\'$(var metadata)\' != \'\'')"/>
 
@@ -29,7 +32,9 @@
     </node>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="os_container" output="screen" namespace="">
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
-        <param name="tf_prefix" value="$(var tf_prefix)"/>
+        <param name="sensor_frame" value="$(var sensor_frame)"/>
+        <param name="lidar_frame" value="$(var lidar_frame)"/>
+        <param name="imu_frame" value="$(var imu_frame)"/>
         <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -54,6 +54,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
   <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'b\'')"/>

--- a/ouster-ros/launch/rviz.launch.py
+++ b/ouster-ros/launch/rviz.launch.py
@@ -31,6 +31,8 @@ def generate_launch_description():
     # NOTE: the two static tf publishers are rather a workaround to let rviz2
     #     get going and not complain while waiting for the actual sensor frames
     #     to be published that is when running rviz2 using a parent launch file
+    # TODO: need to be able to propagate the modified frame names from the
+    #       parameters file to RVIZ launch py.
     sensor_imu_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",

--- a/ouster-ros/launch/rviz.launch.xml
+++ b/ouster-ros/launch/rviz.launch.xml
@@ -7,6 +7,10 @@
   <arg name="_enable_static_tf_publishers" default="false"
     description="boolean value to enable static tf publishers"/>
 
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"
@@ -16,10 +20,10 @@
       to run rviz2 -->
     <node if="$(var _enable_static_tf_publishers)"
       pkg="tf2_ros" exec="static_transform_publisher" name="stp_sensor_imu"
-      args="--frame-id os_sensor --child-frame-id os_imu"/>
+      args="--frame-id $(var sensor_frame) --child-frame-id $(var imu_frame)"/>
     <node  if="$(var _enable_static_tf_publishers)"
       pkg="tf2_ros" exec="static_transform_publisher" name="stp_sensor_lidar"
-      args="--frame-id os_sensor --child-frame-id os_lidar"/>
+      args="--frame-id $(var sensor_frame) --child-frame-id $(var lidar_frame)"/>
   </group>
 
 </launch>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -40,6 +40,10 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="os_container" output="screen" namespace="">
@@ -56,6 +60,9 @@
         <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
+        <param name="sensor_frame" value="$(var sensor_frame)"/>
+        <param name="lidar_frame" value="$(var lidar_frame)"/>
+        <param name="imu_frame" value="$(var imu_frame)"/>
         <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image"/>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -39,7 +39,6 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -57,7 +56,6 @@
         <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
-        <param name="tf_prefix" value="$(var tf_prefix)"/>
         <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image"/>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -80,6 +80,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -40,6 +40,10 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_sensor" name="os_sensor" output="screen">
@@ -55,6 +59,9 @@
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
+      <param name="sensor_frame" value="$(var sensor_frame)"/>
+      <param name="lidar_frame" value="$(var lidar_frame)"/>
+      <param name="imu_frame" value="$(var imu_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen"/>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -78,6 +78,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -39,7 +39,6 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -56,7 +55,6 @@
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
-      <param name="tf_prefix" value="$(var tf_prefix)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen"/>

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -47,7 +47,10 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -83,6 +86,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.8.1</version>
+  <version>0.8.2</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -83,27 +83,19 @@ class OusterCloud : public OusterProcessingNodeBase {
     }
 
     void on_init() {
-        declare_parameters();
         parse_parameters();
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterCloud: node initialized!");
     }
 
-    void declare_parameters() {
-        declare_parameter<std::string>("tf_prefix");
-        declare_parameter<std::string>("timestamp_mode");
-    }
-
     void parse_parameters() {
-        auto tf_prefix = get_parameter("tf_prefix").as_string();
-        if (is_arg_set(tf_prefix) && tf_prefix.back() != '/')
-            tf_prefix.append("/");
-        sensor_frame = tf_prefix + "os_sensor";
-        imu_frame = tf_prefix + "os_imu";
-        lidar_frame = tf_prefix + "os_lidar";
-        auto timestamp_mode_arg = get_parameter("timestamp_mode").as_string();
-        use_ros_time = timestamp_mode_arg == "TIME_FROM_ROS_TIME";
+        sensor_frame = declare_parameter("sensor_frame", "os_sensor");
+        lidar_frame = declare_parameter("lidar_frame", "lidar_frame");
+        imu_frame = declare_parameter("imu_frame", "os_imu");
+        std::string timestamp_mode = declare_parameter("timestamp_mode", "");
+
+        use_ros_time = timestamp_mode == "TIME_FROM_ROS_TIME";
     }
 
     static double compute_scan_col_ts_spacing_ns(sensor::lidar_mode ld_mode) {

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -83,19 +83,27 @@ class OusterCloud : public OusterProcessingNodeBase {
     }
 
     void on_init() {
+        declare_parameters();
         parse_parameters();
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterCloud: node initialized!");
     }
 
-    void parse_parameters() {
-        sensor_frame = declare_parameter("sensor_frame", "os_sensor");
-        lidar_frame = declare_parameter("lidar_frame", "lidar_frame");
-        imu_frame = declare_parameter("imu_frame", "os_imu");
-        std::string timestamp_mode = declare_parameter("timestamp_mode", "");
+    void declare_parameters() {
+        declare_parameter<std::string>("sensor_frame");
+        declare_parameter<std::string>("lidar_frame");
+        declare_parameter<std::string>("imu_frame");
+        declare_parameter<std::string>("timestamp_mode");
+    }
 
-        use_ros_time = timestamp_mode == "TIME_FROM_ROS_TIME";
+    void parse_parameters() {
+        sensor_frame = get_parameter("sensor_frame").as_string();
+        lidar_frame = get_parameter("lidar_frame").as_string();
+        imu_frame = get_parameter("imu_frame").as_string();
+
+        auto timestamp_mode_arg = get_parameter("timestamp_mode").as_string();
+        use_ros_time = timestamp_mode_arg == "TIME_FROM_ROS_TIME";
     }
 
     static double compute_scan_col_ts_spacing_ns(sensor::lidar_mode ld_mode) {


### PR DESCRIPTION
## Related Issues & PRs
- Parent PR #96

## Summary of Changes
- Replace `tf_prefix` from **os_cloud** with `sensor_frame`, `lidar_frame` and `imu_frame` parameters.

## Validation
* Defaults work 
```bash
ros2 launch ouster_ros sensor.launch.xml sensor_hostname:=$SENSOR_HOSTNAME
```
![image](https://user-images.githubusercontent.com/606033/235243799-a9518071-7968-4812-a53c-105778c8a1bf.png)

* Supplying a different frame names should reflected in the TF tree.
```bash
ros2 launch ouster_ros sensor.launch.xml sensor_hostname:=$SENSOR_HOSTNAME lidar_frame:=NEW_LIDAR_FRAME
```
![image](https://user-images.githubusercontent.com/606033/235245236-98d86422-c2b0-4072-95e8-12f2cc6720d4.png)