### PR TITLE
SW-5459: add a parameter for utc/tai time offset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ ouster_ros(1)
 * introduced a new launch file parameter ``ptp_utc_tai_offset`` which represent offset in seconds
   to be applied to all ROS messages the driver generates when ``TIME_FROM_PTP_1588`` timestamp mode
   is used.
+* fix: destagger columns timestamp when generating destaggered point clouds.
 
 
 ouster_ros v0.10.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changelog
 ouster_ros(1)
 -------------
 * breaking: publish PCL point clouds destaggered.
+* introduced a new launch file parameter ``ptp_utc_tai_offset`` which represent offset in seconds
+  to be applied to all ROS messages the driver generates when ``TIME_FROM_PTP_1588`` timestamp mode
+  is used.
 
 
 ouster_ros v0.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,17 +29,14 @@ RUN set -xe \
 && groupadd -o -g ${BUILD_GID} build \
 && useradd -o -u ${BUILD_UID} -d ${BUILD_HOME} -rm -s /bin/bash -g build build
 
-# Install build dependencies using rosdep
-COPY --chown=build:build package.xml $OUSTER_ROS_PATH/package.xml
+# Set up build environment
+COPY --chown=build:build . $OUSTER_ROS_PATH
 
 RUN set -xe         \
 && apt-get update   \
 && rosdep init      \
 && rosdep update --rosdistro=$ROS_DISTRO \
 && rosdep install -y --from-paths $OUSTER_ROS_PATH
-
-# Set up build environment
-COPY --chown=build:build . $OUSTER_ROS_PATH
 
 USER build:build
 WORKDIR ${BUILD_HOME}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [ROS1 (melodic/noetic)](https://github.com/ouster-lidar/ouster-ros/tree/master) |
 [ROS2 (rolling/humble/iron)](https://github.com/ouster-lidar/ouster-ros/tree/ros2) |
-[ROS2 (foxy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2-foxy)
+[ROS2 (galactic/foxy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2-foxy)
 
 <p style="float: right;"><img width="20%" src="docs/images/logo.png" /></p>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 |:-----------:|:------:|
 | ROS1 (melodic/noetic) | [![melodic/noetic](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=master)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 | ROS2 (rolling/humble/iron) | [![rolling/humble/iron](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
-| ROS2 (foxy) | [![foxy](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2-foxy)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
+| ROS2 (galactic/foxy) | [![galactic/foxy](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2-foxy)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 
 - [Overview](#overview)
 - [Requirements](#requirements)

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -206,6 +206,12 @@ inline ouster::img_t<T> get_or_fill_zero(sensor::ChanField field,
     return result;
 }
 
+/**
+ * simple utility to function that ensures we don't wrap around uint64_t due
+ * to negative value bigger than ts value
+ */
+uint64_t ts_safe_offset_add(uint64_t ts, int64_t offset);
+
 ros::Time ts_to_ros_time(uint64_t ts);
 
 }  // namespace impl

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -208,11 +208,19 @@ inline ouster::img_t<T> get_or_fill_zero(sensor::ChanField field,
 
 /**
  * simple utility to function that ensures we don't wrap around uint64_t due
- * to negative value bigger than ts value
+ * to a negative value being bigger than ts value in absolute terms.
+ * @remark method does not check upper boundary
  */
-uint64_t ts_safe_offset_add(uint64_t ts, int64_t offset);
+inline uint64_t ts_safe_offset_add(uint64_t ts, int64_t offset) {
+    return offset < 0 && ts < static_cast<uint64_t>(std::abs(offset)) ? 0 : ts + offset;
+}
 
-ros::Time ts_to_ros_time(uint64_t ts);
+
+inline ros::Time ts_to_ros_time(uint64_t ts) {
+    ros::Time t;
+    t.fromNSec(ts);
+    return t;
+}
 
 }  // namespace impl
 

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -207,14 +207,13 @@ inline ouster::img_t<T> get_or_fill_zero(sensor::ChanField field,
 }
 
 /**
- * simple utility to function that ensures we don't wrap around uint64_t due
+ * simple utility function that ensures we don't wrap around uint64_t due
  * to a negative value being bigger than ts value in absolute terms.
  * @remark method does not check upper boundary
  */
 inline uint64_t ts_safe_offset_add(uint64_t ts, int64_t offset) {
     return offset < 0 && ts < static_cast<uint64_t>(std::abs(offset)) ? 0 : ts + offset;
 }
-
 
 inline ros::Time ts_to_ros_time(uint64_t ts) {
     ros::Time t;

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -17,8 +17,9 @@
     would set lidar_frame to be the frame used when publishing these messages."/>
 
   <arg name="timestamp_mode" doc="method used to timestamp measurements"/>
-  <arg name="dynamic_transforms_broadcast"
-    doc="static or dynamic transforms broadcast"/>
+  <arg name="ptp_utc_tai_offset" doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
+
+  <arg name="dynamic_transforms_broadcast" doc="static or dynamic transforms broadcast"/>
   <arg name="dynamic_transforms_broadcast_rate"
     doc="set the rate (Hz) of broadcast when using dynamic broadcast; minimum value is 1 Hz"/>
 
@@ -47,6 +48,7 @@
         value="$(arg dynamic_transforms_broadcast_rate)"/>
       <param name="~/proc_mask" value="$(arg proc_mask)"/>
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
+      <param name="~/ptp_utc_tai_offset" type="double" value="$(arg ptp_utc_tai_offset)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -25,6 +25,9 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="ptp_utc_tai_offset" default="-37.0"
+    doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
+
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
@@ -71,6 +74,8 @@
       <param name="~/udp_profile_lidar" type="str" value="$(arg udp_profile_lidar)"/>
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/ptp_utc_tai_offset" type="double"
+        value="$(arg ptp_utc_tai_offset)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
       <param name="~/tf_prefix" value="$(arg tf_prefix)"/>
       <param name="~/sensor_frame" value="$(arg sensor_frame)"/>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -27,7 +27,6 @@
     }"/>
   <arg name="ptp_utc_tai_offset" default="-37.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
-
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -25,6 +25,8 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="ptp_utc_tai_offset" default="-37.0"
+    doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
   <arg name="metadata" default="" doc="path to write metadata file when receiving sensor data"/>
   <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
@@ -89,6 +91,7 @@
     <arg name="imu_frame" value="$(arg imu_frame)"/>
     <arg name="point_cloud_frame" value="$(arg point_cloud_frame)"/>
     <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
+    <arg name="ptp_utc_tai_offset" value="$(arg ptp_utc_tai_offset)"/>
     <arg name="dynamic_transforms_broadcast"
       value="$(arg dynamic_transforms_broadcast)"/>
     <arg name="dynamic_transforms_broadcast_rate"

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -7,6 +7,8 @@
     possible values: {
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="ptp_utc_tai_offset" default="-37.0"
+    doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
 
@@ -64,6 +66,7 @@
     <arg name="imu_frame" value="$(arg imu_frame)"/>
     <arg name="point_cloud_frame" value="$(arg point_cloud_frame)"/>
     <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
+    <arg name="ptp_utc_tai_offset" value="$(arg ptp_utc_tai_offset)"/>
     <arg name="dynamic_transforms_broadcast"
       value="$(arg dynamic_transforms_broadcast)"/>
     <arg name="dynamic_transforms_broadcast_rate"

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -25,6 +25,9 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="ptp_utc_tai_offset" default="-37.0"
+    doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
+
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
@@ -92,6 +95,8 @@
     <arg name="imu_frame" value="$(arg imu_frame)"/>
     <arg name="point_cloud_frame" value="$(arg point_cloud_frame)"/>
     <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
+    <param name="~/ptp_utc_tai_offset" type="double"
+      value="$(arg ptp_utc_tai_offset)"/>
     <arg name="_no_bond" value="$(arg _no_bond)"/>
     <arg name="dynamic_transforms_broadcast"
       value="$(arg dynamic_transforms_broadcast)"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -95,8 +95,7 @@
     <arg name="imu_frame" value="$(arg imu_frame)"/>
     <arg name="point_cloud_frame" value="$(arg point_cloud_frame)"/>
     <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
-    <param name="~/ptp_utc_tai_offset" type="double"
-      value="$(arg ptp_utc_tai_offset)"/>
+    <arg name="ptp_utc_tai_offset" value="$(arg ptp_utc_tai_offset)"/>
     <arg name="_no_bond" value="$(arg _no_bond)"/>
     <arg name="dynamic_transforms_broadcast"
       value="$(arg dynamic_transforms_broadcast)"/>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -29,6 +29,9 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="ptp_utc_tai_offset" default="-37.0"
+    doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
+
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
@@ -98,6 +101,7 @@
     <arg name="imu_frame" value="$(arg imu_frame)"/>
     <arg name="point_cloud_frame" value="$(arg point_cloud_frame)"/>
     <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
+    <arg name="ptp_utc_tai_offset" value="$(arg ptp_utc_tai_offset)"/>
     <arg name="_no_bond" value="$(arg _no_bond)"/>
     <arg name="dynamic_transforms_broadcast"
       value="$(arg dynamic_transforms_broadcast)"/>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.9.1</version>
+  <version>0.9.2</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/imu_packet_handler.h
+++ b/src/imu_packet_handler.h
@@ -29,28 +29,26 @@ class ImuPacketHandler {
         const auto& pf = ouster::sensor::get_format(info);
         using Timestamper = std::function<ros::Time(const uint8_t*)>;
         Timestamper timestamper;
-        // clang-format off
         if (timestamp_mode == "TIME_FROM_ROS_TIME") {
-            timestamper = Timestamper{[](const uint8_t* /*imu_buf*/) {
-                return ros::Time::now();
-            }};
+            timestamper = Timestamper{
+                [](const uint8_t* /*imu_buf*/) { return ros::Time::now(); }};
         } else if (timestamp_mode == "TIME_FROM_PTP_1588") {
-            timestamper = Timestamper{[pf, ptp_utc_tai_offset](const uint8_t* imu_buf) {
-                uint64_t ts = pf.imu_gyro_ts(imu_buf);
-                ts = impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
-                return impl::ts_to_ros_time(ts);
-            }};
+            timestamper =
+                Timestamper{[pf, ptp_utc_tai_offset](const uint8_t* imu_buf) {
+                    uint64_t ts = pf.imu_gyro_ts(imu_buf);
+                    ts = impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
+                    return impl::ts_to_ros_time(ts);
+                }};
         } else {
             timestamper = Timestamper{[pf](const uint8_t* imu_buf) {
                 return impl::ts_to_ros_time(pf.imu_gyro_ts(imu_buf));
             }};
         }
 
-        // clang-format on
         return [&pf, &frame, timestamper](const uint8_t* imu_buf) {
             return packet_to_imu_msg(pf, timestamper(imu_buf), frame, imu_buf);
         };
     }
 };
 
-}   // namespace ouster_ros
+}  // namespace ouster_ros

--- a/src/imu_packet_handler.h
+++ b/src/imu_packet_handler.h
@@ -24,15 +24,28 @@ class ImuPacketHandler {
    public:
     static HandlerType create_handler(const ouster::sensor::sensor_info& info,
                                       const std::string& frame,
-                                      bool use_ros_time) {
+                                      const std::string& timestamp_mode,
+                                      int64_t ptp_utc_tai_offset) {
         const auto& pf = ouster::sensor::get_format(info);
         using Timestamper = std::function<ros::Time(const uint8_t*)>;
+        Timestamper timestamper;
         // clang-format off
-        auto timestamper = use_ros_time ?
-            Timestamper{[](const uint8_t* /*imu_buf*/) {
-                return ros::Time::now(); }} :
-            Timestamper{[pf](const uint8_t* imu_buf) {
-                return impl::ts_to_ros_time(pf.imu_gyro_ts(imu_buf)); }};
+        if (timestamp_mode == "TIME_FROM_ROS_TIME") {
+            timestamper = Timestamper{[](const uint8_t* /*imu_buf*/) {
+                return ros::Time::now();
+            }};
+        } else if (timestamp_mode == "TIME_FROM_PTP_1588") {
+            timestamper = Timestamper{[pf, ptp_utc_tai_offset](const uint8_t* imu_buf) {
+                uint64_t ts = pf.imu_gyro_ts(imu_buf);
+                ts = impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
+                return impl::ts_to_ros_time(ts);
+            }};
+        } else {
+            timestamper = Timestamper{[pf](const uint8_t* imu_buf) {
+                return impl::ts_to_ros_time(pf.imu_gyro_ts(imu_buf));
+            }};
+        }
+
         // clang-format on
         return [&pf, &frame, timestamper](const uint8_t* imu_buf) {
             return packet_to_imu_msg(pf, timestamper(imu_buf), frame, imu_buf);

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -254,12 +254,10 @@ class LidarPacketHandler {
                                        const uint8_t* lidar_buf,
                                        int64_t ptp_utc_tai_offset) {
         if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
-        ouster::LidarScan::Header<uint64_t> utc_timestamp =
-            lidar_scan->timestamp().unaryExpr(
-                [ptp_utc_tai_offset](uint64_t ts) {
-                    return impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
-                });
-        lidar_scan_estimated_ts = compute_scan_ts(utc_timestamp);
+        auto ts_v = lidar_scan->timestamp();
+        for (int i = 0; i < ts_v.rows(); ++i)
+            ts_v[i] = impl::ts_safe_offset_add(ts_v[i], ptp_utc_tai_offset);
+        lidar_scan_estimated_ts = compute_scan_ts(ts_v);
         lidar_scan_estimated_msg_ts =
             impl::ts_to_ros_time(lidar_scan_estimated_ts);
         return true;

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -254,10 +254,11 @@ class LidarPacketHandler {
                                        const uint8_t* lidar_buf,
                                        int64_t ptp_utc_tai_offset) {
         if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
-        auto utc_timestamp = lidar_scan->timestamp().unaryExpr(
-            [ptp_utc_tai_offset](uint64_t ts) {
-                return impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
-            });
+        ouster::LidarScan::Header<uint64_t> utc_timestamp =
+            lidar_scan->timestamp().unaryExpr(
+                [ptp_utc_tai_offset](uint64_t ts) {
+                    return impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
+                });
         lidar_scan_estimated_ts = compute_scan_ts(utc_timestamp);
         lidar_scan_estimated_msg_ts =
             impl::ts_to_ros_time(lidar_scan_estimated_ts);

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -254,9 +254,11 @@ class LidarPacketHandler {
                                        const uint8_t* lidar_buf,
                                        int64_t ptp_utc_tai_offset) {
         if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
-        lidar_scan_estimated_ts = compute_scan_ts(lidar_scan->timestamp());
-        lidar_scan_estimated_ts = impl::ts_safe_offset_add(
-            lidar_scan_estimated_ts, ptp_utc_tai_offset);
+        auto utc_timestamp = lidar_scan->timestamp().unaryExpr(
+            [ptp_utc_tai_offset](uint64_t ts) {
+                return impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
+            });
+        lidar_scan_estimated_ts = compute_scan_ts(utc_timestamp);
         lidar_scan_estimated_msg_ts =
             impl::ts_to_ros_time(lidar_scan_estimated_ts);
         return true;

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -93,7 +93,10 @@ class LidarPacketHandler {
 
    public:
     LidarPacketHandler(const ouster::sensor::sensor_info& info,
-                       bool use_ros_time) {
+                       const std::vector<LidarScanProcessor>& handlers,
+                       const std::string& timestamp_mode,
+                       int64_t ptp_utc_tai_offset) :
+                       lidar_scan_handlers{handlers} {
         // initialize lidar_scan processor and buffer
         scan_batcher = std::make_unique<ouster::ScanBatcher>(info);
         lidar_scan = std::make_unique<ouster::LidarScan>(
@@ -107,14 +110,22 @@ class LidarPacketHandler {
         };
         const sensor::packet_format& pf = sensor::get_format(info);
 
-        lidar_packet_accumlator =
-            use_ros_time
-                ? LidarPacketAccumlator{[this, pf](const uint8_t* lidar_buf) {
-                      return lidar_handler_ros_time(pf, lidar_buf);
-                  }}
-                : LidarPacketAccumlator{[this, pf](const uint8_t* lidar_buf) {
-                      return lidar_handler_sensor_time(pf, lidar_buf);
-                  }};
+        if (timestamp_mode == "TIME_FROM_ROS_TIME") {
+            lidar_packet_accumlator =
+                LidarPacketAccumlator{[this, pf](const uint8_t* lidar_buf) {
+                    return lidar_handler_ros_time(pf, lidar_buf);
+                }};
+        } else if (timestamp_mode == "TIME_FROM_PTP_1588") {
+            lidar_packet_accumlator =
+                LidarPacketAccumlator{[this, pf, ptp_utc_tai_offset](const uint8_t* lidar_buf) {
+                    return lidar_handler_sensor_time_ptp(pf, lidar_buf, ptp_utc_tai_offset);
+                }};
+        } else {
+            lidar_packet_accumlator =
+                LidarPacketAccumlator{[this, pf](const uint8_t* lidar_buf) {
+                    return lidar_handler_sensor_time(pf, lidar_buf);
+                }};
+        }
     }
 
     LidarPacketHandler(const LidarPacketHandler&) = delete;
@@ -129,12 +140,12 @@ class LidarPacketHandler {
 
    public:
     static HandlerType create_handler(
-        const ouster::sensor::sensor_info& info, bool use_ros_time,
-        const std::vector<LidarScanProcessor>& handlers) {
-        auto handler = std::make_shared<LidarPacketHandler>(info, use_ros_time);
-
-        handler->lidar_scan_handlers = handlers;
-
+        const ouster::sensor::sensor_info& info,
+        const std::vector<LidarScanProcessor>& handlers,
+        const std::string& timestamp_mode,
+        int64_t ptp_utc_tai_offset) {
+        auto handler = std::make_shared<LidarPacketHandler>(
+            info, handlers, timestamp_mode, ptp_utc_tai_offset);
         return [handler](const uint8_t* lidar_buf) {
             if (handler->lidar_packet_accumlator(lidar_buf)) {
                 for (auto h : handler->lidar_scan_handlers) {
@@ -202,7 +213,6 @@ class LidarPacketHandler {
         assert(idx != ts_v.data() + ts_v.size());  // should never happen
         int curr_scan_first_nonzero_idx = idx - ts_v.data();
         uint64_t curr_scan_first_nonzero_value = *idx;
-
         uint64_t scan_ns = curr_scan_first_nonzero_idx == 0
                                ? curr_scan_first_nonzero_value
                                : impute_value(last_scan_last_nonzero_idx,
@@ -210,7 +220,6 @@ class LidarPacketHandler {
                                               curr_scan_first_nonzero_idx,
                                               curr_scan_first_nonzero_value,
                                               static_cast<int>(ts_v.size()));
-
         last_scan_last_nonzero_idx =
             find_if_reverse(ts_v, [](uint64_t h) { return h != 0; });
         assert(last_scan_last_nonzero_idx >= 0);  // should never happen
@@ -227,9 +236,7 @@ class LidarPacketHandler {
                                    const uint8_t* lidar_buf,
                                    const ros::Time current_time) {
         auto curr_scan_first_arrived_idx = packet_col_index(pf, lidar_buf);
-        auto delta_time = ros::Duration(
-            0,
-            std::lround(scan_col_ts_spacing_ns * curr_scan_first_arrived_idx));
+        auto delta_time = ros::Duration(0, std::lround(scan_col_ts_spacing_ns * curr_scan_first_arrived_idx));
         return current_time - delta_time;
     }
 
@@ -237,8 +244,16 @@ class LidarPacketHandler {
                                    const uint8_t* lidar_buf) {
         if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
         lidar_scan_estimated_ts = compute_scan_ts(lidar_scan->timestamp());
-        lidar_scan_estimated_msg_ts =
-            impl::ts_to_ros_time(lidar_scan_estimated_ts);
+        lidar_scan_estimated_msg_ts = impl::ts_to_ros_time(lidar_scan_estimated_ts);
+        return true;
+    }
+
+    bool lidar_handler_sensor_time_ptp(const sensor::packet_format&,
+                                   const uint8_t* lidar_buf, int64_t ptp_utc_tai_offset) {
+        if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
+        lidar_scan_estimated_ts = compute_scan_ts(lidar_scan->timestamp());
+        lidar_scan_estimated_ts = impl::ts_safe_offset_add(lidar_scan_estimated_ts, ptp_utc_tai_offset);
+        lidar_scan_estimated_msg_ts = impl::ts_to_ros_time(lidar_scan_estimated_ts);
         return true;
     }
 

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -153,9 +153,8 @@ class OusterCloud : public nodelet::Nodelet {
             }
 
             processors.push_back(LaserScanProcessor::create(
-                info,
-                tf_bcast.lidar_frame_id(),
-                scan_ring, [this](LaserScanProcessor::OutputType msgs) {
+                info, tf_bcast.lidar_frame_id(), scan_ring,
+                [this](LaserScanProcessor::OutputType msgs) {
                     for (size_t i = 0; i < msgs.size(); ++i) {
                         if (msgs[i]->header.stamp > last_msg_ts)
                             last_msg_ts = msgs[i]->header.stamp;

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -103,9 +103,8 @@ class OusterDriver : public OusterSensor {
             }
 
             processors.push_back(LaserScanProcessor::create(
-                info,
-                tf_bcast.lidar_frame_id(),
-                scan_ring, [this](LaserScanProcessor::OutputType msgs) {
+                info, tf_bcast.lidar_frame_id(), scan_ring,
+                [this](LaserScanProcessor::OutputType msgs) {
                     for (size_t i = 0; i < msgs.size(); ++i) {
                         scan_pubs[i].publish(*msgs[i]);
                     }

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -52,15 +52,16 @@ class OusterDriver : public OusterSensor {
             pnh.param("proc_mask", std::string{"IMU|IMG|PCL|SCAN"});
         auto tokens = parse_tokens(proc_mask, '|');
 
-        auto timestamp_mode_arg = pnh.param("timestamp_mode", std::string{});
-        bool use_ros_time = timestamp_mode_arg == "TIME_FROM_ROS_TIME";
+        auto timestamp_mode = pnh.param("timestamp_mode", std::string{});
+        double ptp_utc_tai_offset = pnh.param("ptp_utc_tai_offset", -37.0);
 
         auto& nh = getNodeHandle();
 
         if (check_token(tokens, "IMU")) {
             imu_pub = nh.advertise<sensor_msgs::Imu>("imu", 100);
             imu_packet_handler = ImuPacketHandler::create_handler(
-                info, tf_bcast.imu_frame_id(), use_ros_time);
+                info, tf_bcast.imu_frame_id(), timestamp_mode,
+                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }
 
         int num_returns = get_n_returns(info);
@@ -103,10 +104,7 @@ class OusterDriver : public OusterSensor {
 
             processors.push_back(LaserScanProcessor::create(
                 info,
-                tf_bcast
-                    .point_cloud_frame_id(),  // TODO: should we allow having a
-                                              // different frame for the laser
-                                              // scan than point cloud???
+                tf_bcast.lidar_frame_id(),
                 scan_ring, [this](LaserScanProcessor::OutputType msgs) {
                     for (size_t i = 0; i < msgs.size(); ++i) {
                         scan_pubs[i].publish(*msgs[i]);
@@ -151,7 +149,8 @@ class OusterDriver : public OusterSensor {
         if (check_token(tokens, "PCL") || check_token(tokens, "SCAN") ||
             check_token(tokens, "IMG"))
             lidar_packet_handler = LidarPacketHandler::create_handler(
-                info, use_ros_time, processors);
+                info, processors, timestamp_mode,
+                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
     }
 
     virtual void on_lidar_packet_msg(const uint8_t* raw_lidar_packet) override {

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -199,7 +199,6 @@ void copy_scan_to_cloud_destaggered(
     const ouster::img_t<NearIrT>& near_ir, const ouster::img_t<SignalT>& signal,
     const std::vector<int>& pixel_shift_by_row) {
     auto timestamp = ls.timestamp();
-
     const auto rg = range.data();
     const auto rf = reflectivity.data();
     const auto nr = near_ir.data();
@@ -210,11 +209,9 @@ void copy_scan_to_cloud_destaggered(
 #endif
     for (auto u = 0; u < ls.h; u++) {
         for (auto v = 0; v < ls.w; v++) {
-            const auto ts_src_idx = (v + ls.w - pixel_shift_by_row[u]) % ls.w;
-            const auto col_ts = timestamp[ts_src_idx];
-            const auto ts = col_ts > scan_ts ? col_ts - scan_ts : 0UL;
-            const auto src_idx =
-                u * ls.w + (v + ls.w - pixel_shift_by_row[u]) % ls.w;
+            const auto v_shift = (v + ls.w - pixel_shift_by_row[u]) % ls.w;
+            auto ts = timestamp[v_shift]; ts = ts > scan_ts ? ts - scan_ts : 0UL;
+            const auto src_idx = u * ls.w + v_shift;
             const auto tgt_idx = u * ls.w + v;
             const auto xyz = points.row(src_idx);
             cloud.points[tgt_idx] = ouster_ros::Point{

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -112,6 +112,12 @@ sensor::ChanField suitable_return(sensor::ChanField input_field, bool second) {
     }
 }
 
+uint64_t ts_safe_offset_add(uint64_t ts, int64_t offset) {
+    if (offset >= 0 || ts > static_cast<uint64_t>(std::abs(offset)))
+        ts += offset;
+    return ts;
+}
+
 ros::Time ts_to_ros_time(uint64_t ts) {
     ros::Time t;
     t.fromNSec(ts);

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -112,18 +112,6 @@ sensor::ChanField suitable_return(sensor::ChanField input_field, bool second) {
     }
 }
 
-uint64_t ts_safe_offset_add(uint64_t ts, int64_t offset) {
-    if (offset >= 0 || ts > static_cast<uint64_t>(std::abs(offset)))
-        ts += offset;
-    return ts;
-}
-
-ros::Time ts_to_ros_time(uint64_t ts) {
-    ros::Time t;
-    t.fromNSec(ts);
-    return t;
-}
-
 }  // namespace impl
 
 template <typename PointT, typename RangeT, typename ReflectivityT,

--- a/src/os_sensor_nodelet_base.cpp
+++ b/src/os_sensor_nodelet_base.cpp
@@ -6,12 +6,12 @@
  * @brief implementation of OusterSensorNodeletBase interface
  */
 
-#include <fstream>
-
 #include "ouster_ros/os_sensor_nodelet_base.h"
 
 #include <ouster/impl/build.h>
 #include <std_msgs/String.h>
+
+#include <fstream>
 
 #include "ouster_ros/GetMetadata.h"
 

--- a/src/os_transforms_broadcaster.h
+++ b/src/os_transforms_broadcaster.h
@@ -89,6 +89,9 @@ class OusterTransformsBroadcaster {
     }
 
     const std::string& imu_frame_id() const { return imu_frame; }
+    const std::string& lidar_frame_id() const { return lidar_frame; }
+    const std::string& sensor_frame_id() const { return sensor_frame; }
+
     const std::string& point_cloud_frame_id() const {
         return point_cloud_frame;
     }
@@ -100,9 +103,9 @@ class OusterTransformsBroadcaster {
     std::string node_name;
     tf2_ros::StaticTransformBroadcaster static_tf_bcast;
     tf2_ros::TransformBroadcaster tf_bcast;  // non-static
-    std::string sensor_frame;
     std::string imu_frame;
     std::string lidar_frame;
+    std::string sensor_frame;
     std::string point_cloud_frame;
 };
 

--- a/src/point_cloud_processor.h
+++ b/src/point_cloud_processor.h
@@ -62,9 +62,9 @@ class PointCloudProcessor {
     void process(const ouster::LidarScan& lidar_scan, uint64_t scan_ts,
                  const ros::Time& msg_ts) {
         for (int i = 0; i < static_cast<int>(pc_msgs.size()); ++i) {
-            scan_to_cloud_f_destaggered(cloud,
-                points, lut_direction, lut_offset,
-                scan_ts, lidar_scan, pixel_shift_by_row, i);
+            scan_to_cloud_f_destaggered(cloud, points, lut_direction,
+                                        lut_offset, scan_ts, lidar_scan,
+                                        pixel_shift_by_row, i);
             pcl_toROSMsg(cloud, *pc_msgs[i]);
             pc_msgs[i]->header.stamp = msg_ts;
             pc_msgs[i]->header.frame_id = frame;
@@ -105,4 +105,4 @@ class PointCloudProcessor {
     PostProcessingFn post_processing_fn;
 };
 
-}   // namespace ouster_ros
+}  // namespace ouster_ros


### PR DESCRIPTION
## Related Issues & PRs
- Incorporated #53
- addresses #186
- ROS2 Humble: #195 
- ROS2 Foxy: #198 

## Summary of Changes
* Add parameter for UTC/TAI offset in ptp mode.
* Don't alter the frame id for **LaserScan** messages.

## Validation
Use a sensor with PTP mode and a host machine with sync enabled.
The sensor timestamps and the host machine timestamp should match (on the order of 10 microseconds)