### PR TITLE
launch: Set default ptp offset to 0.0

### DIFF
--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -25,7 +25,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="ptp_utc_tai_offset" default="-37.0"
+  <arg name="ptp_utc_tai_offset" default="0.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -25,7 +25,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="ptp_utc_tai_offset" default="-37.0"
+  <arg name="ptp_utc_tai_offset" default="0.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
   <arg name="metadata" default="" doc="path to write metadata file when receiving sensor data"/>
   <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -7,7 +7,7 @@
     possible values: {
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="ptp_utc_tai_offset" default="-37.0"
+  <arg name="ptp_utc_tai_offset" default="0.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -25,7 +25,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="ptp_utc_tai_offset" default="-37.0"
+  <arg name="ptp_utc_tai_offset" default="0.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
 
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -29,7 +29,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <arg name="ptp_utc_tai_offset" default="-37.0"
+  <arg name="ptp_utc_tai_offset" default="0.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
 
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>


### PR DESCRIPTION
## Related Issues & PRs
-
## Summary of Changes
`ptp_utc_tai_offset` is set to `-37.0` in all launch files on current master to reflect the current difference in seconds between TAI and UTC.

On my robot with ptp config already set up, this resulted in all my clouds to have a 37 sec offset from the rest of my system in `TIME_FROM_PTP_1588` mode.


## Validation
Ran driver with proposed changes and saw that clouds where in sync with rest of system.