### PR TITLE
disable intraprocess for transient local topics

### DIFF
--- a/ouster-ros/src/os_processing_node_base.cpp
+++ b/ouster-ros/src/os_processing_node_base.cpp
@@ -16,8 +16,10 @@ void OusterProcessingNodeBase::create_metadata_subscriber(
     auto latching_qos = rclcpp::QoS(rclcpp::KeepLast(1));
     latching_qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
     latching_qos.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    rclcpp::SubscriptionOptions subscription_options;
+    subscription_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
     metadata_sub = create_subscription<std_msgs::msg::String>(
-        "metadata", latching_qos, on_sensor_metadata);
+        "metadata", latching_qos, on_sensor_metadata, subscription_options);
 }
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -34,8 +34,10 @@ void OusterSensorNodeBase::create_metadata_publisher() {
     auto latching_qos = rclcpp::QoS(rclcpp::KeepLast(1));
     latching_qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
     latching_qos.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    rclcpp::PublisherOptions publisher_options;
+    publisher_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
     metadata_pub =
-        create_publisher<std_msgs::msg::String>("metadata", latching_qos);
+        create_publisher<std_msgs::msg::String>("metadata", latching_qos, publisher_options);
 }
 
 void OusterSensorNodeBase::publish_metadata() {


### PR DESCRIPTION
## Related Issues & PRs
N/A

## Summary of Changes
Explicitly disable intraprocess communication for metadata publisher and subscription, otherwise it fails if you try to set `use_intraprocess_comms: True` on the whole node.

## Validation
In progress.
