### PR TITLE
Param min packets in cloud

### DIFF
--- a/launch/common.launch
+++ b/launch/common.launch
@@ -41,6 +41,15 @@
     xyzir
     }"/>
 
+  <arg name="min_lidar_packets_per_cloud" doc="Each cloud is built up of an expected
+  amount of udp packets. With this set to 0, the driver will publish all clouds regardless
+  of how many packets it received. If set to a positive integer, the driver will discard the entire
+  cloud if it does not consist of at least this many udp packets.
+  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
+  To calculate the number of expected packets, use the following formula:
+
+  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
+  />
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
@@ -60,6 +69,7 @@
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
       <param name="~/ptp_utc_tai_offset" type="double" value="$(arg ptp_utc_tai_offset)"/>
       <param name="~/point_type" value="$(arg point_type)"/>
+      <param name="~/min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
     </node>
   </group>
 

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -41,15 +41,12 @@
     xyzir
     }"/>
 
-  <arg name="min_lidar_packets_per_cloud" doc="Each cloud is built up of an expected
-  amount of udp packets. With this set to 0, the driver will publish all clouds regardless
-  of how many packets it received. If set to a positive integer, the driver will discard the entire
-  cloud if it does not consist of at least this many udp packets.
-  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
-  To calculate the number of expected packets, use the following formula:
-
-  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
-  />
+  <arg name="num_columns_required" doc="
+    Each pointcloud is built from a number of UDP data packets. If some packets are
+    lost, the pointcloud will be incomplete. If you set this to zero, all pointclouds
+    will be published regardless of completeness. If set to a positive integer,
+    pointclouds with fewer than the specified number of columns will not be published.
+    The number of columns is the same as the width of the pointcloud (512, 1024, etc)."/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
@@ -69,7 +66,7 @@
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
       <param name="~/ptp_utc_tai_offset" type="double" value="$(arg ptp_utc_tai_offset)"/>
       <param name="~/point_type" value="$(arg point_type)"/>
-      <param name="~/min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
+      <param name="~/num_columns_required" value="$(arg num_columns_required)"/>
     </node>
   </group>
 
@@ -77,6 +74,7 @@
     <node pkg="nodelet" type="nodelet" name="img_node"
       output="screen" required="true"
       args="load ouster_ros/OusterImage os_nodelet_mgr $(arg _no_bond)">
+      <param name="~/num_columns_required" value="$(arg num_columns_required)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -64,16 +64,12 @@
     xyzir
     }"/>
 
-  <arg name="min_lidar_packets_per_cloud" default="0"
-  doc="Each cloud is built up of an expected amount of udp packets. With this set
-  to 0, the driver will publish all clouds regardless of how many packets it
-  received. If set to a positive integer, the driver will discard the entire
-  cloud if it does not consist of at least this many udp packets.
-  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
-  To calculate the number of expected packets, use the following formula:
-
-  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
-  />
+  <arg name="num_columns_required" default="0" doc=" Each pointcloud is built from a number
+    of UDP data packets. If some packets are lost, the pointcloud will be incomplete.
+    If you set this to zero, all pointclouds will be published regardless of completeness.
+    If set to a positive integer, pointclouds with fewer than the specified number of columns
+    will not be published.
+    The number of columns is the same as the width of the pointcloud (512, 1024, etc)."/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -102,7 +98,7 @@
       <param name="~/proc_mask" value="$(arg proc_mask)"/>
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
       <param name="~/point_type" value="$(arg point_type)"/>
-      <param name="~/min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
+      <param name="~/num_columns_required" value="$(arg num_columns_required)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -64,6 +64,17 @@
     xyzir
     }"/>
 
+  <arg name="min_lidar_packets_per_cloud" default="0"
+  doc="Each cloud is built up of an expected amount of udp packets. With this set
+  to 0, the driver will publish all clouds regardless of how many packets it
+  received. If set to a positive integer, the driver will discard the entire
+  cloud if it does not consist of at least this many udp packets.
+  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
+  To calculate the number of expected packets, use the following formula:
+
+  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
+  />
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -91,6 +102,7 @@
       <param name="~/proc_mask" value="$(arg proc_mask)"/>
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
       <param name="~/point_type" value="$(arg point_type)"/>
+      <param name="~/min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
     </node>
   </group>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -67,16 +67,12 @@
     xyzir
     }"/>
 
-  <arg name="min_lidar_packets_per_cloud" default="0"
-  doc="Each cloud is built up of an expected amount of udp packets. With this set
-  to 0, the driver will publish all clouds regardless of how many packets it
-  received. If set to a positive integer, the driver will discard the entire
-  cloud if it does not consist of at least this many udp packets.
-  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
-  To calculate the number of expected packets, use the following formula:
-
-  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
-  />
+  <arg name="num_columns_required" default="0" doc=" Each pointcloud is built from a number
+    of UDP data packets. If some packets are lost, the pointcloud will be incomplete.
+    If you set this to zero, all pointclouds will be published regardless of completeness.
+    If set to a positive integer, pointclouds with fewer than the specified number of columns
+    will not be published.
+    The number of columns is the same as the width of the pointcloud (512, 1024, etc)."/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -117,7 +113,7 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
-    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
+    <arg name="num_columns_required" value="$(arg num_columns_required)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -67,6 +67,17 @@
     xyzir
     }"/>
 
+  <arg name="min_lidar_packets_per_cloud" default="0"
+  doc="Each cloud is built up of an expected amount of udp packets. With this set
+  to 0, the driver will publish all clouds regardless of how many packets it
+  received. If set to a positive integer, the driver will discard the entire
+  cloud if it does not consist of at least this many udp packets.
+  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
+  To calculate the number of expected packets, use the following formula:
+
+  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
+  />
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -106,6 +117,7 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
+    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -47,6 +47,17 @@
     xyzir
     }"/>
 
+  <arg name="min_lidar_packets_per_cloud" default="0"
+  doc="Each cloud is built up of an expected amount of udp packets. With this set
+  to 0, the driver will publish all clouds regardless of how many packets it
+  received. If set to a positive integer, the driver will discard the entire
+  cloud if it does not consist of at least this many udp packets.
+  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
+  To calculate the number of expected packets, use the following formula:
+
+  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
+  />
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -81,6 +92,7 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
+    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -47,16 +47,12 @@
     xyzir
     }"/>
 
-  <arg name="min_lidar_packets_per_cloud" default="0"
-  doc="Each cloud is built up of an expected amount of udp packets. With this set
-  to 0, the driver will publish all clouds regardless of how many packets it
-  received. If set to a positive integer, the driver will discard the entire
-  cloud if it does not consist of at least this many udp packets.
-  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
-  To calculate the number of expected packets, use the following formula:
-
-  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
-  />
+  <arg name="num_columns_required" default="0" doc=" Each pointcloud is built from a number
+    of UDP data packets. If some packets are lost, the pointcloud will be incomplete.
+    If you set this to zero, all pointclouds will be published regardless of completeness.
+    If set to a positive integer, pointclouds with fewer than the specified number of columns
+    will not be published.
+    The number of columns is the same as the width of the pointcloud (512, 1024, etc)."/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -92,7 +88,7 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
-    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
+    <arg name="num_columns_required" value="$(arg num_columns_required)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -72,16 +72,12 @@
     xyzir
     }"/>
 
-  <arg name="min_lidar_packets_per_cloud" default="0"
-  doc="Each cloud is built up of an expected amount of udp packets. With this set
-  to 0, the driver will publish all clouds regardless of how many packets it
-  received. If set to a positive integer, the driver will discard the entire
-  cloud if it does not consist of at least this many udp packets.
-  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
-  To calculate the number of expected packets, use the following formula:
-
-  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
-  />
+  <arg name="num_columns_required" default="0" doc=" Each pointcloud is built from a number
+    of UDP data packets. If some packets are lost, the pointcloud will be incomplete.
+    If you set this to zero, all pointclouds will be published regardless of completeness.
+    If set to a positive integer, pointclouds with fewer than the specified number of columns
+    will not be published.
+    The number of columns is the same as the width of the pointcloud (512, 1024, etc)."/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -122,7 +118,7 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
-    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
+    <arg name="num_columns_required" value="$(arg num_columns_required)"/>
   </include>
 
 </launch>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -72,6 +72,17 @@
     xyzir
     }"/>
 
+  <arg name="min_lidar_packets_per_cloud" default="0"
+  doc="Each cloud is built up of an expected amount of udp packets. With this set
+  to 0, the driver will publish all clouds regardless of how many packets it
+  received. If set to a positive integer, the driver will discard the entire
+  cloud if it does not consist of at least this many udp packets.
+  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
+  To calculate the number of expected packets, use the following formula:
+
+  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
+  />
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -111,6 +122,7 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
+    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
   </include>
 
 </launch>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -76,16 +76,12 @@
     xyzir
     }"/>
 
-  <arg name="min_lidar_packets_per_cloud" default="0"
-  doc="Each cloud is built up of an expected amount of udp packets. With this set
-  to 0, the driver will publish all clouds regardless of how many packets it
-  received. If set to a positive integer, the driver will discard the entire
-  cloud if it does not consist of at least this many udp packets.
-  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
-  To calculate the number of expected packets, use the following formula:
-
-  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
-  />
+  <arg name="num_columns_required" default="0" doc=" Each pointcloud is built from a number
+    of UDP data packets. If some packets are lost, the pointcloud will be incomplete.
+    If you set this to zero, all pointclouds will be published regardless of completeness.
+    If set to a positive integer, pointclouds with fewer than the specified number of columns
+    will not be published.
+    The number of columns is the same as the width of the pointcloud (512, 1024, etc)."/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -129,7 +125,7 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
-    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
+    <arg name="num_columns_required" value="$(arg num_columns_required)"/>
 
   </include>
 

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -76,6 +76,17 @@
     xyzir
     }"/>
 
+  <arg name="min_lidar_packets_per_cloud" default="0"
+  doc="Each cloud is built up of an expected amount of udp packets. With this set
+  to 0, the driver will publish all clouds regardless of how many packets it
+  received. If set to a positive integer, the driver will discard the entire
+  cloud if it does not consist of at least this many udp packets.
+  Number of expected packets is dependent on lidar_mode and udp_profile_lidar.
+  To calculate the number of expected packets, use the following formula:
+
+  num_expected_packets = info.format.columns_per_frame * info.format.columns_per_packet"
+  />
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true"
@@ -118,6 +129,8 @@
     <arg name="proc_mask" value="$(arg proc_mask)"/>
     <arg name="scan_ring" value="$(arg scan_ring)"/>
     <arg name="point_type" value="$(arg point_type)"/>
+    <arg name="min_lidar_packets_per_cloud" value="$(arg min_lidar_packets_per_cloud)"/>
+
   </include>
 
 </launch>

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -120,11 +120,27 @@ class LidarPacketHandler {
     static HandlerType create_handler(
         const ouster::sensor::sensor_info& info,
         const std::vector<LidarScanProcessor>& handlers,
-        const std::string& timestamp_mode, int64_t ptp_utc_tai_offset) {
+        const std::string& timestamp_mode, int64_t ptp_utc_tai_offset,
+        const int min_lidar_packets_per_cloud) {
         auto handler = std::make_shared<LidarPacketHandler>(
             info, handlers, timestamp_mode, ptp_utc_tai_offset);
-        return [handler](const uint8_t* lidar_buf) {
+        return [handler, info,
+                min_lidar_packets_per_cloud](const uint8_t* lidar_buf) {
+            thread_local int num_packets_in_cloud = 0;
+            num_packets_in_cloud++;
+
             if (handler->lidar_packet_accumlator(lidar_buf)) {
+                if (num_packets_in_cloud < min_lidar_packets_per_cloud) {
+                    ROS_WARN_STREAM_THROTTLE(
+                        0.1,
+                        "Incomplete cloud, dropping it. Got "
+                            << num_packets_in_cloud << ", expected "
+                            << min_lidar_packets_per_cloud << " lidar packets.");
+                    num_packets_in_cloud = 0;
+                    return;
+              }
+              num_packets_in_cloud = 0;
+
                 for (auto h : handler->lidar_scan_handlers) {
                     h(*handler->lidar_scan, handler->lidar_scan_estimated_ts,
                       handler->lidar_scan_estimated_msg_ts);

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -171,10 +171,13 @@ class OusterCloud : public nodelet::Nodelet {
                 }));
         }
 
+        const int min_lidar_packets_per_cloud =
+            pnh.param("min_lidar_packets_per_cloud", 0);
         if (impl::check_token(tokens, "PCL") || impl::check_token(tokens, "SCAN")) {
             lidar_packet_handler = LidarPacketHandler::create_handler(
                 info, processors, timestamp_mode,
-                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
+                min_lidar_packets_per_cloud);
             lidar_packet_sub = nh.subscribe<PacketMsg>(
                 "lidar_packets", 100, [this](const PacketMsg::ConstPtr msg) {
                     lidar_packet_handler(msg->buf.data());

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -156,11 +156,14 @@ class OusterDriver : public OusterSensor {
                 }));
         }
 
+        const int min_lidar_packets_per_cloud =
+            pnh.param("min_lidar_packets_per_cloud", 0);
         if (impl::check_token(tokens, "PCL") || impl::check_token(tokens, "SCAN") ||
             impl::check_token(tokens, "IMG"))
             lidar_packet_handler = LidarPacketHandler::create_handler(
                 info, processors, timestamp_mode,
-                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
+                min_lidar_packets_per_cloud);
     }
 
     virtual void on_lidar_packet_msg(const uint8_t* raw_lidar_packet) override {

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -50,7 +50,7 @@ class OusterImage : public nodelet::Nodelet {
     }
 
     void create_publishers_subscribers(int n_returns) {
-        // TODO: avoid having to replicate the parameters: 
+        // TODO: avoid having to replicate the parameters:
         // timestamp_mode, ptp_utc_tai_offset, use_system_default_qos in yet
         // another node.
         auto& pnh = getPrivateNodeHandle();
@@ -94,9 +94,12 @@ class OusterImage : public nodelet::Nodelet {
                 })
         };
 
+        const int min_lidar_packets_per_cloud =
+            pnh.param("min_lidar_packets_per_cloud", 0);
         lidar_packet_handler = LidarPacketHandler::create_handler(
             info, processors, timestamp_mode,
-            static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+            static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
+            min_lidar_packets_per_cloud);
         lidar_packet_sub = nh.subscribe<PacketMsg>(
                 "lidar_packets", 100,
                 [this](const PacketMsg::ConstPtr msg) {


### PR DESCRIPTION
## Related Issues & PRs
https://github.com/ouster-lidar/ouster-ros/issues/265

## Summary of Changes
This adds a parameter the user can alter in order to discard clouds that consists of x amount of lidar packets.

## Validation
I have an example bag where we experienced bad connectivity to lidar, resulting in dropped lidar packets.

Validated this PR by doing the following with replay of named bag:

Set param to 0, see that behaviour is as before:

https://github.com/ouster-lidar/ouster-ros/assets/50892582/e839fc11-c927-4c12-be15-a6afefffb2c3

Set param to 500 (I'm in lidar_mode 512x64)

https://github.com/ouster-lidar/ouster-ros/assets/50892582/1edc9f19-1f2a-4533-861d-bc8a80ddc874



corresponding terminal output:
![image](https://github.com/ouster-lidar/ouster-ros/assets/50892582/9fb737cf-99ab-4ca7-9da6-06aca2d49fdb)