### PR TITLE
SW-4972: merge switching to static transform publisher contribution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ ouster_ros(2)
   launch parameters.
 * bugfix: fixed an issue that prevents running multiple instances of the sensor and cloud components
   in the same process.
+* switch to using static transform publisher for the ros2 driver.
 
 ouster_client
 -------------

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -81,7 +81,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -81,7 +81,7 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -53,7 +53,7 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -53,7 +53,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/rviz.launch.py
+++ b/ouster-ros/launch/rviz.launch.py
@@ -35,8 +35,5 @@ def generate_launch_description():
     return LaunchDescription([
         ouster_ns_arg,
         rviz_config_arg,
-        enable_static_tf_arg,
-        sensor_imu_tf,
-        sensor_ldr_tf,
         rviz_node
     ])

--- a/ouster-ros/launch/rviz.launch.py
+++ b/ouster-ros/launch/rviz.launch.py
@@ -24,30 +24,6 @@ def generate_launch_description():
     ouster_ns_arg = DeclareLaunchArgument(
         'ouster_ns', default_value='ouster')
 
-    enable_static_tf = LaunchConfiguration('_enable_static_tf_publishers')
-    enable_static_tf_arg = DeclareLaunchArgument(
-        '_enable_static_tf_publishers', default_value='false')
-
-    # NOTE: the two static tf publishers are rather a workaround to let rviz2
-    #     get going and not complain while waiting for the actual sensor frames
-    #     to be published that is when running rviz2 using a parent launch file
-    # TODO: need to be able to propagate the modified frame names from the
-    #       parameters file to RVIZ launch py.
-    sensor_imu_tf = Node(
-        package="tf2_ros",
-        executable="static_transform_publisher",
-        name="stp_sensor_imu",
-        namespace=ouster_ns,
-        condition=IfCondition(enable_static_tf),
-        arguments=["--frame-id", "os_sensor", "--child-frame-id", "os_imu"])
-    sensor_ldr_tf = Node(
-        package="tf2_ros",
-        executable="static_transform_publisher",
-        name="stp_sensor_lidar",
-        namespace=ouster_ns,
-        condition=IfCondition(enable_static_tf),
-        arguments=["--frame-id", "os_sensor", "--child-frame-id", "os_lidar"])
-
     rviz_node = Node(
         package='rviz2',
         namespace=ouster_ns,

--- a/ouster-ros/launch/rviz.launch.xml
+++ b/ouster-ros/launch/rviz.launch.xml
@@ -4,8 +4,6 @@
     description="Override the default namespace of all ouster nodes"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="_enable_static_tf_publishers" default="false"
-    description="boolean value to enable static tf publishers"/>
 
   <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
   <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
@@ -15,15 +13,6 @@
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"
       launch-prefix="bash -c 'sleep 5; $0 $@'" args="-d $(var rviz_config)"/>
-    <!-- NOTE: this is rather a workaround to let rviz2 get going and not complain while waiting
-      for the actual sensor frames to be published that is when when using the same launch file
-      to run rviz2 -->
-    <node if="$(var _enable_static_tf_publishers)"
-      pkg="tf2_ros" exec="static_transform_publisher" name="stp_sensor_imu"
-      args="--frame-id $(var sensor_frame) --child-frame-id $(var imu_frame)"/>
-    <node  if="$(var _enable_static_tf_publishers)"
-      pkg="tf2_ros" exec="static_transform_publisher" name="stp_sensor_lidar"
-      args="--frame-id $(var sensor_frame) --child-frame-id $(var lidar_frame)"/>
   </group>
 
 </launch>

--- a/ouster-ros/launch/sensor.composite.launch.py
+++ b/ouster-ros/launch/sensor.composite.launch.py
@@ -78,7 +78,7 @@ def generate_launch_description():
     rviz_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([str(rviz_launch_file_path)]),
         condition=IfCondition(rviz_enable),
-        launch_arguments={'_enable_static_tf_publishers': 'true'}.items()
+        launch_arguments={'_enable_static_tf_publishers': 'false'}.items()
     )
 
     # HACK: to configure and activate the the sensor since state transition

--- a/ouster-ros/launch/sensor.composite.launch.py
+++ b/ouster-ros/launch/sensor.composite.launch.py
@@ -77,8 +77,7 @@ def generate_launch_description():
         Path(ouster_ros_pkg_dir) / 'launch' / 'rviz.launch.py'
     rviz_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([str(rviz_launch_file_path)]),
-        condition=IfCondition(rviz_enable),
-        launch_arguments={'_enable_static_tf_publishers': 'false'}.items()
+        condition=IfCondition(rviz_enable)
     )
 
     # HACK: to configure and activate the the sensor since state transition

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -79,7 +79,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -79,7 +79,7 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/sensor.independent.launch.py
+++ b/ouster-ros/launch/sensor.independent.launch.py
@@ -106,7 +106,7 @@ def generate_launch_description():
     rviz_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([str(rviz_launch_file_path)]),
         condition=IfCondition(rviz_enable),
-        launch_arguments={'_enable_static_tf_publishers': 'true'}.items()
+        launch_arguments={'_enable_static_tf_publishers': 'false'}.items()
     )
 
     return launch.LaunchDescription([

--- a/ouster-ros/launch/sensor.independent.launch.py
+++ b/ouster-ros/launch/sensor.independent.launch.py
@@ -105,8 +105,7 @@ def generate_launch_description():
         Path(ouster_ros_pkg_dir) / 'launch' / 'rviz.launch.py'
     rviz_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([str(rviz_launch_file_path)]),
-        condition=IfCondition(rviz_enable),
-        launch_arguments={'_enable_static_tf_publishers': 'false'}.items()
+        condition=IfCondition(rviz_enable)
     )
 
     return launch.LaunchDescription([

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -77,7 +77,7 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -77,7 +77,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -85,7 +85,7 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="true"/>
+    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -85,7 +85,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="_enable_static_tf_publishers" value="false"/>
     <arg name="sensor_frame" value="$(var sensor_frame)"/>
     <arg name="lidar_frame" value="$(var lidar_frame)"/>
     <arg name="imu_frame" value="$(var imu_frame)"/>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.8.3</version>
+  <version>0.8.4</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
- parent #112
- ros2 foxy #125
- resolves #105 for ros2

## Summary of Changes
- Send static transforms only once with a static transform broadcaster

## Validation
- [optional] Launch sensor node (xml | py) and replay / record nodes.