### PR TITLE
ROS-287: Ouster support for Apollo

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ New launch file parameter:
   - `xyzir`: same as xyzi type but adds ring (channel) field.
           this type is same as Velodyne point cloud type
           this type is not compatible with the low data profile.
+  - `xyzit`: same as xyzi type but adds timestamp field.
+          this type is not compatible with the low data profile.
 
 ### Invoking Services
 To execute any of the following service, first you need to open a new terminal

--- a/include/ouster_ros/common_point_types.h
+++ b/include/ouster_ros/common_point_types.h
@@ -56,17 +56,66 @@ struct PointXYZIR : public _PointXYZIR {
     }
 };
 
+/*
+ * Same as Apollo point cloud type
+ * @remark XYZIT point type is not compatible with RNG15_RFL8_NIR8/LOW_DATA
+ * udp lidar profile.
+ */
+struct EIGEN_ALIGN16 _PointXYZIT {
+    PCL_ADD_POINT4D;
+    uint32_t intensity;
+    uint64_t timestamp;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct PointXYZIT : public _PointXYZIT {
+
+    inline PointXYZIT(const _PointXYZIT& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      intensity = pt.intensity; timestamp = pt.timestamp;
+    }
+
+    inline PointXYZIT()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      intensity = 0.0f; timestamp = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, intensity, timestamp);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity, timestamp);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
 }   // namespace ouster_ros
 
 // clang-format off
 
 /* common point types */
+
 POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIR,
     (float, x, x)
     (float, y, y)
     (float, z, z)
     (float, intensity, intensity)
     (std::uint16_t, ring, ring)
+)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIT,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, intensity, intensity)
+    (std::uint16_t, timestamp, timestamp)
 )
 
 // clang-format on

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -38,7 +38,8 @@
     native,
     xyz,
     xyzi,
-    xyzir
+    xyzir,
+    xyzit
     }"/>
 
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -61,7 +61,8 @@
     native,
     xyz,
     xyzi,
-    xyzir
+    xyzir,
+    xyzit
     }"/>
 
   <group ns="$(arg ouster_ns)">

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -44,7 +44,8 @@
     native,
     xyz,
     xyzi,
-    xyzir
+    xyzir,
+    xyzit
     }"/>
 
   <group ns="$(arg ouster_ns)">

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -69,7 +69,8 @@
     native,
     xyz,
     xyzi,
-    xyzir
+    xyzir,
+    xyzit
     }"/>
 
   <group ns="$(arg ouster_ns)">

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -73,7 +73,8 @@
     native,
     xyz,
     xyzi,
-    xyzir
+    xyzir,
+    xyzit
     }"/>
 
   <group ns="$(arg ouster_ns)">

--- a/src/point_cloud_processor_factory.h
+++ b/src/point_cloud_processor_factory.h
@@ -97,7 +97,7 @@ class PointCloudProcessorFactory {
    public:
     static bool point_type_requires_intensity(const std::string& point_type) {
         return point_type == "xyzi" || point_type == "xyzir" ||
-               point_type == "original";
+               point_type == "xyzit" || point_type == "original";
     }
 
     static LidarScanProcessor create_point_cloud_processor(
@@ -138,6 +138,10 @@ class PointCloudProcessorFactory {
                 post_processing_fn);
         } else if (point_type == "xyzir") {
             return make_point_cloud_procssor<PointXYZIR>(
+                info, frame, apply_lidar_to_sensor_transform,
+                post_processing_fn);
+        } else if (point_type == "xyzit") {
+            return make_point_cloud_procssor<PointXYZIT>(
                 info, frame, apply_lidar_to_sensor_transform,
                 post_processing_fn);
         } else if (point_type == "original") {

--- a/src/point_transform.h
+++ b/src/point_transform.h
@@ -19,6 +19,7 @@ DEFINE_MEMBER_CHECKER(x);
 DEFINE_MEMBER_CHECKER(y);
 DEFINE_MEMBER_CHECKER(z);
 DEFINE_MEMBER_CHECKER(t);
+DEFINE_MEMBER_CHECKER(timestamp);
 DEFINE_MEMBER_CHECKER(ring);
 DEFINE_MEMBER_CHECKER(intensity);
 DEFINE_MEMBER_CHECKER(ambient);
@@ -39,6 +40,15 @@ void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
 
     CondBinaryOp<has_t_v<PointTGT> && !has_t_v<PointSRC>>::run(
         tgt_pt, src_pt, [](auto& tgt_pt, const auto&) { tgt_pt.t = 0U; }
+    );
+
+    // t: timestamp
+    CondBinaryOp<has_timestamp_v<PointTGT> && has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { tgt_pt.timestamp = src_pt.t; }
+    );
+
+    CondBinaryOp<has_timestamp_v<PointTGT> && !has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) { tgt_pt.timestamp = 0U; }
     );
 
     // ring


### PR DESCRIPTION
## Related Issues & PRs
- Closes #287

## Summary of Changes
* Quick prototype of adding support for the Apollo's PointXYZIT point type using [Point Cloud Customization feature](https://github.com/ouster-lidar/ouster-ros/discussions/260)

## Validation
* Run the driver with following command:
  `roslaunch ouster_ros sensor_hostname:=os-xxxxxx.loca" point_type:=xyzit`
* Observe that the generated point cloud has the fields {x, y, z, intensity, timestamp} populated with the right values.