### PR TITLE
Cmakelists: Fix install directories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog
 * added the ability to customize the published point clouds(s) to velodyne point cloud format and
   other common pcl point types.
 * ouster_image_nodelet can operate independently from ouster_cloud_nodelet.
-
+* install ouster-ros and ouster_client include directories in separate folders.
 
 ouster_ros v0.10.0
 ==================
@@ -80,7 +80,7 @@ ouster_ros(1)
 * added a no-bond option to the ``sensor.launch`` file
 * reduce the publish rate of imu tf transforms
 * implemented a new node named ``os_driver`` which combines the functionality of ``os_sensor``,
-  ``os_cloud`` and ``os_image`` into a single node. The new node can be launch via the new 
+  ``os_cloud`` and ``os_image`` into a single node. The new node can be launch via the new
   ``driver.launch`` file.
 * introduced a new topic ``/ouster/scan`` which publishes ``sensor_msgs::LaserScan`` messages, the
   user can pick which beam to be used for the message through the ``scan_ring`` launch argument.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,8 @@ install(
 
 install(
   DIRECTORY ouster-sdk/ouster_client/include/optional-lite/nonstd/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/../nonstd
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/../ouster/nonstd/
 )
-
 install(
   FILES
     LICENSE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,18 @@ install(
 )
 
 install(
-  DIRECTORY ${_ouster_ros_INCLUDE_DIRS}
+  DIRECTORY include/ouster_ros/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(
+  DIRECTORY ouster-sdk/ouster_client/include/ouster/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/../ouster
+)
+
+install(
+  DIRECTORY ouster-sdk/ouster_client/include/optional-lite/nonstd/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/../nonstd
 )
 
 install(

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.11.0</version>
+  <version>0.12.0</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>
@@ -24,7 +24,7 @@
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>curl</build_depend>
   <build_depend>spdlog</build_depend>
-  
+
   <exec_depend>nodelet</exec_depend>
   <exec_depend>libjsoncpp</exec_depend>
   <exec_depend>message_runtime</exec_depend>


### PR DESCRIPTION
This fixes issues of including headers from ouster_client or nonstd when using install space.

Folder layout  on current master:
![image](https://github.com/ouster-lidar/ouster-ros/assets/50892582/7a73f3f2-3f91-458b-b413-e72757d60d8b)

Note e.g. `os_point.h` being located in `install/include/ouster_ros/include/ouster_ros/os_point.h`
instead of just `install/include/ouster_ros/os_point.h` where I would expect it to be.

How `install/include` looks after this PR:
![image](https://github.com/ouster-lidar/ouster-ros/assets/50892582/a56c1176-57d4-4251-8c88-81ad802f77a1)
![image](https://github.com/ouster-lidar/ouster-ros/assets/50892582/6c0aabf6-ef32-4dc1-bfd9-72b917226066)
and so on..

This means that if you are using e.g. `stagger` function from `lidar_scan.h` in you own ros_pkg, you can now:

```
#include <ouster/lidar_scan.h>
ouster::stagger(my_img,pixel_shift_vec)
```


## Related Issues & PRs
-
## Summary of Changes
Update install path in CmakeLists.txt
## Validation
Included header from ouster_client and compiled with install space. It works! 