### PR TITLE
SW-5657: Back port SW-5466 to ROS-1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,10 @@ Changelog
 
 [unreleased]
 ============
+* [BREAKING] ROS1 driver code now requires C++17 (required for point cloud customization feature).
 * added the ability to customize the published point clouds(s) to velodyne point cloud format and
   other common pcl point types.
-* ouster_image_nodelet can operate separately from ouster_cloud_nodelet.
+* ouster_image_nodelet can operate independently from ouster_cloud_nodelet.
 
 
 ouster_ros v0.10.0
@@ -21,7 +22,7 @@ ouster_ros(1)
   to be applied to all ROS messages the driver generates when ``TIME_FROM_PTP_1588`` timestamp mode
   is used.
   * [BREAKING]: the default value of ``ptp_utc_tai_offset`` is set to ``-37.0``. To retain the same
-    offset for an existing system users need to set ``ptp_utc_tai_offset`` to ``0.0``.
+    time offset for an existing system, users need to set ``ptp_utc_tai_offset`` to ``0.0``.
 * [BUGFIX]: destagger columns timestamp when generating destaggered point clouds.
 * [BUGFIX]: gracefully stop the driver when shutdown is requested.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,7 +58,6 @@ ouster_client
 * [bugfix] Fixed dropped columns issue with 4096x5 and 2048x10
 
 
-
 ouster_ros v0.9.0
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+[unreleased]
+============
+* added the ability to customize the published point clouds(s) to velodyne point cloud format and
+  other common pcl point types.
+* ouster_image_nodelet can operate separately from ouster_cloud_nodelet.
+
+
 ouster_ros v0.10.0
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,9 @@ ouster_ros(1)
 * [BREAKING]: publish PCL point clouds destaggered.
 * introduced a new launch file parameter ``ptp_utc_tai_offset`` which represent offset in seconds
   to be applied to all ROS messages the driver generates when ``TIME_FROM_PTP_1588`` timestamp mode
-  is used. 
+  is used.
+  * [BREAKING]: the default value of ``ptp_utc_tai_offset`` is set to ``-37.0``. To retain the same
+    offset for an existing system users need to set ``ptp_utc_tai_offset`` to ``0.0``.
 * [BUGFIX]: destagger columns timestamp when generating destaggered point clouds.
 * [BUGFIX]: gracefully stop the driver when shutdown is requested.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(
              nodelet)
 
 # ==== Options ====
+add_compile_options(-std=c++17)
 add_compile_options(-Wall -Wextra)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
 
@@ -96,7 +97,8 @@ if(CATKIN_ENABLE_TESTING)
     tests/point_transform_test.cpp
     tests/point_cloud_compose_test.cpp
   )
-  target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES}
+    ouster_build pcl_common -Wl,--whole-archive ouster_client -Wl,--no-whole-archive)
 endif()
 
 # ==== Install ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,13 @@ add_dependencies(${PROJECT_NAME}_nodelets ${PROJECT_NAME}_gencpp)
 
 # ==== Test ====
 if(CATKIN_ENABLE_TESTING)
-  catkin_add_gtest(${PROJECT_NAME}_test tests/ring_buffer_test.cpp)
+  catkin_add_gtest(${PROJECT_NAME}_test
+    tests/ring_buffer_test.cpp
+    src/os_ros.cpp
+    tests/point_accessor_test.cpp
+    tests/point_transform_test.cpp
+    tests/point_cloud_compose_test.cpp
+  )
   target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES})
 endif()
 

--- a/README.md
+++ b/README.md
@@ -12,21 +12,22 @@
 | ROS2 (rolling/humble/iron) | [![rolling/humble/iron](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 | ROS2 (galactic/foxy) | [![galactic/foxy](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2-foxy)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 
-- [Overview](#overview)
-- [Requirements](#requirements)
-- [Getting Started](#getting-started)
-- [Usage](#usage)
-  - [Launching Nodes](#launching-nodes)
-    - [Sensor Mode](#sensor-mode)
-    - [Recording Mode](#recording-mode)
-    - [Replay Mode](#replay-mode)
-    - [Multicast Mode (experimental)](#multicast-mode-experimental)
-  - [Launch Files Arguments](#launch-files-arguments)
-  - [Invoking Services](#invoking-services)
-    - [GetMetadata](#getmetadata)
-    - [GetConfig](#getconfig)
-    - [SetConfig (experimental)](#setconfig-experimental)
-- [License](#license)
+- [Official ROS1/ROS2 drivers for Ouster sensors](#official-ros1ros2-drivers-for-ouster-sensors)
+  - [Overview](#overview)
+  - [Requirements](#requirements)
+  - [Getting Started](#getting-started)
+  - [Usage](#usage)
+    - [Launching Nodes](#launching-nodes)
+      - [Sensor Mode](#sensor-mode)
+      - [Recording Mode](#recording-mode)
+      - [Replay Mode](#replay-mode)
+      - [Multicast Mode (experimental)](#multicast-mode-experimental)
+    - [Launch Files Arguments](#launch-files-arguments)
+    - [Invoking Services](#invoking-services)
+      - [GetMetadata](#getmetadata)
+      - [GetConfig](#getconfig)
+      - [SetConfig (experimental)](#setconfig-experimental)
+  - [License](#license)
 
 
 ## Overview
@@ -174,6 +175,22 @@ roslaunch ouster_ros driver.launch --ros-args
 ```
 The command should list all available arguments, whether they are optional or required and the
 description and posible values of each argument.
+
+New launch file parameter:
+**point_type**: This parameter allows to customize the point cloud that the
+  driver produces through its `/ouster/points` topics. Choose one of the following
+  values:
+  - `original`: This uses the original point representation `ouster_ros::Point`
+           of the ouster-ros driver.
+  - `native`: directly maps all fields as published by the sensor to an
+           equivalent point cloud representation with the additon of ring
+           and timestamp fields.
+  - `xyz`: the simplest point type, only has {x, y, z}
+  - `xyzi`: same as xyz point type but adds intensity (signal) field. this
+           type is not compatible with the low data profile.
+  - `xyzir`: same as xyzi type but adds ring (channel) field.
+          this type is same as Velodyne point cloud type
+          this type is not compatible with the low data profile.
 
 ### Invoking Services
 To execute any of the following service, first you need to open a new terminal

--- a/include/ouster_ros/common_point_types.h
+++ b/include/ouster_ros/common_point_types.h
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file common_point_types.h
+ * @brief common PCL point datatype for use with ouster sensors
+ */
+
+#pragma once
+
+#include <pcl/point_types.h>
+
+namespace ouster_ros {
+
+/* The following are pcl point representations that are common/standard point
+   representation that we readily support.
+ */
+
+/*
+ * Same as Velodyne point cloud type
+ * @remark XYZIR point type is not compatible with RNG15_RFL8_NIR8/LOW_DATA
+ * udp lidar profile.
+ */
+struct EIGEN_ALIGN16 _PointXYZIR {
+    PCL_ADD_POINT4D;
+    float intensity;
+    uint16_t ring;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct PointXYZIR : public _PointXYZIR {
+
+    inline PointXYZIR(const _PointXYZIR& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      intensity = pt.intensity; ring = pt.ring;
+    }
+
+    inline PointXYZIR()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      intensity = 0.0f; ring = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, intensity, ring);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity, ring);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
+
+// clang-format off
+
+/* common point types */
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIR,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, intensity, intensity)
+    (std::uint16_t, ring, ring)
+)
+
+// clang-format on

--- a/include/ouster_ros/os_point.h
+++ b/include/ouster_ros/os_point.h
@@ -10,36 +10,79 @@
 
 #include <pcl/point_types.h>
 
-#include <Eigen/Core>
-#include <chrono>
-
-#include <ouster/lidar_scan.h>
-
 namespace ouster_ros {
 
-struct EIGEN_ALIGN16 Point {
+// The default/original represntation of the point cloud since the driver
+// inception. This shouldn't be confused with Point_LEGACY which provides exact
+// mapping of the fields of Ouster LidarScan of the Legacy Profile, copying the 
+// the same order and using the same bit representation. For example, this Point
+// struct uses float data type to represent intensity (aka signal); however, the
+// sensor sends the signal channel either as UINT16 or UINT32 depending on the
+// active udp lidar profile.
+struct EIGEN_ALIGN16 _Point {
     PCL_ADD_POINT4D;
-    float intensity;
+    float intensity;        // equivalent to signal
     uint32_t t;
     uint16_t reflectivity;
-    uint16_t ring;
-    uint16_t ambient;
+    uint16_t ring;          // equivalent to channel
+    uint16_t ambient;       // equivalent to near_ir
     uint32_t range;
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
-}  // namespace ouster_ros
+
+struct Point : public _Point {
+
+    inline Point(const _Point& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      intensity = pt.intensity;
+      t = pt.t;
+      reflectivity = pt.reflectivity; 
+      ring = pt.ring;
+      ambient = pt.ambient;
+      range = pt.range;
+    }
+
+    inline Point()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      intensity = 0.0f;
+      t = 0;
+      reflectivity = 0;
+      ring = 0;
+      ambient = 0;
+      range = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, intensity, t, reflectivity, ring, ambient, range);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity, t, reflectivity, ring, ambient, range);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
 
 // clang-format off
+
+// DEFAULT/ORIGINAL
 POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point,
     (float, x, x)
     (float, y, y)
     (float, z, z)
     (float, intensity, intensity)
-    // use std::uint32_t to avoid conflicting with pcl::uint32_t
     (std::uint32_t, t, t)
     (std::uint16_t, reflectivity, reflectivity)
     (std::uint16_t, ring, ring)
     (std::uint16_t, ambient, ambient)
     (std::uint32_t, range, range)
 )
+
 // clang-format on

--- a/include/ouster_ros/sensor_point_types.h
+++ b/include/ouster_ros/sensor_point_types.h
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file sensor_point_types.h
+ * @brief native sensor point types
+ * The following are one-to-one mapping of pcl point representatios that could
+ * fit the data sent by the sensor (with the addition of t and ring fields),
+ * All of these representation follow the same order of LaserScan fields:
+ * 1. range
+ * 2. signal
+ * 3. refelctivity
+ * 4. near_ir
+ * With the exception Point_RNG15_RFL8_NIR8 aka LOW_DATA which does not include
+ * the signal field
+**/
+
+#pragma once
+
+#include <pcl/point_types.h>
+#include <ouster/lidar_scan.h>
+
+namespace ouster_ros {
+
+template <typename K, typename V, size_t N>
+using Table = std::array<std::pair<K, V>, N>;
+
+namespace sensor = ouster::sensor;
+
+template <size_t N>
+using ChanFieldTable = Table<sensor::ChanField, sensor::ChanFieldType, N>;
+
+}
+
+
+namespace ouster_ros {
+
+// Profile_LEGACY
+static constexpr ChanFieldTable<4> Profile_LEGACY{{
+    {sensor::ChanField::RANGE, sensor::ChanFieldType::UINT32},
+    {sensor::ChanField::SIGNAL, sensor::ChanFieldType::UINT32},
+    {sensor::ChanField::NEAR_IR, sensor::ChanFieldType::UINT32},
+    {sensor::ChanField::REFLECTIVITY, sensor::ChanFieldType::UINT32}}
+};
+
+// auto=LEGACY
+struct EIGEN_ALIGN16 _Point_LEGACY {
+    PCL_ADD_POINT4D;
+    uint32_t t;             // timestamp relative to frame
+    uint16_t ring;          // equivalent to channel
+    uint32_t range;
+    uint32_t signal;        // equivalent to intensity
+    uint32_t reflectivity;
+    uint32_t near_ir;       // equivalent to ambient
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct Point_LEGACY : public _Point_LEGACY {
+
+    inline Point_LEGACY(const _Point_LEGACY& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      t = pt.t; ring = pt.ring;
+      range = pt.range; signal = pt.signal;
+      reflectivity = pt.reflectivity; near_ir = pt.near_ir;
+    }
+
+    inline Point_LEGACY()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      t = 0; ring = 0;
+      range = 0; signal = 0;
+      reflectivity = 0; near_ir = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity, near_ir);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity, near_ir);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
+
+// clang-format off
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point_LEGACY,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (std::uint32_t, t, t)
+    (std::uint16_t, ring, ring)
+    (std::uint32_t, range, range)
+    (std::uint32_t, signal, signal)
+    (std::uint32_t, reflectivity, reflectivity)
+    (std::uint32_t, near_ir, near_ir)
+)
+
+namespace ouster_ros {
+
+// Profile_RNG19_RFL8_SIG16_NIR16_DUAL: aka dual returns
+// This profile is definied differently from RNG19_RFL8_SIG16_NIR16_DUAL of how
+// the sensor actually sends the data. The actual RNG19_RFL8_SIG16_NIR16_DUAL
+// has 7 fields not 4, but this profile is defined differently in ROS because
+// we build and publish a point cloud for each return separately. However, it
+// might be desireable to some of the users to choose a point cloud
+// representation which combines parts of the the two or more returns. This isn't
+// something that the current framework could deal with as of now.
+static constexpr ChanFieldTable<4> Profile_RNG19_RFL8_SIG16_NIR16_DUAL {{
+    {sensor::ChanField::RANGE, sensor::ChanFieldType::UINT32},
+    {sensor::ChanField::SIGNAL, sensor::ChanFieldType::UINT16},
+    {sensor::ChanField::REFLECTIVITY, sensor::ChanFieldType::UINT8},
+    {sensor::ChanField::NEAR_IR, sensor::ChanFieldType::UINT16},
+}};
+
+// Note: this is one way to implement the processing of 2nd return
+// This should be an exact copy of Profile_RNG19_RFL8_SIG16_NIR16_DUAL with the
+// exception of ChanField values for the first three fields. NEAR_IR is same for both
+static constexpr ChanFieldTable<4> Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN {{
+    {sensor::ChanField::RANGE2, sensor::ChanFieldType::UINT32},
+    {sensor::ChanField::SIGNAL2, sensor::ChanFieldType::UINT16},
+    {sensor::ChanField::REFLECTIVITY2, sensor::ChanFieldType::UINT8},
+    {sensor::ChanField::NEAR_IR, sensor::ChanFieldType::UINT16},
+}};
+
+// auto=RNG19_RFL8_SIG16_NIR16_DUAL
+struct EIGEN_ALIGN16 _Point_RNG19_RFL8_SIG16_NIR16_DUAL {
+    PCL_ADD_POINT4D;
+    uint32_t t;             // timestamp relative to frame start time
+    uint16_t ring;          // equivalent channel
+    uint32_t range;
+    uint16_t signal;        // equivalent to intensity
+    uint8_t reflectivity;
+    uint16_t near_ir;       // equivalent to ambient
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct Point_RNG19_RFL8_SIG16_NIR16_DUAL : public _Point_RNG19_RFL8_SIG16_NIR16_DUAL {
+
+    inline Point_RNG19_RFL8_SIG16_NIR16_DUAL(const _Point_RNG19_RFL8_SIG16_NIR16_DUAL& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      t = pt.t; ring = pt.ring;
+      range = pt.range; signal = pt.signal;
+      reflectivity = pt.reflectivity; near_ir = pt.near_ir;
+    }
+
+    inline Point_RNG19_RFL8_SIG16_NIR16_DUAL()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      t = 0; ring = 0;
+      range = 0; signal = 0;
+      reflectivity = 0; near_ir = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity, near_ir);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity, near_ir);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespce ouster_ros
+
+// clang-format off
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point_RNG19_RFL8_SIG16_NIR16_DUAL,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (std::uint32_t, t, t)
+    (std::uint16_t, ring, ring)
+    (std::uint32_t, range, range)
+    (std::uint16_t, signal, signal)
+    (std::uint8_t, reflectivity, reflectivity)
+    (std::uint16_t, near_ir, near_ir)
+)
+
+// clang-format on
+
+namespace ouster_ros {
+
+// Profile_RNG19_RFL8_SIG16_NIR16 aka single return
+static constexpr ChanFieldTable<4> Profile_RNG19_RFL8_SIG16_NIR16{{
+    {sensor::ChanField::RANGE, sensor::ChanFieldType::UINT32},
+    {sensor::ChanField::SIGNAL, sensor::ChanFieldType::UINT16},
+    {sensor::ChanField::REFLECTIVITY, sensor::ChanFieldType::UINT16},
+    {sensor::ChanField::NEAR_IR, sensor::ChanFieldType::UINT16},
+}};
+
+// auto=RNG19_RFL8_SIG16_NIR16
+struct EIGEN_ALIGN16 _Point_RNG19_RFL8_SIG16_NIR16 {
+    PCL_ADD_POINT4D;
+    uint32_t t;             // timestamp relative to frame start time
+    uint16_t ring;          // equivalent channel
+    uint32_t range;
+    uint16_t signal;        // equivalent to intensity
+    uint16_t reflectivity;
+    uint16_t near_ir;       // equivalent to ambient
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct Point_RNG19_RFL8_SIG16_NIR16 : public _Point_RNG19_RFL8_SIG16_NIR16 {
+
+    inline Point_RNG19_RFL8_SIG16_NIR16(const _Point_RNG19_RFL8_SIG16_NIR16& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      t = pt.t; ring = pt.ring;
+      range = pt.range; signal = pt.signal;
+      reflectivity = pt.reflectivity; near_ir = pt.near_ir;
+    }
+
+    inline Point_RNG19_RFL8_SIG16_NIR16()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      t = 0; ring = 0;
+      range = 0; signal = 0;
+      reflectivity = 0; near_ir = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity, near_ir);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity, near_ir);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
+
+// clang-format off
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point_RNG19_RFL8_SIG16_NIR16,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (std::uint32_t, t, t)
+    (std::uint16_t, ring, ring)
+    (std::uint32_t, range, range)
+    (std::uint16_t, signal, signal)
+    (std::uint16_t, reflectivity, reflectivity)
+    (std::uint16_t, near_ir, near_ir)
+)
+
+// clang-format on
+
+namespace ouster_ros {
+
+// Profile_RNG15_RFL8_NIR8 aka LOW_DATA
+static constexpr ChanFieldTable<3> Profile_RNG15_RFL8_NIR8{{
+    {sensor::ChanField::RANGE, sensor::ChanFieldType::UINT32},
+    {sensor::ChanField::REFLECTIVITY, sensor::ChanFieldType::UINT16},
+    {sensor::ChanField::NEAR_IR, sensor::ChanFieldType::UINT16},
+}};
+
+// auto=RNG15_RFL8_NIR8 aka LOW_DATA profile
+struct EIGEN_ALIGN16 _Point_RNG15_RFL8_NIR8 {
+    PCL_ADD_POINT4D;
+    // No signal/intensity in low data mode
+    uint32_t t;             // timestamp relative to frame
+    uint16_t ring;          // equivalent to channel
+    uint32_t range;
+    uint16_t reflectivity;
+    uint16_t near_ir;       // equivalent to ambient
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+
+struct Point_RNG15_RFL8_NIR8 : public _Point_RNG15_RFL8_NIR8 {
+
+    inline Point_RNG15_RFL8_NIR8(const _Point_RNG15_RFL8_NIR8& pt) {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      t = pt.t; ring = pt.ring;
+      range = pt.range;
+      reflectivity = pt.reflectivity; near_ir = pt.near_ir;
+    }
+
+    inline Point_RNG15_RFL8_NIR8()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      t = 0; ring = 0;
+      range = 0;
+      reflectivity = 0; near_ir = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, t, ring, range, reflectivity, near_ir);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, t, ring, range, reflectivity, near_ir);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
+
+// clang-format off
+
+// Default=RNG15_RFL8_NIR8 aka LOW_DATA profile
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point_RNG15_RFL8_NIR8,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (std::uint32_t, t, t)
+    (std::uint16_t, ring, ring)
+    (std::uint32_t, range, range)
+    (std::uint16_t, reflectivity, reflectivity)
+    (std::uint16_t, near_ir, near_ir)
+)
+
+// clang-format on

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -32,6 +32,16 @@
     use this parameter in conjunction with the SCAN flag
     and choose a value the range [0, sensor_beams_count)"/>
 
+  <arg name="point_type" doc="point type for the generated point cloud;
+   available options: {
+    original,
+    native,
+    xyz,
+    xyzi,
+    xyzir
+    }"/>
+
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
       output="screen" required="true"
@@ -49,6 +59,7 @@
       <param name="~/proc_mask" value="$(arg proc_mask)"/>
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
       <param name="~/ptp_utc_tai_offset" type="double" value="$(arg ptp_utc_tai_offset)"/>
+      <param name="~/point_type" value="$(arg point_type)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -55,6 +55,15 @@
     use this parameter in conjunction with the SCAN flag
     and choose a value the range [0, sensor_beams_count)"/>
 
+  <arg name="point_type" default="original" doc="point type for the generated point cloud;
+   available options: {
+    original,
+    native,
+    xyz,
+    xyzi,
+    xyzir
+    }"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -81,6 +90,7 @@
       <param name="~/point_cloud_frame" value="$(arg point_cloud_frame)"/>
       <param name="~/proc_mask" value="$(arg proc_mask)"/>
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
+      <param name="~/point_type" value="$(arg point_type)"/>
     </node>
   </group>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -58,6 +58,15 @@
     use this parameter in conjunction with the SCAN flag
     and choose a value the range [0, sensor_beams_count)"/>
 
+  <arg name="point_type" default="original" doc="point type for the generated point cloud;
+   available options: {
+    original,
+    native,
+    xyz,
+    xyzi,
+    xyzir
+    }"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -96,6 +105,7 @@
       value="$(arg dynamic_transforms_broadcast_rate)"/>
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
+    <arg name="point_type" value="$(arg point_type)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -38,6 +38,15 @@
     use this parameter in conjunction with the SCAN flag
     and choose a value the range [0, sensor_beams_count)"/>
 
+  <arg name="point_type" default="original" doc="point type for the generated point cloud;
+   available options: {
+    original,
+    native,
+    xyz,
+    xyzi,
+    xyzir
+    }"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -71,6 +80,7 @@
       value="$(arg dynamic_transforms_broadcast_rate)"/>
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
+    <arg name="point_type" value="$(arg point_type)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -63,6 +63,15 @@
     use this parameter in conjunction with the SCAN flag
     and choose a value the range [0, sensor_beams_count)"/>
 
+  <arg name="point_type" default="original" doc="point type for the generated point cloud;
+   available options: {
+    original,
+    native,
+    xyz,
+    xyzi,
+    xyzir
+    }"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -101,6 +110,7 @@
       value="$(arg dynamic_transforms_broadcast_rate)"/>
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
+    <arg name="point_type" value="$(arg point_type)"/>
   </include>
 
 </launch>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -67,6 +67,15 @@
     use this parameter in conjunction with the SCAN flag
     and choose a value the range [0, sensor_beams_count)"/>
 
+  <arg name="point_type" default="original" doc="point type for the generated point cloud;
+   available options: {
+    original,
+    native,
+    xyz,
+    xyzi,
+    xyzir
+    }"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true"
@@ -108,6 +117,7 @@
       value="$(arg dynamic_transforms_broadcast_rate)"/>
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
+    <arg name="point_type" value="$(arg point_type)"/>
   </include>
 
 </launch>

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -1,0 +1,231 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/ouster-sdk/cmake)
+include(DefaultBuildType)
+
+# ==== Project Name ====
+project(ouster_ros)
+
+# ==== Requirements ====
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(ouster_sensor_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
+find_package(pcl_conversions REQUIRED)
+find_package(tf2_eigen REQUIRED)
+
+# ==== Options ====
+add_compile_options(-Wall -Wextra)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
+
+set(_ouster_ros_INCLUDE_DIRS
+  include
+  ouster-sdk/ouster_client/include
+  ouster-sdk/ouster_client/include/optional-lite
+)
+
+# ==== Libraries ====
+# Build static libraries and bundle them into ouster_ros using the `--whole-archive` flag. This is
+# necessary because catkin doesn't interoperate easily with target-based cmake builds. Object
+# libraries are the recommended way to do this, but require >=3.13 to propagate usage requirements.
+set(_SAVE_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
+
+option(BUILD_VIZ "Turn off building VIZ" OFF)
+option(BUILD_PCAP "Turn off building PCAP" OFF)
+find_package(OusterSDK REQUIRED)
+
+set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
+
+# catkin adds all include dirs to a single variable, don't try to use targets
+include_directories(${_ouster_ros_INCLUDE_DIRS})
+
+# use only MPL-licensed parts of eigen
+add_definitions(-DEIGEN_MPL2_ONLY)
+
+add_library(ouster_ros_library SHARED
+  src/os_ros.cpp
+)
+
+set(ouster_ros_library_deps
+  rclcpp
+  sensor_msgs
+  geometry_msgs
+  ouster_sensor_msgs
+  pcl_conversions
+  tf2
+  tf2_eigen
+)
+
+ament_target_dependencies(ouster_ros_library
+  ${ouster_ros_library_deps}
+)
+
+target_link_libraries(ouster_ros_library
+  # PUBLIC (unsupported)
+    ouster_build
+    pcl_common
+  # PRIVATE (unsupported)
+  -Wl,--whole-archive ouster_client -Wl,--no-whole-archive
+)
+
+# helper method to construct ouster-ros components
+function(create_ros2_component
+  component_lib_name
+  src_list
+  additonal_dependencies
+)
+
+  add_library(${component_lib_name} SHARED
+    ${src_list})
+  target_compile_definitions(${component_lib_name}
+    PRIVATE
+      "OUSTER_ROS_BUILDING_DLL"
+  )
+
+  ament_target_dependencies(${component_lib_name}
+    rclcpp
+    class_loader
+    rclcpp_components
+    rclcpp_lifecycle
+    std_msgs
+    sensor_msgs
+    geometry_msgs
+    ${additonal_dependencies}
+  )
+
+  target_link_libraries(${component_lib_name}
+    ouster_ros_library
+    ${cpp_typesupport_target}
+  )
+
+endfunction()
+
+
+# ==== os_sensor_component ====
+create_ros2_component(os_sensor_component
+  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp"
+  "std_srvs"
+)
+rclcpp_components_register_node(os_sensor_component
+  PLUGIN "ouster_ros::OusterSensor"
+  EXECUTABLE os_sensor
+)
+
+# ==== os_replay_component ====
+create_ros2_component(os_replay_component
+  "src/os_sensor_node_base.cpp;src/os_replay_node.cpp"
+  ""
+)
+rclcpp_components_register_node(os_replay_component
+  PLUGIN "ouster_ros::OusterReplay"
+  EXECUTABLE os_replay
+)
+
+# ==== os_cloud_component ====
+create_ros2_component(os_cloud_component
+  "src/os_processing_node_base.cpp;src/os_cloud_node.cpp"
+  "tf2_ros"
+)
+rclcpp_components_register_node(os_cloud_component
+  PLUGIN "ouster_ros::OusterCloud"
+  EXECUTABLE os_cloud
+)
+
+# ==== os_image_component ====
+create_ros2_component(os_image_component
+  "src/os_processing_node_base.cpp;src/os_image_node.cpp"
+  ""
+)
+rclcpp_components_register_node(os_image_component
+  PLUGIN "ouster_ros::OusterImage"
+  EXECUTABLE os_image
+)
+
+# ==== os_driver_component ====
+create_ros2_component(os_driver_component
+  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/os_driver_node.cpp"
+  "std_srvs"
+)
+rclcpp_components_register_node(os_driver_component
+  PLUGIN "ouster_ros::OusterDriver"
+  EXECUTABLE os_driver
+)
+
+
+# ==== Test ====
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(${PROJECT_NAME}_test
+    test/ring_buffer_test.cpp
+    src/os_ros.cpp
+    test/point_accessor_test.cpp
+    test/point_transform_test.cpp
+    test/point_cloud_compose_test.cpp
+  )
+  ament_target_dependencies(${PROJECT_NAME}_test
+    rclcpp
+    ouster_sensor_msgs
+  )
+  target_include_directories(${PROJECT_NAME}_test PUBLIC
+    ${_ouster_ros_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  target_link_libraries(${PROJECT_NAME}_test ouster_ros_library)
+endif()
+
+
+# ==== Install ====
+install(
+  TARGETS
+    ouster_ros_library
+    os_sensor_component
+    os_replay_component
+    os_cloud_component
+    os_image_component
+    os_driver_component
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  DIRECTORY
+    ${_ouster_ros_INCLUDE_DIRS}
+  DESTINATION
+    include/${PROJECT_NAME}
+)
+
+install(
+  FILES
+    ../LICENSE
+  DESTINATION
+    share/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY
+    launch
+    config
+  DESTINATION
+    share/${PROJECT_NAME}
+)
+
+ament_export_include_directories(include) 
+ament_export_dependencies(rosidl_default_runtime)
+ament_export_libraries(ouster_ros_library)
+ament_export_dependencies(${ouster_ros_library_deps})
+ament_package()

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.10.0</version>
+  <version>0.11.0</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/image_processor.h
+++ b/src/image_processor.h
@@ -18,10 +18,11 @@
 
 #include "ouster/image_processing.h"
 
+namespace ouster_ros {
+
 namespace sensor = ouster::sensor;
 namespace viz = ouster::viz;
 
-namespace ouster_ros {
 class ImageProcessor {
    public:
     using OutputType =

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -51,28 +51,6 @@ uint64_t ulround(T value) {
     return static_cast<uint64_t>(rounded_value);
 }
 
-// TODO: move to a separate file
-std::set<std::string> parse_tokens(const std::string& input, char delim) {
-    std::set<std::string> tokens;
-    std::stringstream ss(input);
-    std::string token;
-
-    while (getline(ss, token, delim)) {
-        // Remove leading and trailing whitespaces from the token
-        size_t start = token.find_first_not_of(" ");
-        size_t end = token.find_last_not_of(" ");
-        token = token.substr(start, end - start + 1);
-        if (!token.empty()) tokens.insert(token);
-    }
-
-    return tokens;
-}
-
-inline bool check_token(const std::set<std::string>& tokens,
-                        const std::string& token) {
-    return tokens.find(token) != tokens.end();
-}
-
 }  // namespace
 
 namespace ouster_ros {

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -20,21 +20,18 @@
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/PointCloud2.h>
 
-#include <algorithm>
-#include <chrono>
-#include <memory>
-#include <cassert>
-
 #include "ouster_ros/PacketMsg.h"
 #include "os_transforms_broadcaster.h"
 #include "imu_packet_handler.h"
 #include "lidar_packet_handler.h"
 #include "point_cloud_processor.h"
 #include "laser_scan_processor.h"
-
-namespace sensor = ouster::sensor;
+#include "point_cloud_processor_factory.h"
 
 namespace ouster_ros {
+
+namespace sensor = ouster::sensor;
+using ouster_ros::PacketMsg;
 
 class OusterCloud : public nodelet::Nodelet {
    public:
@@ -91,14 +88,14 @@ class OusterCloud : public nodelet::Nodelet {
     void create_publishers_subscribers(const sensor::sensor_info& info) {
         auto& pnh = getPrivateNodeHandle();
         auto proc_mask = pnh.param("proc_mask", std::string{"IMU|PCL|SCAN"});
-        auto tokens = parse_tokens(proc_mask, '|');
+        auto tokens = impl::parse_tokens(proc_mask, '|');
 
         auto timestamp_mode = pnh.param("timestamp_mode", std::string{});
         double ptp_utc_tai_offset = pnh.param("ptp_utc_tai_offset", -37.0);
 
         auto& nh = getNodeHandle();
 
-        if (check_token(tokens, "IMU")) {
+        if (impl::check_token(tokens, "IMU")) {
             imu_pub = nh.advertise<sensor_msgs::Imu>("imu", 100);
             imu_packet_handler = ImuPacketHandler::create_handler(
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
@@ -115,41 +112,52 @@ class OusterCloud : public nodelet::Nodelet {
         int num_returns = get_n_returns(info);
 
         std::vector<LidarScanProcessor> processors;
-        if (check_token(tokens, "PCL")) {
+        if (impl::check_token(tokens, "PCL")) {
             lidar_pubs.resize(num_returns);
             for (int i = 0; i < num_returns; ++i) {
                 lidar_pubs[i] = nh.advertise<sensor_msgs::PointCloud2>(
                     topic_for_return("points", i), 10);
             }
 
-            processors.push_back(PointCloudProcessor::create(
-                info, tf_bcast.point_cloud_frame_id(),
-                tf_bcast.apply_lidar_to_sensor_transform(),
-                [this](PointCloudProcessor::OutputType msgs) {
-                    for (size_t i = 0; i < msgs.size(); ++i) {
-                        if (msgs[i]->header.stamp > last_msg_ts)
-                            last_msg_ts = msgs[i]->header.stamp;
-                        lidar_pubs[i].publish(*msgs[i]);
+            auto point_type = pnh.param("point_type", std::string{"original"});
+            processors.push_back(
+                PointCloudProcessorFactory::create_point_cloud_processor(point_type,
+                    info, tf_bcast.point_cloud_frame_id(),
+                    tf_bcast.apply_lidar_to_sensor_transform(),
+                    [this](PointCloudProcessor_OutputType msgs) {
+                        for (size_t i = 0; i < msgs.size(); ++i) {
+                            if (msgs[i]->header.stamp > last_msg_ts)
+                                last_msg_ts = msgs[i]->header.stamp;
+                            lidar_pubs[i].publish(*msgs[i]);
+                        }
                     }
-                }));
+                )
+            );
+
+            // warn about profile incompatibility
+            if (PointCloudProcessorFactory::point_type_requires_intensity(point_type) &&
+                info.format.udp_profile_lidar == UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8) {
+                NODELET_WARN_STREAM(
+                    "selected point type '" << point_type << "' is not compatible with the current udp profile: RNG15_RFL8_NIR8");
+            }
         }
 
-        if (check_token(tokens, "SCAN")) {
+        if (impl::check_token(tokens, "SCAN")) {
             scan_pubs.resize(num_returns);
             for (int i = 0; i < num_returns; ++i) {
                 scan_pubs[i] = nh.advertise<sensor_msgs::LaserScan>(
                     topic_for_return("scan", i), 10);
             }
 
-            // TODO: avoid duplication in os_cloud_node
+            // TODO: avoid this duplication in os_cloud_node
             int beams_count = static_cast<int>(get_beams_count(info));
             int scan_ring = pnh.param("scan_ring", 0);
             scan_ring = std::min(std::max(scan_ring, 0), beams_count - 1);
             if (scan_ring != pnh.param("scan_ring", 0)) {
                 NODELET_WARN_STREAM(
-                    "scan ring is set to a value that exceeds available range"
-                    "please choose a value between [0, " << beams_count <<
-                    "], ring value clamped to: " << scan_ring);
+                    "scan ring is set to a value that exceeds available range "
+                    "please choose a value between [0, " << beams_count << "], "
+                    "ring value clamped to: " << scan_ring);
             }
 
             processors.push_back(LaserScanProcessor::create(
@@ -163,7 +171,7 @@ class OusterCloud : public nodelet::Nodelet {
                 }));
         }
 
-        if (check_token(tokens, "PCL") || check_token(tokens, "SCAN")) {
+        if (impl::check_token(tokens, "PCL") || impl::check_token(tokens, "SCAN")) {
             lidar_packet_handler = LidarPacketHandler::create_handler(
                 info, processors, timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -6,13 +6,12 @@
  * @brief A utilty file that contains helper methods
  */
 
-// prevent clang-format from altering the location of "ouster_ros/ros.h", the
+// prevent clang-format from altering the location of "ouster_ros/os_ros.h", the
 // header file needs to be the first include due to PCL_NO_PRECOMPILE flag
 // clang-format off
 #include "ouster_ros/os_ros.h"
 // clang-format on
 
-#include <pcl_conversions/pcl_conversions.h>
 #include <tf2/LinearMath/Transform.h>
 
 #include <tf2_eigen/tf2_eigen.h>
@@ -112,228 +111,25 @@ sensor::ChanField suitable_return(sensor::ChanField input_field, bool second) {
     }
 }
 
+// TODO: move to a separate file
+std::set<std::string> parse_tokens(const std::string& input, char delim) {
+
+    std::set<std::string> tokens;
+    std::stringstream ss(input);
+    std::string token;
+
+    while (getline(ss, token, delim)) {
+        // Remove leading and trailing whitespaces from the token
+        size_t start = token.find_first_not_of(" ");
+        size_t end = token.find_last_not_of(" ");
+        token = token.substr(start, end - start + 1);
+        if (!token.empty()) tokens.insert(token);
+    }
+
+    return tokens;
+}
+
 }  // namespace impl
-
-template <typename PointT, typename RangeT, typename ReflectivityT,
-          typename NearIrT, typename SignalT>
-void copy_scan_to_cloud(ouster_ros::Cloud& cloud, const ouster::LidarScan& ls,
-                        std::chrono::nanoseconds scan_ts, const PointT& points,
-                        const ouster::img_t<RangeT>& range,
-                        const ouster::img_t<ReflectivityT>& reflectivity,
-                        const ouster::img_t<NearIrT>& near_ir,
-                        const ouster::img_t<SignalT>& signal) {
-    auto timestamp = ls.timestamp();
-    const auto rg = range.data();
-    const auto rf = reflectivity.data();
-    const auto nr = near_ir.data();
-    const auto sg = signal.data();
-    const auto t_zero = std::chrono::duration<long int, std::nano>::zero();
-
-#ifdef __OUSTER_UTILIZE_OPENMP__
-#pragma omp parallel for collapse(2)
-#endif
-    for (auto u = 0; u < ls.h; u++) {
-        for (auto v = 0; v < ls.w; v++) {
-            const auto col_ts = std::chrono::nanoseconds(timestamp[v]);
-            const auto ts = col_ts > scan_ts ? col_ts - scan_ts : t_zero;
-            const auto idx = u * ls.w + v;
-            const auto xyz = points.row(idx);
-            cloud.points[idx] = ouster_ros::Point{
-                {static_cast<float>(xyz(0)), static_cast<float>(xyz(1)),
-                 static_cast<float>(xyz(2)), 1.0f},
-                static_cast<float>(sg[idx]),
-                static_cast<uint32_t>(ts.count()),
-                static_cast<uint16_t>(rf[idx]),
-                static_cast<uint16_t>(u),
-                static_cast<uint16_t>(nr[idx]),
-                static_cast<uint32_t>(rg[idx]),
-            };
-        }
-    }
-}
-
-template <typename PointT, typename RangeT, typename ReflectivityT,
-          typename NearIrT, typename SignalT>
-void copy_scan_to_cloud(ouster_ros::Cloud& cloud, const ouster::LidarScan& ls,
-                        uint64_t scan_ts, const PointT& points,
-                        const ouster::img_t<RangeT>& range,
-                        const ouster::img_t<ReflectivityT>& reflectivity,
-                        const ouster::img_t<NearIrT>& near_ir,
-                        const ouster::img_t<SignalT>& signal) {
-    auto timestamp = ls.timestamp();
-
-    const auto rg = range.data();
-    const auto rf = reflectivity.data();
-    const auto nr = near_ir.data();
-    const auto sg = signal.data();
-
-#ifdef __OUSTER_UTILIZE_OPENMP__
-#pragma omp parallel for collapse(2)
-#endif
-    for (auto u = 0; u < ls.h; u++) {
-        for (auto v = 0; v < ls.w; v++) {
-            const auto col_ts = timestamp[v];
-            const auto ts = col_ts > scan_ts ? col_ts - scan_ts : 0UL;
-            const auto idx = u * ls.w + v;
-            const auto xyz = points.row(idx);
-            cloud.points[idx] = ouster_ros::Point{
-                {static_cast<float>(xyz(0)), static_cast<float>(xyz(1)),
-                 static_cast<float>(xyz(2)), 1.0f},
-                static_cast<float>(sg[idx]),
-                static_cast<uint32_t>(ts),
-                static_cast<uint16_t>(rf[idx]),
-                static_cast<uint16_t>(u),
-                static_cast<uint16_t>(nr[idx]),
-                static_cast<uint32_t>(rg[idx]),
-            };
-        }
-    }
-}
-
-template <typename PointT, typename RangeT, typename ReflectivityT,
-          typename NearIrT, typename SignalT>
-void copy_scan_to_cloud_destaggered(
-    ouster_ros::Cloud& cloud, const ouster::LidarScan& ls, uint64_t scan_ts,
-    const PointT& points, const ouster::img_t<RangeT>& range,
-    const ouster::img_t<ReflectivityT>& reflectivity,
-    const ouster::img_t<NearIrT>& near_ir, const ouster::img_t<SignalT>& signal,
-    const std::vector<int>& pixel_shift_by_row) {
-    auto timestamp = ls.timestamp();
-    const auto rg = range.data();
-    const auto rf = reflectivity.data();
-    const auto nr = near_ir.data();
-    const auto sg = signal.data();
-
-#ifdef __OUSTER_UTILIZE_OPENMP__
-#pragma omp parallel for collapse(2)
-#endif
-    for (auto u = 0; u < ls.h; u++) {
-        for (auto v = 0; v < ls.w; v++) {
-            const auto v_shift = (v + ls.w - pixel_shift_by_row[u]) % ls.w;
-            auto ts = timestamp[v_shift]; ts = ts > scan_ts ? ts - scan_ts : 0UL;
-            const auto src_idx = u * ls.w + v_shift;
-            const auto tgt_idx = u * ls.w + v;
-            const auto xyz = points.row(src_idx);
-            cloud.points[tgt_idx] = ouster_ros::Point{
-                {static_cast<float>(xyz(0)), static_cast<float>(xyz(1)),
-                 static_cast<float>(xyz(2)), 1.0f},
-                static_cast<float>(sg[src_idx]),
-                static_cast<uint32_t>(ts),
-                static_cast<uint16_t>(rf[src_idx]),
-                static_cast<uint16_t>(u),
-                static_cast<uint16_t>(nr[src_idx]),
-                static_cast<uint32_t>(rg[src_idx]),
-            };
-        }
-    }
-}
-
-void scan_to_cloud_f(ouster::PointsF& points,
-                     const ouster::PointsF& lut_direction,
-                     const ouster::PointsF& lut_offset,
-                     std::chrono::nanoseconds scan_ts,
-                     const ouster::LidarScan& ls, ouster_ros::Cloud& cloud,
-                     int return_index) {
-    bool second = (return_index == 1);
-
-    assert(cloud.width == static_cast<std::uint32_t>(ls.w) &&
-           cloud.height == static_cast<std::uint32_t>(ls.h) &&
-           "point cloud and lidar scan size mismatch");
-
-    // across supported lidar profiles range is always 32-bit
-    auto range_channel_field =
-        second ? sensor::ChanField::RANGE2 : sensor::ChanField::RANGE;
-    ouster::img_t<uint32_t> range = ls.field<uint32_t>(range_channel_field);
-
-    ouster::img_t<uint16_t> reflectivity = impl::get_or_fill_zero<uint16_t>(
-        impl::suitable_return(sensor::ChanField::REFLECTIVITY, second), ls);
-
-    ouster::img_t<uint32_t> signal = impl::get_or_fill_zero<uint32_t>(
-        impl::suitable_return(sensor::ChanField::SIGNAL, second), ls);
-
-    ouster::img_t<uint16_t> near_ir = impl::get_or_fill_zero<uint16_t>(
-        impl::suitable_return(sensor::ChanField::NEAR_IR, second), ls);
-
-    ouster::cartesianT(points, range, lut_direction, lut_offset);
-
-    copy_scan_to_cloud(cloud, ls, scan_ts, points, range, reflectivity, near_ir,
-                       signal);
-}
-
-void scan_to_cloud_f(ouster::PointsF& points,
-                     const ouster::PointsF& lut_direction,
-                     const ouster::PointsF& lut_offset, uint64_t scan_ts,
-                     const ouster::LidarScan& ls, ouster_ros::Cloud& cloud,
-                     int return_index) {
-    bool second = (return_index == 1);
-
-    assert(cloud.width == static_cast<std::uint32_t>(ls.w) &&
-           cloud.height == static_cast<std::uint32_t>(ls.h) &&
-           "point cloud and lidar scan size mismatch");
-
-    // across supported lidar profiles range is always 32-bit
-    auto range_channel_field =
-        second ? sensor::ChanField::RANGE2 : sensor::ChanField::RANGE;
-    ouster::img_t<uint32_t> range = ls.field<uint32_t>(range_channel_field);
-
-    ouster::img_t<uint16_t> reflectivity = impl::get_or_fill_zero<uint16_t>(
-        impl::suitable_return(sensor::ChanField::REFLECTIVITY, second), ls);
-
-    ouster::img_t<uint32_t> signal = impl::get_or_fill_zero<uint32_t>(
-        impl::suitable_return(sensor::ChanField::SIGNAL, second), ls);
-
-    ouster::img_t<uint16_t> near_ir = impl::get_or_fill_zero<uint16_t>(
-        impl::suitable_return(sensor::ChanField::NEAR_IR, second), ls);
-
-    ouster::cartesianT(points, range, lut_direction, lut_offset);
-
-    copy_scan_to_cloud(cloud, ls, scan_ts, points, range, reflectivity, near_ir,
-                       signal);
-}
-
-void scan_to_cloud_f_destaggered(ouster_ros::Cloud& cloud,
-                                 ouster::PointsF& points,
-                                 const ouster::PointsF& lut_direction,
-                                 const ouster::PointsF& lut_offset,
-                                 uint64_t scan_ts, const ouster::LidarScan& ls,
-                                 const std::vector<int>& pixel_shift_by_row,
-                                 int return_index) {
-    bool second = (return_index == 1);
-
-    assert(cloud.width == static_cast<std::uint32_t>(ls.w) &&
-           cloud.height == static_cast<std::uint32_t>(ls.h) &&
-           "point cloud and lidar scan size mismatch");
-
-    // across supported lidar profiles range is always 32-bit
-    auto range_channel_field =
-        second ? sensor::ChanField::RANGE2 : sensor::ChanField::RANGE;
-    ouster::img_t<uint32_t> range = ls.field<uint32_t>(range_channel_field);
-
-    ouster::img_t<uint16_t> reflectivity = impl::get_or_fill_zero<uint16_t>(
-        impl::suitable_return(sensor::ChanField::REFLECTIVITY, second), ls);
-
-    ouster::img_t<uint32_t> signal = impl::get_or_fill_zero<uint32_t>(
-        impl::suitable_return(sensor::ChanField::SIGNAL, second), ls);
-
-    ouster::img_t<uint16_t> near_ir = impl::get_or_fill_zero<uint16_t>(
-        impl::suitable_return(sensor::ChanField::NEAR_IR, second), ls);
-
-    ouster::cartesianT(points, range, lut_direction, lut_offset);
-
-    copy_scan_to_cloud_destaggered(cloud, ls, scan_ts, points, range,
-                                   reflectivity, near_ir, signal,
-                                   pixel_shift_by_row);
-}
-
-sensor_msgs::PointCloud2 cloud_to_cloud_msg(const Cloud& cloud,
-                                            const ros::Time& timestamp,
-                                            const std::string& frame) {
-    sensor_msgs::PointCloud2 msg{};
-    pcl::toROSMsg(cloud, msg);
-    msg.header.frame_id = frame;
-    msg.header.stamp = timestamp;
-    return msg;
-}
 
 geometry_msgs::TransformStamped transform_to_tf_msg(
     const ouster::mat4d& mat, const std::string& frame,

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -15,7 +15,6 @@
 #include <pluginlib/class_list_macros.h>
 #include <std_srvs/Empty.h>
 
-#include <tuple>
 #include <chrono>
 
 #include "ouster_ros/PacketMsg.h"

--- a/src/os_transforms_broadcaster.h
+++ b/src/os_transforms_broadcaster.h
@@ -10,6 +10,7 @@
 
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
+#include <nodelet/nodelet.h>
 
 namespace ouster_ros {
 

--- a/src/point_cloud_compose.h
+++ b/src/point_cloud_compose.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <pcl_conversions/pcl_conversions.h>
+#include <sensor_msgs/PointCloud2.h>
+
+#include "ouster_ros/os_point.h"
+#include "ouster_ros/sensor_point_types.h"
+#include "ouster_ros/common_point_types.h"
+
+#include "point_meta_helpers.h"
+#include "point_transform.h"
+
+namespace ouster_ros {
+
+using ouster::sensor::ChanFieldType;
+
+template <ChanFieldType T>
+struct TypeSelector { /*undefined*/
+};
+
+template <>
+struct TypeSelector<ChanFieldType::UINT8> {
+    typedef uint8_t type;
+};
+
+template <>
+struct TypeSelector<ChanFieldType::UINT16> {
+    typedef uint16_t type;
+};
+
+template <>
+struct TypeSelector<ChanFieldType::UINT32> {
+    typedef uint32_t type;
+};
+
+template <>
+struct TypeSelector<ChanFieldType::UINT64> {
+    typedef uint64_t type;
+};
+
+/**
+ * @brief constructs a suitable tuple at compile time that can store a reference
+ * to all the fields of a specific LidarScan object (without conversion)
+ * according to the information specificed by the ChanFieldTable.
+ */
+template <std::size_t Index, std::size_t N, const ChanFieldTable<N>& Table>
+constexpr auto make_lidar_scan_tuple() {
+    if constexpr (Index < N) {
+        using ElementType = typename TypeSelector<Table[Index].second>::type;
+        return std::tuple_cat(
+            std::make_tuple(static_cast<const ElementType*>(0)),
+            std::move(make_lidar_scan_tuple<Index + 1, N, Table>()));
+    } else {
+        return std::make_tuple();
+    }
+}
+
+/**
+ * @brief maps the fields of a LidarScan object to the elements of the supplied
+ * tuple in the same order.
+ */
+template <std::size_t Index, std::size_t N, const ChanFieldTable<N>& Table,
+          typename Tuple>
+void map_lidar_scan_fields_to_tuple(Tuple& tp, const ouster::LidarScan& ls) {
+    static_assert(
+        std::tuple_size_v<Tuple> == N,
+        "target tuple size has a different size from the channel field table");
+    if constexpr (Index < N) {
+        using FieldType = typename TypeSelector<Table[Index].second>::type;
+        using ElementType = std::remove_const_t<
+            std::remove_pointer_t<std::tuple_element_t<Index, Tuple>>>;
+        static_assert(std::is_same_v<ElementType, FieldType>,
+                      "tuple element, field element types mismatch!");
+        std::get<Index>(tp) = ls.field<FieldType>(Table[Index].first).data();
+        map_lidar_scan_fields_to_tuple<Index + 1, N, Table>(tp, ls);
+    }
+}
+
+/**
+ * @brief constructs a suitable tuple at compile time that can store a reference
+ * to all the fields of a specific LidarScan object (without conversion)
+ * according to the information specificed by the ChanFieldTable and directly
+ * maps the fields of the supplied LidarScan to the constructed tuple before
+ * returning.
+ * @param[in] ls LidarScan
+ */
+template <std::size_t Index, std::size_t N, const ChanFieldTable<N>& Table>
+constexpr auto make_lidar_scan_tuple(const ouster::LidarScan& ls) {
+    auto tp = make_lidar_scan_tuple<0, N, Table>();
+    map_lidar_scan_fields_to_tuple<0, N, Table>(tp, ls);
+    return tp;
+}
+
+/**
+ * @brief copies field values from LidarScan fields combined as a tuple into the
+ * the corresponding elements of the input point pt.
+ * @param[out] pt point to copy values into.
+ * @param[in] tp tuple containing arrays to copy LidarScan field values from.
+ * @param[in] idx index of the point to be copied.
+ * @remark this method is to be used mainly with sensor native point types.
+ */
+template <std::size_t Index, typename PointT, typename Tuple>
+void copy_lidar_scan_fields_to_point(PointT& pt, const Tuple& tp, int idx) {
+    if constexpr (Index < std::tuple_size_v<Tuple>) {
+        point::get<5 + Index>(pt) = std::get<Index>(tp)[idx];
+        copy_lidar_scan_fields_to_point<Index + 1>(pt, tp, idx);
+    } else {
+        unused_variable(pt);
+        unused_variable(tp);
+        unused_variable(idx);
+    }
+}
+
+template <class T>
+using Cloud = pcl::PointCloud<T>;
+
+template <std::size_t N, const ChanFieldTable<N>& PROFILE, typename PointT,
+          typename PointS>
+void scan_to_cloud_f_destaggered(ouster_ros::Cloud<PointT>& cloud,
+                                 PointS& staging_point,
+                                 const ouster::PointsF& points,
+                                 uint64_t scan_ts, const ouster::LidarScan& ls,
+                                 const std::vector<int>& pixel_shift_by_row) {
+    auto ls_tuple = make_lidar_scan_tuple<0, N, PROFILE>(ls);
+    auto timestamp = ls.timestamp();
+
+    for (auto u = 0; u < ls.h; u++) {
+        for (auto v = 0; v < ls.w; v++) {
+            const auto v_shift = (v + ls.w - pixel_shift_by_row[u]) % ls.w;
+            auto ts = timestamp[v_shift];
+            ts = ts > scan_ts ? ts - scan_ts : 0UL;
+            const auto src_idx = u * ls.w + v_shift;
+            const auto tgt_idx = u * ls.w + v;
+            const auto xyz = points.row(src_idx);
+            // if target point and staging point has matching type bind the
+            // target directly and avoid performing transform_point at the end
+            auto& pt = CondBinaryBind<std::is_same_v<PointT, PointS>>::run(
+                cloud.points[tgt_idx], staging_point);
+            // all native point types have x, y, z, t and ring values
+            pt.x = static_cast<decltype(pt.x)>(xyz(0));
+            pt.y = static_cast<decltype(pt.y)>(xyz(1));
+            pt.z = static_cast<decltype(pt.z)>(xyz(2));
+            // TODO: in the future we could probably skip copying t and ring
+            // values if knowning before hand that the target point cloud does
+            // not have a field to hold the timestamp or a ring for example the
+            // case of pcl::PointXYZ or pcl::PointXYZI.
+            pt.t = static_cast<uint32_t>(ts);
+            pt.ring = static_cast<uint16_t>(u);
+            copy_lidar_scan_fields_to_point<0>(pt, ls_tuple, src_idx);
+            // only perform point transform operation when PointT, and PointS
+            // don't match
+            CondBinaryOp<!std::is_same_v<PointT, PointS>>::run(
+                cloud.points[tgt_idx], staging_point,
+                [](auto& tgt_pt, const auto& src_pt) {
+                    point::transform(tgt_pt, src_pt);
+                });
+        }
+    }
+}
+
+}  // namespace ouster_ros

--- a/src/point_cloud_processor_factory.h
+++ b/src/point_cloud_processor_factory.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "point_cloud_processor.h"
+
+namespace ouster_ros {
+
+namespace sensor = ouster::sensor;
+using sensor::UDPProfileLidar;
+
+class PointCloudProcessorFactory {
+    template <typename PointT>
+    static typename PointCloudProcessor<PointT>::ScanToCloudFn
+    make_scan_to_cloud_fn(const sensor::sensor_info& info) {
+        switch (info.format.udp_profile_lidar) {
+            case UDPProfileLidar::PROFILE_LIDAR_LEGACY:
+                return [](ouster_ros::Cloud<PointT>& cloud,
+                          const ouster::PointsF& points, uint64_t scan_ts,
+                          const ouster::LidarScan& ls,
+                          const std::vector<int>& pixel_shift_by_row,
+                          int return_index) {
+                    unused_variable(return_index);
+                    Point_LEGACY staging_pt;
+                    scan_to_cloud_f_destaggered<Profile_LEGACY.size(),
+                                                Profile_LEGACY>(
+                        cloud, staging_pt, points, scan_ts, ls,
+                        pixel_shift_by_row);
+                };
+
+            case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
+                return [](ouster_ros::Cloud<PointT>& cloud,
+                          const ouster::PointsF& points, uint64_t scan_ts,
+                          const ouster::LidarScan& ls,
+                          const std::vector<int>& pixel_shift_by_row,
+                          int return_index) {
+                    Point_RNG19_RFL8_SIG16_NIR16_DUAL staging_pt;
+                    if (return_index == 0) {
+                        scan_to_cloud_f_destaggered<
+                            Profile_RNG19_RFL8_SIG16_NIR16_DUAL.size(),
+                            Profile_RNG19_RFL8_SIG16_NIR16_DUAL>(
+                            cloud, staging_pt, points, scan_ts, ls,
+                            pixel_shift_by_row);
+                    } else {
+                        scan_to_cloud_f_destaggered<
+                            Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN
+                                .size(),
+                            Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN>(
+                            cloud, staging_pt, points, scan_ts, ls,
+                            pixel_shift_by_row);
+                    }
+                };
+
+            case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16:
+                return [](ouster_ros::Cloud<PointT>& cloud,
+                          const ouster::PointsF& points, uint64_t scan_ts,
+                          const ouster::LidarScan& ls,
+                          const std::vector<int>& pixel_shift_by_row,
+                          int return_index) {
+                    unused_variable(return_index);
+                    Point_RNG19_RFL8_SIG16_NIR16 staging_pt;
+                    scan_to_cloud_f_destaggered<
+                        Profile_RNG19_RFL8_SIG16_NIR16.size(),
+                        Profile_RNG19_RFL8_SIG16_NIR16>(cloud, staging_pt,
+                                                        points, scan_ts, ls,
+                                                        pixel_shift_by_row);
+                };
+
+            case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
+                return [](ouster_ros::Cloud<PointT>& cloud,
+                          const ouster::PointsF& points, uint64_t scan_ts,
+                          const ouster::LidarScan& ls,
+                          const std::vector<int>& pixel_shift_by_row,
+                          int return_index) {
+                    unused_variable(return_index);
+                    Point_RNG15_RFL8_NIR8 staging_pt;
+                    scan_to_cloud_f_destaggered<Profile_RNG15_RFL8_NIR8.size(),
+                                                Profile_RNG15_RFL8_NIR8>(
+                        cloud, staging_pt, points, scan_ts, ls,
+                        pixel_shift_by_row);
+                };
+
+            default:
+                throw std::runtime_error("unsupported udp_profile_lidar");
+        }
+    }
+
+    template <typename PointT>
+    static LidarScanProcessor make_point_cloud_procssor(
+        const sensor::sensor_info& info, const std::string& frame,
+        bool apply_lidar_to_sensor_transform,
+        PointCloudProcessor_PostProcessingFn post_processing_fn) {
+        auto scan_to_cloud_fn = make_scan_to_cloud_fn<PointT>(info);
+        return PointCloudProcessor<PointT>::create(
+            info, frame, apply_lidar_to_sensor_transform, scan_to_cloud_fn,
+            post_processing_fn);
+    }
+
+   public:
+    static bool point_type_requires_intensity(const std::string& point_type) {
+        return point_type == "xyzi" || point_type == "xyzir" ||
+               point_type == "original";
+    }
+
+    static LidarScanProcessor create_point_cloud_processor(
+        const std::string& point_type, const sensor::sensor_info& info,
+        const std::string& frame, bool apply_lidar_to_sensor_transform,
+        PointCloudProcessor_PostProcessingFn post_processing_fn) {
+        if (point_type == "native") {
+            switch (info.format.udp_profile_lidar) {
+                case UDPProfileLidar::PROFILE_LIDAR_LEGACY:
+                    return make_point_cloud_procssor<Point_LEGACY>(
+                        info, frame, apply_lidar_to_sensor_transform,
+                        post_processing_fn);
+                case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
+                    return make_point_cloud_procssor<
+                        Point_RNG19_RFL8_SIG16_NIR16_DUAL>(
+                        info, frame, apply_lidar_to_sensor_transform,
+                        post_processing_fn);
+                case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16:
+                    return make_point_cloud_procssor<
+                        Point_RNG19_RFL8_SIG16_NIR16>(
+                        info, frame, apply_lidar_to_sensor_transform,
+                        post_processing_fn);
+                case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
+                    return make_point_cloud_procssor<Point_RNG15_RFL8_NIR8>(
+                        info, frame, apply_lidar_to_sensor_transform,
+                        post_processing_fn);
+                default:
+                    // TODO: implement fallback?
+                    throw std::runtime_error("unsupported udp_profile_lidar");
+            }
+        } else if (point_type == "xyz") {
+            return make_point_cloud_procssor<pcl::PointXYZ>(
+                info, frame, apply_lidar_to_sensor_transform,
+                post_processing_fn);
+        } else if (point_type == "xyzi") {
+            return make_point_cloud_procssor<pcl::PointXYZI>(
+                info, frame, apply_lidar_to_sensor_transform,
+                post_processing_fn);
+        } else if (point_type == "xyzir") {
+            return make_point_cloud_procssor<PointXYZIR>(
+                info, frame, apply_lidar_to_sensor_transform,
+                post_processing_fn);
+        } else if (point_type == "original") {
+            return make_point_cloud_procssor<ouster_ros::Point>(
+                info, frame, apply_lidar_to_sensor_transform,
+                post_processing_fn);
+        }
+
+        throw std::runtime_error(
+            "Un-supported point type used: " + point_type + "!");
+    }
+};
+
+}  // namespace ouster_ros

--- a/src/point_meta_helpers.h
+++ b/src/point_meta_helpers.h
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file point_meta_helpers.h
+ * @brief Provides a set of templated routines to enumerate or manipulate
+ * various pcl point representations at compile time.
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <string>
+#include <pcl_conversions/pcl_conversions.h>
+
+namespace ouster_ros {
+
+/**
+ * @brief A macro that facilitate providing a compile time check if a struct has
+ * a member with a specific name
+ */
+#define DEFINE_MEMBER_CHECKER(member) \
+    template<typename T, typename = void> \
+    struct has_##member : std::false_type { }; \
+    template<typename T> \
+    struct has_##member<T, \
+        typename std::enable_if< \
+            !std::is_same<decltype(T::member), void>::value, \
+            void \
+            >::type \
+        > : std::true_type { }; \
+    template<typename C> \
+    inline constexpr bool has_##member##_v = has_##member<C>::value;
+
+/**
+ * @brief A template that can be used to silence unused varaiables warning.
+ */
+template<typename T> inline void unused_variable(const T&) {}
+
+/**
+ * @brief A struct that allows enabling or disabling the execution of an operation
+ * using a compile time condition.
+ */
+template <bool Enable>
+struct CondBinaryOp {
+    template <typename A, typename B, typename BinaryOp>
+    inline static void run(A& a, B& b, BinaryOp binary_op) {
+        if constexpr (Enable) {
+            binary_op(a, b);
+        } else {
+            unused_variable(a); unused_variable(b); unused_variable(binary_op);
+        }
+    }
+};
+
+/**
+ * @brief A struct that a reference to the first variable if the compile time
+ * condition was true and returns a reference to the second variable if condition
+ * was false.
+ */
+template <bool Enable>
+struct CondBinaryBind {
+    template <typename A, typename B>
+    inline static auto& run(A& a, B& b) {
+        if constexpr (Enable) {
+            unused_variable(b);
+            return a;
+        } else {
+            unused_variable(a);
+            return b;
+        }
+    }
+};
+
+namespace point {
+
+/**
+ * @brief A compile-time function to retrieve the number of elements that a 
+ * certain pcl point type has
+ * @param[in] point a pcl point type
+ * @return the number of elements that a point has
+ */
+template <typename T>
+inline constexpr std::size_t size(const T& point) {
+  return std::tuple_size<decltype(point.as_tuple())>::value;
+}
+
+template <>
+inline constexpr std::size_t size<pcl::PointXYZ>(const pcl::PointXYZ&) { return 3U; }
+
+template <>
+inline constexpr std::size_t size<pcl::PointXYZI>(const pcl::PointXYZI&) { return 4U; }
+
+// generic accessor that avoid having to type template before get
+template <size_t I, typename T> 
+inline constexpr auto& get(T& point) { return point.template get<I>(); }
+
+// pcl::PointXYZ compile time element accessors
+template <>
+inline constexpr auto& get<0, pcl::PointXYZ>(pcl::PointXYZ& point) { return point.x; }
+template <>
+inline constexpr auto& get<1, pcl::PointXYZ>(pcl::PointXYZ& point) { return point.y; }
+template <>
+inline constexpr auto& get<2, pcl::PointXYZ>(pcl::PointXYZ& point) { return point.z; }
+
+// pcl::PointXYZI  compile time element accessors
+template <>
+inline  constexpr auto& get<0, pcl::PointXYZI>(pcl::PointXYZI& point) { return point.x; }
+template <>
+inline  constexpr auto& get<1, pcl::PointXYZI>(pcl::PointXYZI& point) { return point.y; }
+template <>
+inline  constexpr auto& get<2, pcl::PointXYZI>(pcl::PointXYZI& point) { return point.z; }
+template <>
+inline  constexpr auto& get<3, pcl::PointXYZI>(pcl::PointXYZI& point) { return point.intensity; }
+
+// TODO: create a generalized vardiac templates of apply and enumerate functions
+
+/**
+ * @brief Iterates the elements of a point (compile time) applying a lambda
+ *  function to each element in sequence within the range [Index, N) where:
+ *      `Index < N and N <= size(pt)`
+ */
+template <std::size_t Index, std::size_t N, typename PointT, typename UnaryOp>
+constexpr void apply(PointT& pt, UnaryOp unary_op) {
+    if constexpr (Index < N) {
+        unary_op(get<Index>(pt));
+        apply<Index + 1, N, PointT, UnaryOp>(pt, unary_op);
+    } else {
+      unused_variable(unary_op);
+    }
+}
+
+/**
+ * @brief Enumerates the elements of a point (compile time) applying a lambda
+ * function to each element in sequence within the range [Index, N) where:
+ *      `Index < N and N <= size(pt)`
+ * The lambda function recieves the index of each element as the first parameter
+ * and a reference to the element as the second parameter
+ */
+template <std::size_t Index, std::size_t N, typename PointT, typename EnumOp>
+constexpr void enumerate(PointT& pt, EnumOp enum_op) {
+    if constexpr (Index < N) {
+        enum_op(Index, get<Index>(pt));
+        enumerate<Index + 1, N, PointT, EnumOp>(pt, enum_op);
+    } else {
+      unused_variable(enum_op);
+    }
+}
+
+}   // point
+}   // ouster_ros

--- a/src/point_transform.h
+++ b/src/point_transform.h
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file point_transform.h
+ * @brief Implements the main transform_point method used to convert point from
+ * a source pcl point format usually sensor native point representation to other
+ * pcl point formats such as Velodyne XYZIR or pcl::XYZ, pcl::XYZI, ... 
+ */
+
+#pragma once
+
+#include "point_meta_helpers.h"
+
+namespace ouster_ros {
+namespace point {
+
+DEFINE_MEMBER_CHECKER(x);
+DEFINE_MEMBER_CHECKER(y);
+DEFINE_MEMBER_CHECKER(z);
+DEFINE_MEMBER_CHECKER(t);
+DEFINE_MEMBER_CHECKER(ring);
+DEFINE_MEMBER_CHECKER(intensity);
+DEFINE_MEMBER_CHECKER(ambient);
+DEFINE_MEMBER_CHECKER(range);
+DEFINE_MEMBER_CHECKER(signal);
+DEFINE_MEMBER_CHECKER(reflectivity);
+DEFINE_MEMBER_CHECKER(near_ir);
+
+template <typename PointTGT, typename PointSRC>
+void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
+    // NOTE: for now we assume all points have xyz component
+    tgt_pt.x = src_pt.x; tgt_pt.y = src_pt.y; tgt_pt.z = src_pt.z;
+
+    // t: timestamp
+    CondBinaryOp<has_t_v<PointTGT> && has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { tgt_pt.t = src_pt.t; }
+    );
+
+    CondBinaryOp<has_t_v<PointTGT> && !has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) { tgt_pt.t = 0U; }
+    );
+
+    // ring
+    CondBinaryOp<has_ring_v<PointTGT> && has_ring_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { tgt_pt.ring = src_pt.ring; }
+    );
+
+    CondBinaryOp<has_ring_v<PointTGT> && !has_ring_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
+            tgt_pt.ring = static_cast<decltype(tgt_pt.ring)>(0);
+        }
+    );
+
+    // range
+    CondBinaryOp<has_range_v<PointTGT> && has_range_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { tgt_pt.range = src_pt.range; }
+    );
+
+    CondBinaryOp<has_range_v<PointTGT> && !has_range_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) { tgt_pt.range = 0U; }
+    );
+
+    // signal
+    CondBinaryOp<has_signal_v<PointTGT> && has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { tgt_pt.signal = src_pt.signal; }
+    );
+
+    CondBinaryOp<has_signal_v<PointTGT> && !has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
+            tgt_pt.signal = static_cast<decltype(tgt_pt.signal)>(0);
+        }
+    );
+
+    // intensity <- signal
+    // PointTGT should not have signal and intensity at the same time [normally]
+    CondBinaryOp<has_intensity_v<PointTGT> && has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) {
+            tgt_pt.intensity = static_cast<decltype(tgt_pt.intensity)>(src_pt.signal);
+        }
+    );
+
+    CondBinaryOp<has_intensity_v<PointTGT> && !has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
+            tgt_pt.intensity = static_cast<decltype(tgt_pt.intensity)>(0);
+        }
+    );
+
+    // reflectivity
+    CondBinaryOp<has_reflectivity_v<PointTGT> && has_reflectivity_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) {
+            tgt_pt.reflectivity = src_pt.reflectivity;
+        }
+    );
+
+    CondBinaryOp<has_reflectivity_v<PointTGT> && !has_reflectivity_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
+            tgt_pt.reflectivity = static_cast<decltype(tgt_pt.reflectivity)>(0);
+        }
+    );
+
+    // near_ir
+    CondBinaryOp<has_near_ir_v<PointTGT> && has_near_ir_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { tgt_pt.near_ir = src_pt.near_ir; }
+    );
+
+    CondBinaryOp<has_near_ir_v<PointTGT> && !has_near_ir_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
+            tgt_pt.near_ir = static_cast<decltype(tgt_pt.near_ir)>(0); }
+    );
+
+    // ambient <- near_ir
+    CondBinaryOp<has_ambient_v<PointTGT> && has_near_ir_v<PointSRC>>::run(tgt_pt, src_pt,
+        [](auto& tgt_pt, const auto& src_pt) {
+            tgt_pt.ambient = static_cast<decltype(tgt_pt.ambient)>(src_pt.near_ir);
+        }
+    );
+
+    CondBinaryOp<has_ambient_v<PointTGT> && !has_near_ir_v<PointSRC>>::run(tgt_pt, src_pt,
+        [](auto& tgt_pt, const auto&) {
+            tgt_pt.ambient = static_cast<decltype(tgt_pt.ambient)>(0);
+        }
+    );
+}
+
+}   // point
+}   // ouster_ros

--- a/tests/point_accessor_test.cpp
+++ b/tests/point_accessor_test.cpp
@@ -1,0 +1,218 @@
+#include <gtest/gtest.h>
+
+// prevent clang-format from altering the location of "ouster_ros/os_ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+#include "ouster_ros/sensor_point_types.h"
+#include "ouster_ros/common_point_types.h"
+#include "ouster_ros/os_point.h"
+#include "../src/point_meta_helpers.h"
+
+using namespace std;
+using namespace ouster_ros;
+
+class PointAccessorTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        pt_xyz = pcl::_PointXYZ{0.0f, 1.0f, 2.0f, 1.0f};
+        pt_xyzi = pcl::_PointXYZI{{0.0f, 1.0f, 2.0f, 1.0}, 3.0f};
+        pt_xyzir = ouster_ros::_PointXYZIR{{0.0f, 1.0f, 2.0f, 1.0f}, 3.0f, 4};
+
+        pt_legacy = ouster_ros::_Point_LEGACY{
+            {0.0f, 1.0f, 2.0f, 1.0f},   // x, y, z, w
+            3, 4,                       // t, ring
+            5, 6, 7, 8                  // range, signal, reflectivity, near_ir
+        };
+
+        pt_rg19_rf8_sg16_nr16_dual = ouster_ros::_Point_RNG19_RFL8_SIG16_NIR16_DUAL{
+            {0.0f, 1.0f, 2.0f, 1.0f},   // x, y, z, w
+            3, 4,                       // t, ring
+            5, 6, 7, 8                  // range, signal, reflectivity, near_ir
+        };
+
+        pt_rg19_rf8_sg16_nr16 = ouster_ros::_Point_RNG19_RFL8_SIG16_NIR16{
+            {0.0f, 1.0f, 2.0f, 1.0f},   // x, y, z, w
+            3, 4,                       // t, ring
+            5, 6, 7, 8                  // range, signal, reflectivity, near_ir
+        };
+
+        pt_rg15_rfl8_nr8 = ouster_ros::_Point_RNG15_RFL8_NIR8{
+            {0.0f, 1.0f, 2.0f, 1.0f},   // x, y, z, w
+            3, 4,                       // t, ring
+            5, 6, 7,                    // range, reflectivity, near_ir
+        };
+
+        pt_os_point = ouster_ros::_Point{
+            {0.0f, 1.0f, 2.0f, 1.0f},   // x, y, z, w
+            3.0f, 4,                    // intensity, t,
+            5, 6, 7, 8                  // reflectivity, ring, ambient, range
+        };
+    }
+
+    void TearDown() override {}
+
+    // pcl & velodyne point types
+    static pcl::PointXYZ pt_xyz;
+    static pcl::PointXYZI pt_xyzi;
+    static PointXYZIR pt_xyzir;
+    // native point types
+    static Point_LEGACY pt_legacy;
+    static Point_RNG19_RFL8_SIG16_NIR16_DUAL pt_rg19_rf8_sg16_nr16_dual;
+    static Point_RNG19_RFL8_SIG16_NIR16 pt_rg19_rf8_sg16_nr16;
+    static Point_RNG15_RFL8_NIR8 pt_rg15_rfl8_nr8;
+    // ouster_ros original/legacy point (not to be confused with Point_LEGACY)
+    static ouster_ros::Point pt_os_point;
+};
+
+// pcl & velodyne point types
+pcl::PointXYZ PointAccessorTest::pt_xyz;
+pcl::PointXYZI PointAccessorTest::pt_xyzi;
+PointXYZIR PointAccessorTest::pt_xyzir;
+// native point types
+Point_LEGACY PointAccessorTest::pt_legacy;
+Point_RNG19_RFL8_SIG16_NIR16_DUAL PointAccessorTest::pt_rg19_rf8_sg16_nr16_dual;
+Point_RNG19_RFL8_SIG16_NIR16 PointAccessorTest::pt_rg19_rf8_sg16_nr16;
+Point_RNG15_RFL8_NIR8 PointAccessorTest::pt_rg15_rfl8_nr8;
+// ouster_ros original/legacy point (not to be confused with Point_LEGACY)
+ouster_ros::Point PointAccessorTest::pt_os_point;
+
+TEST_F(PointAccessorTest, ElementCount) {
+    // pcl & velodyne point types
+    EXPECT_EQ(point::size(pt_xyz), 3U);
+    EXPECT_EQ(point::size(pt_xyzi), 4U);
+    EXPECT_EQ(point::size(pt_xyzir), 5U);
+    // all native sensor point types has {x, y, z, t and ring} fields
+    EXPECT_EQ(point::size(pt_legacy), 5 + Profile_LEGACY.size());
+    EXPECT_EQ(point::size(pt_rg19_rf8_sg16_nr16_dual),
+              5 + Profile_RNG19_RFL8_SIG16_NIR16_DUAL.size());
+    EXPECT_EQ(point::size(pt_rg19_rf8_sg16_nr16),
+              5 + Profile_RNG19_RFL8_SIG16_NIR16.size());
+    EXPECT_EQ(point::size(pt_rg15_rfl8_nr8),
+              5 + Profile_RNG15_RFL8_NIR8.size());
+    // ouster_ros original/legacy point type
+    EXPECT_EQ(point::size(pt_os_point), 9U);
+}
+
+// This test is only concerned with pcl & velodyne point types to verify that
+// point::get<I> performs as expected. Subsequent tests does the same test on
+// the remaining point types but uses point::apply and point::enumerate rather
+// than accessing each element individually/directly as this test case does.
+TEST_F(PointAccessorTest, ElementGetSet) {
+    // pcl::PointXYZ
+    EXPECT_EQ(point::get<0>(pt_xyz), 0.0f);
+    EXPECT_EQ(point::get<1>(pt_xyz), 1.0f);
+    EXPECT_EQ(point::get<2>(pt_xyz), 2.0f);
+    // pcl::PointXYZI
+    EXPECT_EQ(point::get<0>(pt_xyzi), 0.0f);
+    EXPECT_EQ(point::get<1>(pt_xyzi), 1.0f);
+    EXPECT_EQ(point::get<2>(pt_xyzi), 2.0f);
+    EXPECT_EQ(point::get<3>(pt_xyzi), 3.0f);
+    // ouster_ros::PointXYZIR
+    EXPECT_EQ(point::get<0>(pt_xyzir), 0.0f);
+    EXPECT_EQ(point::get<1>(pt_xyzir), 1.0f);
+    EXPECT_EQ(point::get<2>(pt_xyzir), 2.0f);
+    EXPECT_EQ(point::get<3>(pt_xyzir), 3.0f);
+    EXPECT_EQ(point::get<4>(pt_xyzir), 4);
+
+    // pcl::PointXYZ
+    point::get<0>(pt_xyz) = 10.0f;
+    point::get<1>(pt_xyz) = 11.0f;
+    point::get<2>(pt_xyz) = 12.0f;
+    // pcl::PointXYZI
+    point::get<0>(pt_xyzi) = 10.0f;
+    point::get<1>(pt_xyzi) = 11.0f;
+    point::get<2>(pt_xyzi) = 12.0f;
+    point::get<3>(pt_xyzi) = 13.0f;
+    // ouster_ros::PointXYZIR
+    point::get<0>(pt_xyzir) = 10.0f;
+    point::get<1>(pt_xyzir) = 11.0f;
+    point::get<2>(pt_xyzir) = 12.0f;
+    point::get<3>(pt_xyzir) = 13.0f;
+    point::get<4>(pt_xyzir) = 14;
+
+    // pcl::PointXYZ
+    EXPECT_EQ(point::get<0>(pt_xyz), 10.0f);
+    EXPECT_EQ(point::get<1>(pt_xyz), 11.0f);
+    EXPECT_EQ(point::get<2>(pt_xyz), 12.0f);
+    // pcl::PointXYZI
+    EXPECT_EQ(point::get<0>(pt_xyzi), 10.0f);
+    EXPECT_EQ(point::get<1>(pt_xyzi), 11.0f);
+    EXPECT_EQ(point::get<2>(pt_xyzi), 12.0f);
+    EXPECT_EQ(point::get<3>(pt_xyzi), 13.0f);
+    // ouster_ros::PointXYZIR
+    EXPECT_EQ(point::get<0>(pt_xyzir), 10.0f);
+    EXPECT_EQ(point::get<1>(pt_xyzir), 11.0f);
+    EXPECT_EQ(point::get<2>(pt_xyzir), 12.0f);
+    EXPECT_EQ(point::get<3>(pt_xyzir), 13.0f);
+    EXPECT_EQ(point::get<4>(pt_xyzir), 14);
+}
+
+template <std::size_t N, typename PointT>
+void expect_element_equals_index(PointT& pt) {
+    point::enumerate<0, N>(pt, [](auto index, auto value) {
+        EXPECT_EQ(value, static_cast<decltype(value)>(index));
+    });
+}
+
+TEST_F(PointAccessorTest, ExpectElementValueSameAsIndex) {
+    // pcl + velodyne point types
+    expect_element_equals_index<point::size(pt_xyz)>(pt_xyz);
+    expect_element_equals_index<point::size(pt_xyzi)>(pt_xyzi);
+    expect_element_equals_index<point::size(pt_xyzir)>(pt_xyzir);
+    // native sensor point types
+    expect_element_equals_index<point::size(pt_legacy)>(pt_legacy);
+    expect_element_equals_index<point::size(pt_rg19_rf8_sg16_nr16_dual)>(
+        pt_rg19_rf8_sg16_nr16_dual);
+    expect_element_equals_index<point::size(pt_rg19_rf8_sg16_nr16)>(
+        pt_rg19_rf8_sg16_nr16);
+    expect_element_equals_index<point::size(pt_rg15_rfl8_nr8)>(
+        pt_rg15_rfl8_nr8);
+    // ouster_ros original/legacy point type
+    expect_element_equals_index<point::size(pt_os_point)>(pt_os_point);
+}
+
+template <std::size_t N, typename PointT>
+void increment_by_value(PointT& pt, int increment) {
+    point::apply<0, N>(pt, [increment](auto& value) { value += increment; });
+}
+
+template <std::size_t N, typename PointT>
+void expect_value_increased_by_value(PointT& pt, int increment) {
+    point::enumerate<0, N>(pt, [increment](auto index, auto value) {
+        EXPECT_EQ(value, static_cast<decltype(value)>(index + increment));
+    });
+};
+
+TEST_F(PointAccessorTest, ExpectPointElementValueIncrementedByValue) {
+    auto increment = 1;
+
+    // pcl + velodyne point types
+    increment_by_value<point::size(pt_xyz)>(pt_xyz, increment);
+    expect_value_increased_by_value<point::size(pt_xyz)>(pt_xyz, increment);
+    increment_by_value<point::size(pt_xyzi)>(pt_xyzi, increment);
+    expect_value_increased_by_value<point::size(pt_xyzi)>(pt_xyzi, increment);
+    increment_by_value<point::size(pt_xyzir)>(pt_xyzir, increment);
+    expect_value_increased_by_value<point::size(pt_xyzir)>(pt_xyzir, increment);
+    // // native sensor point types
+    increment_by_value<point::size(pt_legacy)>(pt_legacy, increment);
+    expect_value_increased_by_value<point::size(pt_legacy)>(pt_legacy,
+                                                            increment);
+    increment_by_value<point::size(pt_rg19_rf8_sg16_nr16_dual)>(
+        pt_rg19_rf8_sg16_nr16_dual, increment);
+    expect_value_increased_by_value<point::size(pt_rg19_rf8_sg16_nr16_dual)>(
+        pt_rg19_rf8_sg16_nr16_dual, increment);
+    increment_by_value<point::size(pt_rg19_rf8_sg16_nr16)>(
+        pt_rg19_rf8_sg16_nr16, increment);
+    expect_value_increased_by_value<point::size(pt_rg19_rf8_sg16_nr16)>(
+        pt_rg19_rf8_sg16_nr16, increment);
+    increment_by_value<point::size(pt_rg15_rfl8_nr8)>(pt_rg15_rfl8_nr8,
+                                                      increment);
+    expect_value_increased_by_value<point::size(pt_rg15_rfl8_nr8)>(
+        pt_rg15_rfl8_nr8, increment);
+    // // ouster_ros original/legacy point type
+    increment_by_value<point::size(pt_os_point)>(pt_os_point, increment);
+    expect_value_increased_by_value<point::size(pt_os_point)>(pt_os_point,
+                                                              increment);
+}

--- a/tests/point_cloud_compose_test.cpp
+++ b/tests/point_cloud_compose_test.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <ouster/lidar_scan.h>
+
+// prevent clang-format from altering the location of "ouster_ros/os_ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+#include "ouster_ros/sensor_point_types.h"
+#include "ouster_ros/common_point_types.h"
+#include "ouster_ros/os_point.h"
+#include "../src/point_meta_helpers.h"
+#include "../src/point_cloud_compose.h"
+
+class PointCloudComposeTest : public ::testing::Test {
+   protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+};
+
+using namespace std;
+using namespace ouster::sensor;
+using namespace ouster_ros;
+
+// TODO: generalize the test case!
+
+TEST_F(PointCloudComposeTest, MapLidarScanFields) {
+    const auto WIDTH = 5U;
+    const auto HEIGHT = 3U;
+    const auto SAMPLES = WIDTH * HEIGHT;
+    UDPProfileLidar lidar_udp_profile =
+        UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL;
+
+    ouster::LidarScan ls(WIDTH, HEIGHT, lidar_udp_profile);
+
+    auto fill_data = [](auto& img, auto base, auto count) {
+        auto* p = img.data();
+        for (auto i = 0U; i < count; ++i)
+            p[i] =
+                static_cast<std::remove_reference_t<decltype(p[0])>>(base + i);
+    };
+
+    auto range = ls.field<uint32_t>(RANGE);
+    auto signal = ls.field<uint16_t>(SIGNAL);
+    auto reflect = ls.field<uint8_t>(REFLECTIVITY);
+    auto near_ir = ls.field<uint16_t>(NEAR_IR);
+
+    // choose a base value that could ultimately wrap around
+    fill_data(range, static_cast<uint32_t>(1 + (1ULL << 32) - SAMPLES / 2),
+              SAMPLES);
+    fill_data(signal, static_cast<uint16_t>(3 + (1 << 16) - SAMPLES / 2),
+              SAMPLES);
+    fill_data(reflect, static_cast<uint8_t>(5 + (1 << 8) - SAMPLES / 2),
+              SAMPLES);
+    fill_data(near_ir, static_cast<uint16_t>(7 + (1 << 16) - SAMPLES / 2),
+              SAMPLES);
+
+    ouster_ros::Cloud<Point_RNG19_RFL8_SIG16_NIR16_DUAL> cloud{WIDTH, HEIGHT};
+
+    auto ls_tuple =
+        make_lidar_scan_tuple<0, Profile_RNG19_RFL8_SIG16_NIR16_DUAL.size(),
+                              Profile_RNG19_RFL8_SIG16_NIR16_DUAL>(ls);
+
+    ouster_ros::Point_RNG19_RFL8_SIG16_NIR16_DUAL pt;
+
+    for (auto src_idx = 0U; src_idx < SAMPLES; ++src_idx) {
+        copy_lidar_scan_fields_to_point<0>(pt, ls_tuple, src_idx);
+        EXPECT_EQ(point::get<5>(pt), range(0, src_idx));
+        EXPECT_EQ(point::get<6>(pt), signal(0, src_idx));
+        EXPECT_EQ(point::get<7>(pt), reflect(0, src_idx));
+        EXPECT_EQ(point::get<8>(pt), near_ir(0, src_idx));
+    }
+}

--- a/tests/point_transform_test.cpp
+++ b/tests/point_transform_test.cpp
@@ -1,0 +1,292 @@
+#include <gtest/gtest.h>
+
+#include <random>
+
+// prevent clang-format from altering the location of "ouster_ros/os_ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+#include "ouster_ros/sensor_point_types.h"
+#include "ouster_ros/common_point_types.h"
+#include "ouster_ros/os_point.h"
+#include "../src/point_cloud_compose.h"
+#include "../src/point_meta_helpers.h"
+
+using namespace ouster_ros;
+using namespace ouster_ros::point;
+
+class PointTransformTest : public ::testing::Test {
+    template <std::size_t N, typename PointT>
+    void initialize_point_elements_with_randoms(PointT& pt) {
+        std::default_random_engine g;
+        std::uniform_real_distribution<double> d(0.0, 128.0);
+        point::apply<0, N>(pt, [&g, &d](auto& value) {
+            using value_type = std::remove_reference_t<decltype(value)>;
+            value = static_cast<value_type>(d(g));
+        });
+    }
+
+   protected:
+    void SetUp() override {
+        // pcl + velodyne point types
+        initialize_point_elements_with_randoms<point::size(pt_xyz)>(pt_xyz);
+        initialize_point_elements_with_randoms<point::size(pt_xyzi)>(pt_xyzi);
+        initialize_point_elements_with_randoms<point::size(pt_xyzir)>(pt_xyzir);
+        // native sensor point types
+        initialize_point_elements_with_randoms<point::size(pt_legacy)>(
+            pt_legacy);
+        initialize_point_elements_with_randoms<point::size(
+            pt_rg19_rf8_sg16_nr16_dual)>(pt_rg19_rf8_sg16_nr16_dual);
+        initialize_point_elements_with_randoms<point::size(
+            pt_rg19_rf8_sg16_nr16)>(pt_rg19_rf8_sg16_nr16);
+        initialize_point_elements_with_randoms<point::size(pt_rg15_rfl8_nr8)>(
+            pt_rg15_rfl8_nr8);
+        // ouster_ros original/legacy point type
+        initialize_point_elements_with_randoms<point::size(pt_os_point)>(
+            pt_os_point);
+    }
+
+    void TearDown() override {}
+
+    // pcl & velodyne point types
+    static pcl::PointXYZ pt_xyz;
+    static pcl::PointXYZI pt_xyzi;
+    static PointXYZIR pt_xyzir;
+    // native point types
+    static Point_LEGACY pt_legacy;
+    static Point_RNG19_RFL8_SIG16_NIR16_DUAL pt_rg19_rf8_sg16_nr16_dual;
+    static Point_RNG19_RFL8_SIG16_NIR16 pt_rg19_rf8_sg16_nr16;
+    static Point_RNG15_RFL8_NIR8 pt_rg15_rfl8_nr8;
+    // ouster_ros original/legacy point (not to be confused with Point_LEGACY)
+    static ouster_ros::Point pt_os_point;
+};
+
+// pcl & velodyne point types
+pcl::PointXYZ PointTransformTest::pt_xyz;
+pcl::PointXYZI PointTransformTest::pt_xyzi;
+PointXYZIR PointTransformTest::pt_xyzir;
+// native point types
+Point_LEGACY PointTransformTest::pt_legacy;
+Point_RNG19_RFL8_SIG16_NIR16_DUAL
+    PointTransformTest::pt_rg19_rf8_sg16_nr16_dual;
+Point_RNG19_RFL8_SIG16_NIR16 PointTransformTest::pt_rg19_rf8_sg16_nr16;
+Point_RNG15_RFL8_NIR8 PointTransformTest::pt_rg15_rfl8_nr8;
+// ouster_ros original/legacy point (not to be confused with Point_LEGACY)
+ouster_ros::Point PointTransformTest::pt_os_point;
+
+template <typename PointT, typename PointU>
+void expect_points_xyz_equal(PointT& point1, PointU& point2) {
+    EXPECT_EQ(point1.x, point2.x);
+    EXPECT_EQ(point1.y, point2.y);
+    EXPECT_EQ(point1.z, point2.z);
+}
+
+template <typename PointTGT, typename PointSRC>
+void verify_point_transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
+    // t: timestamp
+    CondBinaryOp<has_t_v<PointTGT> && has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.t, src_pt.t);
+        });
+
+    CondBinaryOp<has_t_v<PointTGT> && !has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt,
+        [](const auto& tgt_pt, const auto&) { EXPECT_EQ(tgt_pt.t, 0U); });
+
+    // ring
+    CondBinaryOp<has_ring_v<PointTGT> && has_ring_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.ring, src_pt.ring);
+        });
+
+    CondBinaryOp<has_ring_v<PointTGT> && !has_ring_v<PointSRC>>::run(
+        tgt_pt, src_pt,
+        [](const auto& tgt_pt, const auto&) { EXPECT_EQ(tgt_pt.ring, 0U); });
+
+    // range
+    CondBinaryOp<has_range_v<PointTGT> && has_range_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.range, src_pt.range);
+        });
+
+    CondBinaryOp<has_range_v<PointTGT> && !has_range_v<PointSRC>>::run(
+        tgt_pt, src_pt,
+        [](const auto& tgt_pt, const auto&) { EXPECT_EQ(tgt_pt.range, 0U); });
+
+    // signal
+    CondBinaryOp<has_signal_v<PointTGT> && has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.signal, src_pt.signal);
+        });
+
+    CondBinaryOp<has_signal_v<PointTGT> && !has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.signal, static_cast<decltype(tgt_pt.signal)>(0));
+        });
+
+    // intensity <- signal
+    CondBinaryOp<has_intensity_v<PointTGT> && has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.intensity,
+                      static_cast<decltype(tgt_pt.intensity)>(src_pt.signal));
+        });
+
+    CondBinaryOp<has_intensity_v<PointTGT> && !has_signal_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.intensity,
+                      static_cast<decltype(tgt_pt.intensity)>(0));
+        });
+
+    // reflectivity
+    CondBinaryOp<has_reflectivity_v<PointTGT> && has_reflectivity_v<PointSRC>>::
+        run(tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.reflectivity, src_pt.reflectivity);
+        });
+
+    CondBinaryOp<has_reflectivity_v<PointTGT> &&
+                 !has_reflectivity_v<PointSRC>>::
+        run(tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.reflectivity,
+                      static_cast<decltype(tgt_pt.reflectivity)>(0));
+        });
+
+    // near_ir
+    CondBinaryOp<has_near_ir_v<PointTGT> && has_near_ir_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.near_ir, src_pt.near_ir);
+        });
+
+    CondBinaryOp<has_near_ir_v<PointTGT> && has_near_ir_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.near_ir, static_cast<decltype(tgt_pt.near_ir)>(0));
+        });
+
+    // ambient <- near_ir
+    CondBinaryOp<has_ambient_v<PointTGT> && has_near_ir_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.ambient,
+                      static_cast<decltype(tgt_pt.ambient)>(src_pt.near_ir));
+        });
+
+    CondBinaryOp<has_ambient_v<PointTGT> && !has_near_ir_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.ambient, static_cast<decltype(tgt_pt.ambient)>(0));
+        });
+}
+
+// lambda function to check that point elements other than xyz have been zeroed
+template <std::size_t N, typename PointT>
+void expect_point_fields_zeros(PointT& pt) {
+    // starting at 3 to skip xyz
+    point::apply<3, N>(pt, [](auto value) {
+        EXPECT_EQ(value, static_cast<decltype(value)>(0));
+    });
+};
+
+TEST_F(PointTransformTest, ExpectPointFieldZeroed) {
+    point::transform(pt_xyzi, pt_xyz);
+    expect_points_xyz_equal(pt_xyzi, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_xyzi)>(pt_xyzi);
+
+    point::transform(pt_xyzir, pt_xyz);
+    expect_points_xyz_equal(pt_xyzir, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_xyzir)>(pt_xyzir);
+
+    point::transform(pt_legacy, pt_xyz);
+    expect_points_xyz_equal(pt_legacy, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_legacy)>(pt_legacy);
+
+    point::transform(pt_rg19_rf8_sg16_nr16_dual, pt_xyz);
+    expect_points_xyz_equal(pt_rg19_rf8_sg16_nr16_dual, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_rg19_rf8_sg16_nr16_dual)>(
+        pt_rg19_rf8_sg16_nr16_dual);
+
+    point::transform(pt_rg19_rf8_sg16_nr16, pt_xyz);
+    expect_points_xyz_equal(pt_rg19_rf8_sg16_nr16, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_rg19_rf8_sg16_nr16)>(
+        pt_rg19_rf8_sg16_nr16);
+
+    point::transform(pt_rg15_rfl8_nr8, pt_xyz);
+    expect_points_xyz_equal(pt_rg15_rfl8_nr8, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_rg15_rfl8_nr8)>(pt_rg15_rfl8_nr8);
+
+    point::transform(pt_os_point, pt_xyz);
+    expect_points_xyz_equal(pt_os_point, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_os_point)>(pt_os_point);
+}
+
+TEST_F(PointTransformTest, TestTransformReduce_LEGACY) {
+    point::transform(pt_xyz, pt_legacy);
+    expect_points_xyz_equal(pt_xyz, pt_legacy);
+    verify_point_transform(pt_xyz, pt_legacy);
+
+    point::transform(pt_xyzi, pt_legacy);
+    expect_points_xyz_equal(pt_xyzi, pt_legacy);
+    verify_point_transform(pt_xyzi, pt_legacy);
+
+    point::transform(pt_xyzir, pt_legacy);
+    expect_points_xyz_equal(pt_xyzir, pt_legacy);
+    verify_point_transform(pt_xyzir, pt_legacy);
+}
+
+TEST_F(PointTransformTest, TestTransformReduce_RNG19_RFL8_SIG16_NIR16_DUAL) {
+    point::transform(pt_xyz, pt_rg19_rf8_sg16_nr16_dual);
+    expect_points_xyz_equal(pt_xyz, pt_rg19_rf8_sg16_nr16_dual);
+    verify_point_transform(pt_xyz, pt_rg19_rf8_sg16_nr16_dual);
+
+    point::transform(pt_xyzi, pt_rg19_rf8_sg16_nr16_dual);
+    expect_points_xyz_equal(pt_xyzi, pt_rg19_rf8_sg16_nr16_dual);
+    verify_point_transform(pt_xyzi, pt_rg19_rf8_sg16_nr16_dual);
+
+    point::transform(pt_xyzir, pt_rg19_rf8_sg16_nr16_dual);
+    expect_points_xyz_equal(pt_xyzir, pt_rg19_rf8_sg16_nr16_dual);
+    verify_point_transform(pt_xyzir, pt_rg19_rf8_sg16_nr16_dual);
+}
+
+TEST_F(PointTransformTest, TestTransformReduce_RNG19_RFL8_SIG16_NIR16) {
+    point::transform(pt_xyz, pt_rg19_rf8_sg16_nr16);
+    expect_points_xyz_equal(pt_xyz, pt_rg19_rf8_sg16_nr16);
+    verify_point_transform(pt_xyz, pt_rg19_rf8_sg16_nr16);
+
+    point::transform(pt_xyzi, pt_rg19_rf8_sg16_nr16);
+    expect_points_xyz_equal(pt_xyzi, pt_rg19_rf8_sg16_nr16);
+    verify_point_transform(pt_xyzi, pt_rg19_rf8_sg16_nr16);
+
+    point::transform(pt_xyzir, pt_rg19_rf8_sg16_nr16);
+    expect_points_xyz_equal(pt_xyzir, pt_rg19_rf8_sg16_nr16);
+    verify_point_transform(pt_xyzir, pt_rg19_rf8_sg16_nr16);
+}
+
+TEST_F(PointTransformTest, TestTransformReduce_RNG15_RFL8_NIR8) {
+    point::transform(pt_xyz, pt_rg15_rfl8_nr8);
+    expect_points_xyz_equal(pt_xyz, pt_rg15_rfl8_nr8);
+    verify_point_transform(pt_xyz, pt_rg15_rfl8_nr8);
+
+    point::transform(pt_xyzi, pt_rg15_rfl8_nr8);
+    expect_points_xyz_equal(pt_xyzi, pt_rg15_rfl8_nr8);
+    verify_point_transform(pt_xyzi, pt_rg15_rfl8_nr8);
+
+    point::transform(pt_xyzir, pt_rg15_rfl8_nr8);
+    expect_points_xyz_equal(pt_xyzir, pt_rg15_rfl8_nr8);
+    verify_point_transform(pt_xyzir, pt_rg15_rfl8_nr8);
+}
+
+TEST_F(PointTransformTest,
+       TestTransform_SensorNativePoints_2_ouster_ros_Point) {
+    point::transform(pt_os_point, pt_legacy);
+    expect_points_xyz_equal(pt_os_point, pt_legacy);
+    verify_point_transform(pt_os_point, pt_legacy);
+
+    point::transform(pt_os_point, pt_rg19_rf8_sg16_nr16_dual);
+    expect_points_xyz_equal(pt_os_point, pt_rg19_rf8_sg16_nr16_dual);
+    verify_point_transform(pt_os_point, pt_rg19_rf8_sg16_nr16_dual);
+
+    point::transform(pt_os_point, pt_rg19_rf8_sg16_nr16);
+    expect_points_xyz_equal(pt_os_point, pt_rg19_rf8_sg16_nr16);
+    verify_point_transform(pt_os_point, pt_rg19_rf8_sg16_nr16);
+
+    point::transform(pt_os_point, pt_rg15_rfl8_nr8);
+    expect_points_xyz_equal(pt_os_point, pt_rg15_rfl8_nr8);
+    verify_point_transform(pt_os_point, pt_rg15_rfl8_nr8);
+}


### PR DESCRIPTION
## Related Issues & PRs
- parent #216 
- resolves #15 
- resolves #29
- resolves #210 
- resolves #97
- related #217
- related #223
- resolves #231 (adds a note to CHANGLOG.rst indicating that the default `ptp_utc_tai_offset` forms a breaking change).  

## Summary of Changes
- added the ability to customize the published point clouds(s) to velodyne point cloud format and
  other common pcl point types.
- made ouster_image_nodelet operate separately from ouster_cloud_nodelet
- added a note to `CHANGLOG.rst` indicating that the default `ptp_utc_tai_offset` forms a breaking change.
- require C++17 for the ROS1 driver starting with v0.11 (C++14 :no_good:)

## Validation (TBD)
- Run the driver with default parameters and verify no observable behavioral changes.
- Change `point_type` parameter to `native` and verify that it reflects the same point cloud format that we get from the sensor.
- Change `point_type` parameter to `xyz` and verify that the published point cloud format only has `xyz` fields, regardless of the underlying sensor format.
- Change `point_type` parameter to `xyzi` and verify that the published point cloud format only has `xyz` fields plus intensity, regardless of the underlying sensor format (you should get a warning when the low data mode is selected for this mode).
- Change `point_type` parameter to `xyzir` and verify that the published point cloud format only has `xyz` fields plus intensity plus ring, regardless of the underlying sensor format (you should get a warning when the low data mode is selected for this mode).