### PR TITLE
ROS-175: Quick prototype on how to reduce the vertical resolution for the point cloud

### DIFF
--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -143,7 +143,7 @@ void scan_to_cloud_f_destaggered(ouster_ros::Cloud& cloud,
                      const ouster::PointsF& lut_offset, uint64_t scan_ts,
                      const ouster::LidarScan& ls,
                      const std::vector<int>& pixel_shift_by_row,
-                     int return_index);
+                     int return_index, int skip_rings = 1);
 
 /**
  * Serialize a PCL point cloud to a ROS message


### PR DESCRIPTION
## Related Issues & PRs
- closes #175
- related https://github.com/ouster-lidar/ouster_example/pull/338

## Summary of Changes
- Demonstrate how to reduce the vertical resolution of the published point cloud
- TODO:
  - parameterize the factor of reduction 
  - apply the same concept to the published image topics

## Validation
`roslaunch ouster_ros ..` then `rostopic echo /ouster/points` and verify the vertical resolution is cut down by the hard coded factor skip_rings factor.