### PR TITLE
ROS compatibility mode dual returns fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ ouster_ros(2)
   topics with ``SensorDataQoS`` selected by default for live sensor mode and ``SystemDefaultQoS``
   enabled for record and replay modes.
 * introduced a new topic ``/ouster/scan`` which publishes ``sensor_msgs::msg::LaserScan`` messages
+* fix: on dual returns the 2nd point cloud replaces the 1st one. 
 
 ouster_client
 -------------

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -216,8 +216,7 @@ void OusterSensor::save_metadata() {
 
     // write metadata file. If metadata_path is relative, will use cwd
     // (usually ~/.ros)
-
-    if (!write_text_to_file(meta_file, cached_metadata)) {
+    if (write_text_to_file(meta_file, cached_metadata)) {
         RCLCPP_INFO_STREAM(get_logger(),
                            "Wrote sensor metadata to " << meta_file);
     } else {

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -31,9 +31,10 @@ class PointCloudProcessor {
                         PostProcessingFn func)
         : frame(frame_id),
           cloud{info.format.columns_per_frame, info.format.pixels_per_column},
-          pc_msgs(get_n_returns(info),
-                  std::make_shared<sensor_msgs::msg::PointCloud2>()),
+          pc_msgs(get_n_returns(info)),
           post_processing_fn(func) {
+        for (size_t i = 0; i < pc_msgs.size(); ++i)
+            pc_msgs[i] = std::make_shared<sensor_msgs::msg::PointCloud2>();
         ouster::mat4d additional_transform =
             apply_lidar_to_sensor_transform ? info.lidar_to_sensor_transform
                                             : ouster::mat4d::Identity();


### PR DESCRIPTION
## Related Issues & PRs
- fixes #146 

## Summary of Changes
- Address an issue where the 2nd point cloud replaces the 1st one when using dual returns

## Validation
Connect to a sensor with dual return enabled and observe both point clouds published accordingly