### PR TITLE
SW-4924: replace tf_prefix by sensor_frame lidar_frame and imu_frame parameters (foxy)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ ouster_ros(2)
 * make specifying metadata file optional during record and replay modes as of package version 8.1
 * bugfix: activate metadata topic explicitly
 * bugfix: remove ``--clock`` option when playing bag files in ros-foxy.
+* replace ``tf_prefix`` from ``os_cloud`` with ``sensor_frame``, ``lidar_frame`` and ``imu_frame``
+  launch parameters.
 
 ouster_client
 -------------

--- a/ouster-ros/config/parameters.yaml
+++ b/ouster-ros/config/parameters.yaml
@@ -12,5 +12,7 @@ ouster/os_sensor:
     imu_port: 0
 ouster/os_cloud:
   ros__parameters:
-    tf_prefix: ''
+    sensor_frame: 'os_sensor'
+    lidar_frame: 'os_lidar'
+    imu_frame: 'os_imu'
     timestamp_mode: ''

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -18,7 +18,10 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
   <let name="_use_metadata_file" value="$(eval '\'$(var metadata)\' != \'\'')"/>
 
@@ -28,8 +31,10 @@
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
-      <param name="tf_prefix" value="$(var tf_prefix)"/>
-      <param name="timestamp_mode" value="$(var timestamp_mode)"/>
+        <param name="sensor_frame" value="$(var sensor_frame)"/>
+        <param name="lidar_frame" value="$(var lidar_frame)"/>
+        <param name="imu_frame" value="$(var imu_frame)"/>
+        <param name="timestamp_mode" value="$(var timestamp_mode)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen"/>
   </group>
@@ -47,6 +52,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
   <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'b\'')"/>

--- a/ouster-ros/launch/rviz.launch.py
+++ b/ouster-ros/launch/rviz.launch.py
@@ -31,6 +31,8 @@ def generate_launch_description():
     # NOTE: the two static tf publishers are rather a workaround to let rviz2
     #     get going and not complain while waiting for the actual sensor frames
     #     to be published that is when running rviz2 using a parent launch file
+    # TODO: need to be able to propagate the modified frame names from the
+    #       parameters file to RVIZ launch py.
     sensor_imu_tf = Node(
         package="tf2_ros",
         executable="static_transform_publisher",

--- a/ouster-ros/launch/rviz.launch.xml
+++ b/ouster-ros/launch/rviz.launch.xml
@@ -7,6 +7,10 @@
   <arg name="_enable_static_tf_publishers" default="false"
     description="boolean value to enable static tf publishers"/>
 
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"
@@ -16,10 +20,10 @@
       to run rviz2 -->
     <node if="$(var _enable_static_tf_publishers)"
       pkg="tf2_ros" exec="static_transform_publisher" name="stp_sensor_imu"
-      args="0 0 0 0 0 0 os_sensor os_imu"/>
+      args="0 0 0 0 0 0 $(var sensor_frame) $(var imu_frame)"/>
     <node  if="$(var _enable_static_tf_publishers)"
       pkg="tf2_ros" exec="static_transform_publisher" name="stp_sensor_lidar"
-      args="0 0 0 0 0 0 os_sensor os_lidar"/>
+      args="0 0 0 0 0 0 $(var sensor_frame) $(var lidar_frame)"/>
   </group>
 
 </launch>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -39,7 +39,10 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -57,7 +60,9 @@
         <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
-        <param name="tf_prefix" value="$(var tf_prefix)"/>
+        <param name="sensor_frame" value="$(var sensor_frame)"/>
+        <param name="lidar_frame" value="$(var lidar_frame)"/>
+        <param name="imu_frame" value="$(var imu_frame)"/>
         <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image"/>
@@ -75,6 +80,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -39,7 +39,10 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -56,7 +59,9 @@
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
-      <param name="tf_prefix" value="$(var tf_prefix)"/>
+      <param name="sensor_frame" value="$(var sensor_frame)"/>
+      <param name="lidar_frame" value="$(var lidar_frame)"/>
+      <param name="imu_frame" value="$(var imu_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen"/>
@@ -73,6 +78,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -47,7 +47,10 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -65,7 +68,9 @@
         <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
-        <param name="tf_prefix" value="$(var tf_prefix)"/>
+        <param name="sensor_frame" value="$(var sensor_frame)"/>
+        <param name="lidar_frame" value="$(var lidar_frame)"/>
+        <param name="imu_frame" value="$(var imu_frame)"/>
         <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image"/>
@@ -83,6 +88,9 @@
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
     <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="sensor_frame" value="$(var sensor_frame)"/>
+    <arg name="lidar_frame" value="$(var lidar_frame)"/>
+    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.8.3</version>
+  <version>0.8.4</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -105,17 +105,17 @@ class OusterCloud : public OusterProcessingNodeBase {
     }
 
     void declare_parameters() {
-        declare_parameter("tf_prefix");
+        declare_parameter("sensor_frame");
+        declare_parameter("lidar_frame");
+        declare_parameter("imu_frame");
         declare_parameter("timestamp_mode");
     }
 
     void parse_parameters() {
-        auto tf_prefix = get_parameter("tf_prefix").as_string();
-        if (is_arg_set(tf_prefix) && tf_prefix.back() != '/')
-            tf_prefix.append("/");
-        sensor_frame = tf_prefix + "os_sensor";
-        imu_frame = tf_prefix + "os_imu";
-        lidar_frame = tf_prefix + "os_lidar";
+        sensor_frame = get_parameter("sensor_frame").as_string();
+        lidar_frame = get_parameter("lidar_frame").as_string();
+        imu_frame = get_parameter("imu_frame").as_string();
+
         auto timestamp_mode_arg = get_parameter("timestamp_mode").as_string();
         use_ros_time = timestamp_mode_arg == "TIME_FROM_ROS_TIME";
     }


### PR DESCRIPTION
## Related Issues & PRs
- Parent PR #96
- Rolling/Humble Equivalent PR #115 

## Summary of Changes
- Replace `tf_prefix` from **os_cloud** with `sensor_frame`, `lidar_frame` and `imu_frame` parameters.

## Validation
* Defaults work 
```bash
ros2 launch ouster_ros sensor.launch.xml sensor_hostname:=$SENSOR_HOSTNAME
```
![image](https://user-images.githubusercontent.com/606033/235243799-a9518071-7968-4812-a53c-105778c8a1bf.png)

* Supplying a different frame names should reflected in the TF tree.
```bash
ros2 launch ouster_ros sensor.launch.xml sensor_hostname:=$SENSOR_HOSTNAME lidar_frame:=NEW_LIDAR_FRAME
```
![image](https://user-images.githubusercontent.com/606033/235245236-98d86422-c2b0-4072-95e8-12f2cc6720d4.png)