### PR TITLE
Destagger timestamp of each point as well

### DIFF
--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -216,7 +216,8 @@ void copy_scan_to_cloud_destaggered(
 #endif
     for (auto u = 0; u < ls.h; u++) {
         for (auto v = 0; v < ls.w; v++) {
-            const auto col_ts = timestamp[v];
+            const auto ts_src_idx = (v + ls.w - pixel_shift_by_row[u]) % ls.w;
+            const auto col_ts = timestamp[ts_src_idx];
             const auto ts = col_ts > scan_ts ? col_ts - scan_ts : 0UL;
             const auto src_idx =
                 u * ls.w + (v + ls.w - pixel_shift_by_row[u]) % ls.w;


### PR DESCRIPTION
As far as I understand the staggered vs destaggered the time stamp of one column within a staggered image / point cloud is always the same. But in an destaggered image / point cloud represents the same azimuth value in one column. 
See [here](https://static.ouster.dev/sdk-docs/reference/lidar-scan.html#staggering-and-destaggering)

Therefore i would expect the timestamp of each point in the destaggered point cloud to be corected by the pixel shift as well.

## Related Issues & PRs
#188 
#60

## Summary of Changes
I applied the pixel shift to the timestamp as well

## Validation
I tested it with an OS2, FW 2.5.2 with an follow up node for point cloud undistortion and it seem to work.
