### PR TITLE
Reconnection behavior

### DIFF
--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -67,3 +67,4 @@ ouster/os_driver:
     # data QoS. This is preferrable for production but default QoS is needed for
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
     use_system_default_qos: false
+    retry_configuration: false

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -28,6 +28,8 @@
 
 #include "thread_safe_ring_buffer.h"
 
+#define THROTTLING_TIME 10000
+
 namespace sensor = ouster::sensor;
 using lifecycle_msgs::srv::ChangeState;
 using rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface;
@@ -105,8 +107,8 @@ class OusterSensor : public OusterSensorNodeBase {
 
     uint8_t compose_config_flags(const sensor::sensor_config& config);
 
-    void configure_sensor(const std::string& hostname,
-                          sensor::sensor_config& config);
+    bool configure_sensor(const std::string& hostname,
+                          sensor::sensor_config& config, bool retry);
 
     std::string load_config_file(const std::string& config_file);
 
@@ -184,6 +186,11 @@ class OusterSensor : public OusterSensorNodeBase {
     // TODO: add as a ros parameter
     const int max_read_imu_packet_errors = 60;
     int read_imu_packet_errors = 0;
+
+    bool had_reconnection_success = false;
+    bool retry_configuration = false;
+    rclcpp::Time first_lidar_data_rx = rclcpp::Time(0, 0);
+    sensor::sensor_config config;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -98,17 +98,15 @@ class OusterSensor : public OusterSensorNodeBase {
 
     void create_set_config_service();
 
-    std::shared_ptr<sensor::client> create_sensor_client(
-        const std::string& hostname, const sensor::sensor_config& config);
+    std::shared_ptr<sensor::client> create_sensor_client(const std::string& hostname);
 
     sensor::sensor_config parse_config_from_ros_parameters();
 
     sensor::sensor_config parse_config_from_staged_config_string();
 
-    uint8_t compose_config_flags(const sensor::sensor_config& config);
+    uint8_t compose_config_flags();
 
-    bool configure_sensor(const std::string& hostname,
-                          sensor::sensor_config& config, bool retry);
+    bool configure_sensor(const std::string& hostname, bool retry);
 
     std::string load_config_file(const std::string& config_file);
 


### PR DESCRIPTION
## Related Issues & PRs

This same reconnection behavior for ROS1: https://github.com/ouster-lidar/ouster-ros/pull/119
The issue it started from: https://github.com/ouster-lidar/ouster-ros/issues/55

## Summary of Changes

Idea adapted to ROS2 from this PR: https://github.com/ouster-lidar/ouster-ros/pull/119 

Added reconnection behavior

- New `retry_configuration` parameter that sets if we want to use the new reconnection behavior or not. Initially I've defaulted it to `false` as not to change current behavior automatically, ideas?
- Makes config an attribute so we can reuse it in the connection loop
- Adds logic to the `configure_sensor()` and to `connection_loop()` methods so that we can retry to configure the sensor
- [QUESTIONABLE CHANGE MARK] Added throttling to the logs that come when trying to reconnect, to avoid the consequent spamming

## Validation

- Starting the system with sensor and/or ethernet cable disconnected
  - If `retry_configuration`
    - Driver will keep trying to configure the sensor until it's connected
    - Logs are throttled 
  - Else
    - Same behavior as before: driver will fail to configure the sensor and stop trying
- Same if the sensor is disconnected during runtime after it's already been configured   