### PR TITLE
Fix: Make libjsoncpp-dev exec_depend match build_depend and system name

### DIFF
--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -33,7 +33,7 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>libjsoncpp</exec_depend>
+  <exec_depend>libjsoncpp-dev</exec_depend>
   <exec_depend>curl</exec_depend>
   <exec_depend>spdlog</exec_depend>
   <exec_depend>libtins-dev</exec_depend>


### PR DESCRIPTION
There is a small issue with the current package.xml on the `ros2` branch.

`libjsoncpp` does not exist when installing with `apt`. Instead, it should be `libjsoncpp-dev`.
The current situation can cause errors for certain build systems using the `exec_depend` keys.
This PR brings it in line with the `build_depend` key for `libjsoncpp-dev`.

## Related Issues & PRs
None.
I can create one if required.

## Summary of Changes
* Appended `-dev` to `<exec_depend>libjsoncpp`

## Validation
- IMO not required as it has no effect on default builds.
