### PR TITLE
Configurable qos and default history depth

### DIFF
--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -157,7 +157,7 @@ class OusterCloud : public OusterProcessingNodeBase {
             rclcpp::SubscriptionOptions subscription_options;
             subscription_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
             lidar_packet_sub = create_subscription<PacketMsg>(
-                "lidar_packets", selected_qos,
+                "lidar_packets", selected_qos.keep_last(100),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     lidar_packet_handler(msg->buf.data());
                 },

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -154,11 +154,14 @@ class OusterCloud : public OusterProcessingNodeBase {
         if (check_token(tokens, "PCL") || check_token(tokens, "SCAN")) {
             lidar_packet_handler = LidarPacketHandler::create_handler(
                 info, use_ros_time, processors);
+            rclcpp::SubscriptionOptions subscription_options;
+            subscription_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
             lidar_packet_sub = create_subscription<PacketMsg>(
                 "lidar_packets", selected_qos,
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     lidar_packet_handler(msg->buf.data());
-                });
+                },
+                subscription_options);
         }
     }
 

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -645,7 +645,7 @@ void OusterSensor::create_publishers() {
     rclcpp::PublisherOptions publisher_options;
     publisher_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
     lidar_packet_pub =
-        create_publisher<PacketMsg>("lidar_packets", selected_qos, publisher_options);
+        create_publisher<PacketMsg>("lidar_packets", selected_qos.keep_last(100), publisher_options);
     imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos, publisher_options);
 }
 

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -642,9 +642,11 @@ void OusterSensor::create_publishers() {
     rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
     auto selected_qos =
         use_system_default_qos ? system_default_qos : sensor_data_qos;
+    rclcpp::PublisherOptions publisher_options;
+    publisher_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
     lidar_packet_pub =
-        create_publisher<PacketMsg>("lidar_packets", selected_qos);
-    imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos);
+        create_publisher<PacketMsg>("lidar_packets", selected_qos, publisher_options);
+    imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos, publisher_options);
 }
 
 void OusterSensor::allocate_buffers() {


### PR DESCRIPTION
## Related Issues & PRs
#190
https://github.com/ouster-lidar/ouster_example/issues/120

## Summary of Changes
Set history depth on lidar packets topic to be something more reasonable.

Allow for configuring qos of the packet topics using parameters. http://design.ros2.org/articles/qos_configurability.html
Note that this requires at least ROS Galactic. It is not compatible with Foxy or earlier. If that backward compatibility is desirable I would like to instead expose a parameter that at least can set the history depth.

This is desirable because neither the system default qos nor the sensor data qos profiles have very large history depths, and the lidar packet topic can be publishing at hundreds of hertz, and I believe it might be dropped packets that are causing missing data in the pointcloud. For example:
```yaml
os_sensor:
  ros__parameters:
    qos_overrides:
      /lidar_packets:
        publisher:
          depth: 1000
os_cloud:
  ros__parameters:
    qos_overrides:
      /lidar_packets:
        subscription:
          depth: 1000
```

Note that this also applies to intraprocess communication since the intraprocess buffer is set to the size of the history depth qos.

## Validation
Lost packets show up if the os_cloud process is under high load, resulting in a "propeller effect". I can confirm that increasing the history depth eliminates this issue.
