### PR TITLE
ROS-196: laser scan from ros driver is not properly aligned with point cloud [humble]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 [unreleased]
 ============
 * [BUGFIX]: LaserScan is not properly aligned with generated point cloud
+  * address an issue where LaserScan appeared different on FW prior to 2.4
 * [BUGFIX]: LaserScan does not work when using dual mode
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 
 [unreleased]
 ============
-* fix: LaserScan is not properly aligned with generated point cloud
+* [BUGFIX]: LaserScan is not properly aligned with generated point cloud
+* [BUGFIX]: LaserScan does not work when using dual mode
+
 
 ouster_ros v0.12.0
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+[unreleased]
+============
+* fix: LaserScan is not properly aligned with generated point cloud
+
 ouster_ros v0.12.0
 ==================
 * [BREAKING]: updated ouster_client to the release of ``20231031`` [v0.10.0]; changes listed below.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - [Official ROS driver for Ouster sensors](#official-ros-driver-for-ouster-sensors)
   - [Overview](#overview)
+  - [Supported Devices](#supported-devices)
   - [Requirements](#requirements)
     - [Linux](#linux)
     - [Windows](#windows)
@@ -42,6 +43,17 @@ driver will handle incoming IMU and lidar packets, decode lidar frames and publi
 messages on the topics of `/ouster/imu` and `/ouster/points`. In the case the used sensor supports
 dual return and it was configured to use this capability, then another topic will published under the
 name `/ouster/points2` which corresponds to the second point cloud.
+
+
+## Supported Devices
+The driver supports the following list of Ouster sensors:
+- [OS0](https://ouster.com/products/hardware/os0-lidar-sensor)
+- [OS1](https://ouster.com/products/hardware/os1-lidar-sensor)
+- [OS2](https://ouster.com/products/hardware/os2-lidar-sensor)
+- [OSDome](https://ouster.com/products/hardware/osdome-lidar-sensor)
+
+You can obtain detailed specs sheet about the sensors and obtain updated FW through the website
+[downloads](https://ouster.com/downloads) section.
 
 ## Requirements
 This branch is only intended for use with **Rolling**, **Humble** and **Iron** ROS 2 distros. Please

--- a/ouster-ros/config/viz.rviz
+++ b/ouster-ros/config/viz.rviz
@@ -13,7 +13,9 @@ Panels:
         - /nearir1/Topic1
         - /reflec1
         - /signal1
-      Splitter Ratio: 0.5
+        - /LaserScan1
+        - /LaserScan1/Topic1
+      Splitter Ratio: 0.626074492931366
     Tree Height: 1185
   - Class: rviz_common/Selection
     Name: Selection
@@ -92,23 +94,23 @@ Visualization Manager:
       Enabled: true
       Frame Timeout: 15
       Frames:
-        " os_imu":
-          Value: true
-        " os_lidar":
-          Value: true
-        " os_sensor":
-          Value: true
         All Enabled: true
+        os_imu:
+          Value: true
+        os_lidar:
+          Value: true
+        os_sensor:
+          Value: true
       Marker Scale: 1
       Name: TF
       Show Arrows: true
       Show Axes: true
       Show Names: false
       Tree:
-        " os_sensor":
-          " os_imu":
+        os_sensor:
+          os_imu:
             {}
-          " os_lidar":
+          os_lidar:
             {}
       Update Interval: 0
       Value: true
@@ -168,10 +170,44 @@ Visualization Manager:
         Reliability Policy: Best Effort
         Value: /ouster/signal_image
       Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 1000
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /ouster/scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: "os_sensor"
+    Fixed Frame: os_sensor
     Frame Rate: 30
   Name: root
   Tools:

--- a/ouster-ros/config/viz.rviz
+++ b/ouster-ros/config/viz.rviz
@@ -192,7 +192,7 @@ Visualization Manager:
       Position Transformer: XYZ
       Selectable: true
       Size (Pixels): 3
-      Size (m): 0.009999999776482582
+      Size (m): 0.02
       Style: Flat Squares
       Topic:
         Depth: 5

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -156,6 +156,7 @@ inline bool check_token(const std::set<std::string>& tokens,
     return tokens.find(token) != tokens.end();
 }
 
+ouster::util::version parse_version(const std::string& fw_rev);
 
 } // namespace impl
 

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -108,6 +108,8 @@ geometry_msgs::msg::TransformStamped transform_to_tf_msg(
  * @param[in] frame the parent frame of the generated laser scan message
  * @param[in] lidar_mode lidar mode (width x frequency)
  * @param[in] ring selected ring to be published
+ * @param[in] pixel_shift_by_row pixel shifts by row
+ * @param[in] return_index index of return desired starting at 0
  * @return ROS message suitable for publishing as a LaserScan
  */
 sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
@@ -115,7 +117,7 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     const rclcpp::Time& timestamp,
     const std::string &frame,
     const ouster::sensor::lidar_mode lidar_mode,
-    const uint16_t ring,
+    const uint16_t ring, const std::vector<int>& pixel_shift_by_row,
     const int return_index);
 
 namespace impl {

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.12.0</version>
+  <version>0.12.1</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/laser_scan_processor.h
+++ b/ouster-ros/src/laser_scan_processor.h
@@ -30,14 +30,15 @@ class LaserScanProcessor {
           ld_mode(info.mode),
           ring_(ring),
           pixel_shift_by_row(info.format.pixel_shift_by_row),
-          scan_msgs(get_n_returns(info),
-                    std::make_shared<sensor_msgs::msg::LaserScan>()),
-          post_processing_fn(func) {}
+          scan_msgs(get_n_returns(info)), post_processing_fn(func) {
+            for (size_t i = 0; i < scan_msgs.size(); ++i)
+                scan_msgs[i] = std::make_shared<sensor_msgs::msg::LaserScan>();
+          }
 
    private:
     void process(const ouster::LidarScan& lidar_scan, uint64_t,
                  const rclcpp::Time& msg_ts) {
-        for (int i = 0; i < static_cast<int>(scan_msgs.size()); ++i) {
+        for (size_t i = 0; i < scan_msgs.size(); ++i) {
             *scan_msgs[i] = lidar_scan_to_laser_scan_msg(
                 lidar_scan, msg_ts, frame, ld_mode, ring_, pixel_shift_by_row, i);
         }

--- a/ouster-ros/src/laser_scan_processor.h
+++ b/ouster-ros/src/laser_scan_processor.h
@@ -29,6 +29,7 @@ class LaserScanProcessor {
         : frame(frame_id),
           ld_mode(info.mode),
           ring_(ring),
+          pixel_shift_by_row(info.format.pixel_shift_by_row),
           scan_msgs(get_n_returns(info),
                     std::make_shared<sensor_msgs::msg::LaserScan>()),
           post_processing_fn(func) {}
@@ -38,7 +39,7 @@ class LaserScanProcessor {
                  const rclcpp::Time& msg_ts) {
         for (int i = 0; i < static_cast<int>(scan_msgs.size()); ++i) {
             *scan_msgs[i] = lidar_scan_to_laser_scan_msg(
-                lidar_scan, msg_ts, frame, ld_mode, ring_, i);
+                lidar_scan, msg_ts, frame, ld_mode, ring_, pixel_shift_by_row, i);
         }
 
         if (post_processing_fn) post_processing_fn(scan_msgs);
@@ -61,6 +62,7 @@ class LaserScanProcessor {
     std::string frame;
     sensor::lidar_mode ld_mode;
     uint16_t ring_;
+    std::vector<int> pixel_shift_by_row;
     OutputType scan_msgs;
     PostProcessingFn post_processing_fn;
 };

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -148,8 +148,7 @@ class OusterCloud : public OusterProcessingNodeBase {
             processors.push_back(LaserScanProcessor::create(
                 info, tf_bcast.lidar_frame_id(), scan_ring,
                 [this](LaserScanProcessor::OutputType msgs) {
-                    for (size_t i = 0; i < msgs.size(); ++i)
-                        scan_pubs[i]->publish(*msgs[i]);
+                    for (size_t i = 0; i < msgs.size(); ++i) scan_pubs[i]->publish(*msgs[i]);
                 }));
         }
 

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -126,8 +126,7 @@ class OusterDriver : public OusterSensor {
             processors.push_back(LaserScanProcessor::create(
                 info, tf_bcast.lidar_frame_id(), scan_ring,
                 [this](LaserScanProcessor::OutputType msgs) {
-                    for (size_t i = 0; i < msgs.size(); ++i)
-                        scan_pubs[i]->publish(*msgs[i]);
+                    for (size_t i = 0; i < msgs.size(); ++i) scan_pubs[i]->publish(*msgs[i]);
                 }));
         }
 

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -41,7 +41,7 @@ class OusterDriver : public OusterSensor {
     }
 
     ~OusterDriver() override {
-        RCLCPP_INFO(get_logger(), "OusterDriver::~OusterDriver() called");
+        RCLCPP_DEBUG(get_logger(), "OusterDriver::~OusterDriver() called");
         halt();
     }
 

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -151,7 +151,8 @@ geometry_msgs::msg::TransformStamped transform_to_tf_msg(
 sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     const ouster::LidarScan& ls, const rclcpp::Time& timestamp,
     const std::string& frame, const ouster::sensor::lidar_mode ld_mode,
-    const uint16_t ring, const int return_index) {
+    const uint16_t ring, const std::vector<int>& pixel_shift_by_row,
+    const int return_index) {
     sensor_msgs::msg::LaserScan msg;
     msg.header.stamp = timestamp;
     msg.header.frame_id = frame;
@@ -177,10 +178,13 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     const auto sg = signal.data();
     msg.ranges.resize(ls.w);
     msg.intensities.resize(ls.w);
-    int idx = ls.w * ring + ls.w;
-    for (int i = 0; idx-- > ls.w * ring; ++i) {
-        msg.ranges[i] = rg[idx] * ouster::sensor::range_unit;
-        msg.intensities[i] = static_cast<float>(sg[idx]);
+
+    const auto u = ring;
+    for (auto v = 0; v < ls.w; ++v) {
+        const auto v_shift = (ls.w - 1 - (v + ls.w / 2 + pixel_shift_by_row[u])) % ls.w;
+        const auto src_idx = u * ls.w + v_shift;
+        msg.ranges[v] = rg[src_idx] * ouster::sensor::range_unit;
+        msg.intensities[v] = static_cast<float>(sg[src_idx]);
     }
 
     return msg;

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -179,10 +179,11 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     msg.ranges.resize(ls.w);
     msg.intensities.resize(ls.w);
 
-    const auto u = ring;
     for (auto v = 0; v < ls.w; ++v) {
-        const auto v_shift = (ls.w - 1 - (v + ls.w / 2 + pixel_shift_by_row[u])) % ls.w;
-        const auto src_idx = u * ls.w + v_shift;
+        auto idx = ls.w / 2 - 1 - v;
+        auto sign = v < ls.w / 2 ? +1 : -1;
+        auto v_shift = (idx - sign * pixel_shift_by_row[ring]) % ls.w;
+        auto src_idx = ring * ls.w + v_shift;
         msg.ranges[v] = rg[src_idx] * ouster::sensor::range_unit;
         msg.intensities[v] = static_cast<float>(sg[src_idx]);
     }

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -180,7 +180,8 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     msg.intensities.resize(ls.w);
 
     for (auto v = 0; v < ls.w; ++v) {
-        auto v_shift = (ls.w / 2 - 1 - v - pixel_shift_by_row[ring]) % ls.w;
+        auto sign = v < ls.w / 2 ? -1 : +1;
+        auto v_shift = (ls.w / 2 - 1 - v + sign * pixel_shift_by_row[ring]) % ls.w;
         auto src_idx = ring * ls.w + v_shift;
         msg.ranges[v] = rg[src_idx] * ouster::sensor::range_unit;
         msg.intensities[v] = static_cast<float>(sg[src_idx]);

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -199,12 +199,13 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     msg.ranges.resize(ls.w);
     msg.intensities.resize(ls.w);
 
-    for (auto v = 0; v < ls.w; ++v) {
-        auto sign = v < ls.w / 2 ? -1 : +1;
-        auto v_shift = (ls.w / 2 - 1 - v + sign * pixel_shift_by_row[ring]) % ls.w;
-        auto src_idx = ring * ls.w + v_shift;
-        msg.ranges[v] = rg[src_idx] * ouster::sensor::range_unit;
-        msg.intensities[v] = static_cast<float>(sg[src_idx]);
+    uint16_t u = ring;
+    for (auto v =  0; v < ls.w; ++v) {
+        auto v_shift = (v + ls.w - pixel_shift_by_row[u] + ls.w / 2) % ls.w;
+        auto src_idx = u * ls.w + v_shift;
+        auto tgt_idx = ls.w - 1 - v;
+        msg.ranges[tgt_idx] = rg[src_idx] * ouster::sensor::range_unit;
+        msg.intensities[tgt_idx] = static_cast<float>(sg[src_idx]);
     }
 
     return msg;

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -19,11 +19,15 @@
 #include <chrono>
 #include <string>
 #include <vector>
+#include <regex>
 
-namespace sensor = ouster::sensor;
-using ouster_sensor_msgs::msg::PacketMsg;
 
 namespace ouster_ros {
+
+namespace sensor = ouster::sensor;
+using namespace ouster::util;
+using ouster_sensor_msgs::msg::PacketMsg;
+
 
 bool is_legacy_lidar_profile(const sensor::sensor_info& info) {
     using sensor::UDPProfileLidar;
@@ -128,6 +132,22 @@ std::set<std::string> parse_tokens(const std::string& input, char delim) {
     }
 
     return tokens;
+}
+
+version parse_version(const std::string& fw_rev) {
+    auto rgx = std::regex(R"(v(\d+).(\d+)\.(\d+))");
+    std::smatch matches;
+    std::regex_search(fw_rev, matches, rgx);
+
+    if (matches.size() < 4) return invalid_version;
+
+    try {
+        return version{static_cast<uint16_t>(stoul(matches[1])),
+                    static_cast<uint16_t>(stoul(matches[2])),
+                    static_cast<uint16_t>(stoul(matches[3]))};
+    } catch (const std::exception&) {
+        return invalid_version;
+    }
 }
 
 }  // namespace impl

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -180,9 +180,7 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     msg.intensities.resize(ls.w);
 
     for (auto v = 0; v < ls.w; ++v) {
-        auto idx = ls.w / 2 - 1 - v;
-        auto sign = v < ls.w / 2 ? +1 : -1;
-        auto v_shift = (idx - sign * pixel_shift_by_row[ring]) % ls.w;
+        auto v_shift = (ls.w / 2 - 1 - v - pixel_shift_by_row[ring]) % ls.w;
         auto src_idx = ring * ls.w + v_shift;
         msg.ranges[v] = rg[src_idx] * ouster::sensor::range_unit;
         msg.intensities[v] = static_cast<float>(sg[src_idx]);

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -37,7 +37,7 @@ OusterSensor::OusterSensor(const rclcpp::NodeOptions& options)
     : OusterSensor("os_sensor", options) {}
 
 OusterSensor::~OusterSensor() {
-    RCLCPP_INFO(get_logger(), "OusterDriver::~OusterSensor() called");
+    RCLCPP_DEBUG(get_logger(), "OusterSensor::~OusterSensor() called");
     halt();
 }
 


### PR DESCRIPTION
## Related Issues & PRs
- ROS1: #224 
- ROS2 foxy: #204 
- resolves #196
- resolves #237 
- resolves #241

## Summary of Changes
- Apply destagger to LaserScan message
- Add LaserScan object to RVIZ
- Fix an issue where LaserScan does not work properly with using dual mode
- Address an issue where LaserScan appeared different on FW prior to 2.4

## Validation
- Make sure that the PointCloud and LaserScan fully aligned