### PR TITLE
SW-4993: Reduce the publish rate of imu tf transforms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ ouster_ros(1)
   save it to the bag file on record
 * make specifying metadata file optional during record and replay modes as of package version 8.1
 * added a no-bond option to the ``sensor.launch`` file
+* reduce the publish rate of imu tf transforms
 
 ouster_ros(2)
 -------------

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.8.2</version>
+  <version>0.8.3</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -197,6 +197,9 @@ class OusterCloud : public nodelet::Nodelet {
 
         tf_bcast.sendTransform(ouster_ros::transform_to_tf_msg(
             info.lidar_to_sensor_transform, sensor_frame, lidar_frame, msg_ts));
+
+        tf_bcast.sendTransform(ouster_ros::transform_to_tf_msg(
+            info.imu_to_sensor_transform, sensor_frame, imu_frame, msg_ts));
     }
 
     uint64_t impute_value(int last_scan_last_nonzero_idx,
@@ -312,9 +315,6 @@ class OusterCloud : public nodelet::Nodelet {
         sensor_msgs::ImuPtr imu_msg_ptr =
             boost::make_shared<sensor_msgs::Imu>(imu_msg);
         imu_pub.publish(imu_msg_ptr);
-
-        tf_bcast.sendTransform(ouster_ros::transform_to_tf_msg(
-            info.imu_to_sensor_transform, sensor_frame, imu_frame, msg_ts));
     };
 
     inline ros::Time to_ros_time(uint64_t ts) {


### PR DESCRIPTION
## Related Issues & PRs
- closes #105 
- related #9 

## Summary of Changes
- Reduce the publish rate of tf transforms by publishing IMU TF transforms at the same rate as LIDAR TF transforms

> **Note:**
> Using **StaticTransformPublisher** is the proper thing to do but due to an issue that exists(or existed) in ROS1 which causes it to generate tons of warnings that couldn't be silenced as noted in #9 and also based on my own experience; so as a compromise I kept everything pretty much as is but reduced the publish rate of IMU TF transforms by publishing them at the same time as LIDAR TF transforms.  

## Validation
- Before this change the total publish rate of TF messages generated by ROS driver would be at 120+ Hz.
- Launch a sensor with the ouster driver in one terminal and run a tf monitor in another terminal and observe the frequency of published TF transforms. The total publish rate shouldn't exceed 20 Hz for lidar modes with 10 Hz FPS and 40 Hz for lidar modes with 20 Hz FPS.