### PR TITLE
HOTFIX: call on_activate on imu/lidar packet topics

### DIFF
--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -88,6 +88,8 @@ LifecycleNodeInterface::CallbackReturn OusterSensor::on_activate(
     if (active_config.empty() || cached_metadata.empty())
         update_config_and_metadata(*sensor_client);
     create_publishers();
+    if (imu_packet_pub) imu_packet_pub->on_activate();
+    if (lidar_packet_pub) lidar_packet_pub->on_activate();
     allocate_buffers();
     start_packet_processing_threads();
     start_sensor_connection_thread();


### PR DESCRIPTION
## Related Issues & PRs
- resolves: #212

## Summary of Changes
- Restore previous call of on_activate on imu/lidar packet topics

## Validation
sensor.launch.xml
