### PR TITLE
SW-5167: fix black columns when recording a bag file

### DIFF
--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -60,7 +60,7 @@ ouster/os_driver:
     # to select which beam of the LidarScan to use when producing the LaserScan
     # message. Choose a value the range [0, sensor_beams_count).
     scan_ring: 0
-    # use_system_default_qos[optional]: if False, data are published with sensor
+    # use_system_default_qos[optional]: if false, data are published with sensor
     # data QoS. This is preferrable for production but default QoS is needed for
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
-    use_system_default_qos: False
+    use_system_default_qos: false

--- a/ouster-ros/launch/record.independent.launch.xml
+++ b/ouster-ros/launch/record.independent.launch.xml
@@ -42,21 +42,28 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
-  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
-  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
-  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+  <arg name="sensor_frame" default="os_sensor"
+    description="sets name of choice for the sensor_frame tf frame, value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar"
+    description="sets name of choice for the os_lidar tf frame, value can not be empty"/>
+  <arg name="imu_frame" default="os_imu"
+      description="sets name of choice for the os_imu tf frame, value can not be empty"/>
+  <arg name="point_cloud_frame" default=""
+    description="which frame to be used when publishing PointCloud2 or LaserScan messages.
+    Choose between the value of sensor_frame or lidar_frame, leaving this value empty
+    would set lidar_frame to be the frame used when publishing these messages."/>
 
   <arg name="use_system_default_qos" default="true"
     description="Use the default system QoS settings"/>
+
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    currently IMG is not supported and does not affect anything,
+    The IMG flag here is not supported and does not affect anything,
     to disable image topics you would need to omit the os_image node
     from the launch file"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
-    and choose a value the range [0, sensor_beams_count)"
-  />
+    and choose a value the range [0, sensor_beams_count)"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -72,12 +79,12 @@
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="metadata" value="$(var metadata)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
-      <param name="proc_mask" value="$(var proc_mask)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
       <param name="sensor_frame" value="$(var sensor_frame)"/>
       <param name="lidar_frame" value="$(var lidar_frame)"/>
       <param name="imu_frame" value="$(var imu_frame)"/>
+      <param name="point_cloud_frame" value="$(var point_cloud_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
       <param name="proc_mask" value="$(var proc_mask)"/>

--- a/ouster-ros/launch/record.independent.launch.xml
+++ b/ouster-ros/launch/record.independent.launch.xml
@@ -41,7 +41,22 @@
     description="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
-  <arg name="tf_prefix" default="" description="namespace for tf transforms"/>
+
+  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
+  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+
+  <arg name="use_system_default_qos" default="true"
+    description="Use the default system QoS settings"/>
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
+    currently IMG is not supported and does not affect anything,
+    to disable image topics you would need to omit the os_image node
+    from the launch file"/>
+
+  <arg name="scan_ring" default="0" description="
+    use this parameter in conjunction with the SCAN flag
+    and choose a value the range [0, sensor_beams_count)"
+  />
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -56,12 +71,21 @@
       <param name="lidar_mode" value="$(var lidar_mode)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="metadata" value="$(var metadata)"/>
+      <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+      <param name="proc_mask" value="$(var proc_mask)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
-      <param name="tf_prefix" value="$(var tf_prefix)"/>
+      <param name="sensor_frame" value="$(var sensor_frame)"/>
+      <param name="lidar_frame" value="$(var lidar_frame)"/>
+      <param name="imu_frame" value="$(var imu_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
+      <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+      <param name="proc_mask" value="$(var proc_mask)"/>
+      <param name="scan_ring" value="$(var scan_ring)"/>
     </node>
-    <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen"/>
+    <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen">
+      <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+    </node>
   </group>
 
   <!-- HACK: configure and activate the sensor node via a process execute since state

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -25,13 +25,17 @@
 
   <let name="_use_metadata_file" value="$(eval '\'$(var metadata)\' != \'\'')"/>
 
-  <arg name="use_system_default_qos" default="true" description="Use the default system QoS settings"/>
+  <arg name="use_system_default_qos" default="true"
+    description="Use the default system QoS settings"/>
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
+    currently IMG is not supported and does not affect anything,
+    to disable image topics you would need to omit the os_image node
+    from the launch file"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
     and choose a value the range [0, sensor_beams_count)"
   />
-
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -39,15 +43,16 @@
       <param name="metadata" value="$(var metadata)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
-        <param name="sensor_frame" value="$(var sensor_frame)"/>
-        <param name="lidar_frame" value="$(var lidar_frame)"/>
-        <param name="imu_frame" value="$(var imu_frame)"/>
-        <param name="timestamp_mode" value="$(var timestamp_mode)"/>
-        <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
-        <param name="scan_ring" value="$(var scan_ring)"/>
+      <param name="sensor_frame" value="$(var sensor_frame)"/>
+      <param name="lidar_frame" value="$(var lidar_frame)"/>
+      <param name="imu_frame" value="$(var imu_frame)"/>
+      <param name="timestamp_mode" value="$(var timestamp_mode)"/>
+      <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+      <param name="proc_mask" value="$(var proc_mask)"/>
+      <param name="scan_ring" value="$(var scan_ring)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen">
-        <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+      <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
     </node>
   </group>
 
@@ -63,9 +68,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="sensor_frame" value="$(var sensor_frame)"/>
-    <arg name="lidar_frame" value="$(var lidar_frame)"/>
-    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
   <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'b\'')"/>

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -19,23 +19,30 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
-  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
-  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
-  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+  <arg name="sensor_frame" default="os_sensor"
+    description="sets name of choice for the sensor_frame tf frame, value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar"
+    description="sets name of choice for the os_lidar tf frame, value can not be empty"/>
+  <arg name="imu_frame" default="os_imu"
+      description="sets name of choice for the os_imu tf frame, value can not be empty"/>
+  <arg name="point_cloud_frame" default=""
+    description="which frame to be used when publishing PointCloud2 or LaserScan messages.
+    Choose between the value of sensor_frame or lidar_frame, leaving this value empty
+    would set lidar_frame to be the frame used when publishing these messages."/>
 
   <let name="_use_metadata_file" value="$(eval '\'$(var metadata)\' != \'\'')"/>
 
   <arg name="use_system_default_qos" default="true"
     description="Use the default system QoS settings"/>
+
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    currently IMG is not supported and does not affect anything,
+    The IMG flag here is not supported and does not affect anything,
     to disable image topics you would need to omit the os_image node
     from the launch file"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
-    and choose a value the range [0, sensor_beams_count)"
-  />
+    and choose a value the range [0, sensor_beams_count)"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -46,6 +53,7 @@
       <param name="sensor_frame" value="$(var sensor_frame)"/>
       <param name="lidar_frame" value="$(var lidar_frame)"/>
       <param name="imu_frame" value="$(var imu_frame)"/>
+      <param name="point_cloud_frame" value="$(var point_cloud_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
       <param name="proc_mask" value="$(var proc_mask)"/>

--- a/ouster-ros/launch/rviz.launch.xml
+++ b/ouster-ros/launch/rviz.launch.xml
@@ -5,10 +5,6 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
-  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
-  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
-  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
-
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen"

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -87,9 +87,9 @@
 
   <!-- HACK: configure and activate the sensor node via a process execute since state
     transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor configure"
+  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver configure"
     launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor activate"
+  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver activate"
     launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -40,14 +40,22 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
-  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
-  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
-  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+  <arg name="sensor_frame" default="os_sensor"
+    description="sets name of choice for the sensor_frame tf frame, value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar"
+    description="sets name of choice for the os_lidar tf frame, value can not be empty"/>
+  <arg name="imu_frame" default="os_imu"
+      description="sets name of choice for the os_imu tf frame, value can not be empty"/>
+  <arg name="point_cloud_frame" default=""
+    description="which frame to be used when publishing PointCloud2 or LaserScan messages.
+    Choose between the value of sensor_frame or lidar_frame, leaving this value empty
+    would set lidar_frame to be the frame used when publishing these messages."/>
 
-  <arg name="use_system_default_qos" default="false" description="Use the default system QoS settings"/>
-  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    use any combination of the 4 flags to enable or disable specific processors"
-  />
+  <arg name="use_system_default_qos" default="false"
+    description="Use the default system QoS settings"/>
+  
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN"
+    description="use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
@@ -65,11 +73,11 @@
       <param name="imu_port" value="$(var imu_port)"/>
       <param name="udp_profile_lidar" value="$(var udp_profile_lidar)"/>
       <param name="lidar_mode" value="$(var lidar_mode)"/>
-      <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="metadata" value="$(var metadata)"/>
       <param name="sensor_frame" value="$(var sensor_frame)"/>
       <param name="lidar_frame" value="$(var lidar_frame)"/>
       <param name="imu_frame" value="$(var imu_frame)"/>
+      <param name="point_cloud_frame" value="$(var point_cloud_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
       <param name="proc_mask" value="$(var proc_mask)"/>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -95,9 +95,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="sensor_frame" value="$(var sensor_frame)"/>
-    <arg name="lidar_frame" value="$(var lidar_frame)"/>
-    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -40,21 +40,28 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
-  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
-  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
-  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+  <arg name="sensor_frame" default="os_sensor"
+    description="sets name of choice for the sensor_frame tf frame, value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar"
+    description="sets name of choice for the os_lidar tf frame, value can not be empty"/>
+  <arg name="imu_frame" default="os_imu"
+      description="sets name of choice for the os_imu tf frame, value can not be empty"/>
+  <arg name="point_cloud_frame" default=""
+    description="which frame to be used when publishing PointCloud2 or LaserScan messages.
+    Choose between the value of sensor_frame or lidar_frame, leaving this value empty
+    would set lidar_frame to be the frame used when publishing these messages."/>
 
   <arg name="use_system_default_qos" default="false"
     description="Use the default system QoS settings"/>
+
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    currently IMG is not supported and does not affect anything,
+    The IMG flag here is not supported and does not affect anything,
     to disable image topics you would need to omit the os_image node
     from the launch file"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
-    and choose a value the range [0, sensor_beams_count)"
-  />
+    and choose a value the range [0, sensor_beams_count)"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -76,6 +83,7 @@
       <param name="sensor_frame" value="$(var sensor_frame)"/>
       <param name="lidar_frame" value="$(var lidar_frame)"/>
       <param name="imu_frame" value="$(var imu_frame)"/>
+      <param name="point_cloud_frame" value="$(var point_cloud_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
       <param name="proc_mask" value="$(var proc_mask)"/>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -104,9 +104,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="sensor_frame" value="$(var sensor_frame)"/>
-    <arg name="lidar_frame" value="$(var lidar_frame)"/>
-    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -44,7 +44,8 @@
   <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
   <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
 
-  <arg name="use_system_default_qos" default="false" description="Use the default system QoS settings"/>
+  <arg name="use_system_default_qos" default="false"
+    description="Use the default system QoS settings"/>
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
     currently IMG is not supported and does not affect anything,
     to disable image topics you would need to omit the os_image node

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -77,7 +77,6 @@
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="metadata" value="$(var metadata)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
-      <param name="proc_mask" value="$(var proc_mask)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
       <param name="sensor_frame" value="$(var sensor_frame)"/>

--- a/ouster-ros/launch/sensor.launch.xml
+++ b/ouster-ros/launch/sensor.launch.xml
@@ -1,1 +1,1 @@
-sensor.independent.launch.xml
+sensor.composite.launch.xml

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -48,12 +48,20 @@
   <arg name="rviz_config" default="$(find-pkg-share ouster_ros)/config/viz.rviz"
     description="optional rviz config file"/>
 
-  <arg name="sensor_frame" default="os_sensor" description="value can not be empty"/>
-  <arg name="lidar_frame" default="os_lidar" description="value can not be empty"/>
-  <arg name="imu_frame" default="os_imu" description="value can not be empty"/>
+  <arg name="sensor_frame" default="os_sensor"
+    description="sets name of choice for the sensor_frame tf frame, value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar"
+    description="sets name of choice for the os_lidar tf frame, value can not be empty"/>
+  <arg name="imu_frame" default="os_imu"
+      description="sets name of choice for the os_imu tf frame, value can not be empty"/>
+  <arg name="point_cloud_frame" default=""
+    description="which frame to be used when publishing PointCloud2 or LaserScan messages.
+    Choose between the value of sensor_frame or lidar_frame, leaving this value empty
+    would set lidar_frame to be the frame used when publishing these messages."/>
 
   <arg name="use_system_default_qos" default="false"
     description="Use the default system QoS settings"/>
+
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN"
     description="Use any combination of the 4 flags to enable or disable specific processors"/>
 
@@ -72,11 +80,11 @@
       <param name="imu_port" value="$(var imu_port)"/>
       <param name="udp_profile_lidar" value="$(var udp_profile_lidar)"/>
       <param name="lidar_mode" value="$(var lidar_mode)"/>
-      <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="metadata" value="$(var metadata)"/>
       <param name="sensor_frame" value="$(var sensor_frame)"/>
       <param name="lidar_frame" value="$(var lidar_frame)"/>
       <param name="imu_frame" value="$(var imu_frame)"/>
+      <param name="point_cloud_frame" value="$(var point_cloud_frame)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
       <param name="proc_mask" value="$(var proc_mask)"/>

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -94,9 +94,9 @@
 
   <!-- HACK: configure and activate the sensor node via a process execute since state
     transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor configure"
+  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver configure"
     launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor activate"
+  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver activate"
     launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -102,9 +102,6 @@
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="sensor_frame" value="$(var sensor_frame)"/>
-    <arg name="lidar_frame" value="$(var lidar_frame)"/>
-    <arg name="imu_frame" value="$(var imu_frame)"/>
   </include>
 
 </launch>

--- a/ouster-ros/src/os_static_transforms_broadcaster.h
+++ b/ouster-ros/src/os_static_transforms_broadcaster.h
@@ -22,7 +22,7 @@ class OusterStaticTransformsBroadcaster {
         node->declare_parameter("sensor_frame", "os_sensor");
         node->declare_parameter("lidar_frame", "os_lidar");
         node->declare_parameter("imu_frame", "os_imu");
-        node->declare_parameter("point_cloud_frame", "os_lidar");
+        node->declare_parameter("point_cloud_frame", "");
     }
 
     void parse_parameters() {
@@ -33,8 +33,8 @@ class OusterStaticTransformsBroadcaster {
 
         // validate point_cloud_frame
         if (point_cloud_frame.empty()) {
-            point_cloud_frame =
-                lidar_frame;  // for ROS1 we'd still use sensor_frame
+            // ROS2 uses lidar_frame as the default point_cloud_frame
+            point_cloud_frame = lidar_frame;
         } else if (point_cloud_frame != sensor_frame &&
                    point_cloud_frame != lidar_frame) {
             RCLCPP_WARN(node->get_logger(),


### PR DESCRIPTION
## Related Issues & PRs
- related #149

## Summary of Changes
- Use `SystemDefaultQoS` by default when recording/replaying
- Switch to using composite/merged driver node by default for `sensor.launch.xml` launch file.
- Initialize `point_cloud_frame` with an empty string
- Misc:
  - Add missing param definitions to `record.independent.launch.xml` 
  - Remove unused param definitions in `rviz.launch.xml` 

## Validation
- Launch a live sensor using the xml launch file format setting only the value of the `sensor_hostname`
```bash
ros2 launch ouster_ros sensor.launch.xml \
  sensor_hostname:=<sensor host>
```
Once the sensor connects verify that all topics are using a BEST_EFFORT policy using:
```bash
ros2 topic echo -v "topic_name"
```
- Launch `record.launch.xml` as follows:
```bash
ros2 launch ouster_ros record.launch.xml \
  sensor_hostname:=<sensor host>          \
  bag_file:=<bag file>
```
Once the sensor connects verify that all topics are using a RELIABLE policy using:
```bash
ros2 topic echo -v "topic_name"
```