### PR TITLE
Drop service_msgs from package.xml in ros2 foxy

### DIFF
--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -20,7 +20,6 @@
   <depend>pcl_ros</depend>
   <depend>pcl_conversions</depend>
   <depend>std_srvs</depend>
-  <depend>service_msgs</depend>
 
   <build_depend>ouster_msgs</build_depend>
   <build_depend>ouster_srvs</build_depend>


### PR DESCRIPTION
## Related Issues & PRs
- Related #113 
- Related #117 

## Summary of Changes
- Drop `service_msgs` from ROS dependencies

## Validation
- Build succeeds