### PR TITLE
ROS-288: ROS2 crashes when standby mode is set and then set to normal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 * [BUGFIX]: LaserScan is not properly aligned with generated point cloud
   * address an issue where LaserScan appeared different on FW prior to 2.4
 * [BUGFIX]: LaserScan does not work when using dual mode
+* [BUGFIX]: ROS2 crashes when standby mode is set and then set to normal
 
 ouster_ros v0.12.0
 ==================

--- a/ouster-ros/launch/driver.launch.py
+++ b/ouster-ros/launch/driver.launch.py
@@ -50,6 +50,7 @@ def generate_launch_description():
         namespace=ouster_ns,
         parameters=[params_file],
         output='screen',
+        arguments=['--ros-args', '--log-level', 'debug']
     )
 
     sensor_configure_event = EmitEvent(

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.12.1</version>
+  <version>0.12.2</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -801,9 +801,9 @@ void OusterSensor::start_packet_processing_threads() {
     imu_packets_processing_thread_active = true;
     imu_packets_processing_thread = std::make_unique<std::thread>([this]() {
         while (imu_packets_processing_thread_active) {
-            imu_packets->read([this](const uint8_t* buffer) {
-                on_imu_packet_msg(buffer);
-            });
+            imu_packets->read_timeout([this](const uint8_t* buffer) {
+                if (buffer != nullptr) on_imu_packet_msg(buffer);
+            }, 1s);
         }
         RCLCPP_DEBUG(get_logger(), "imu_packets_processing_thread done.");
     });
@@ -811,9 +811,9 @@ void OusterSensor::start_packet_processing_threads() {
     lidar_packets_processing_thread_active = true;
     lidar_packets_processing_thread = std::make_unique<std::thread>([this]() {
         while (lidar_packets_processing_thread_active) {
-            lidar_packets->read([this](const uint8_t* buffer) {
-                on_lidar_packet_msg(buffer);
-            });
+            lidar_packets->read_timeout([this](const uint8_t* buffer) {
+                if (buffer != nullptr) on_lidar_packet_msg(buffer);
+            }, 1s);
         }
         RCLCPP_DEBUG(get_logger(), "lidar_packets_processing_thread done.");
     });

--- a/ouster-sensor-msgs/package.xml
+++ b/ouster-sensor-msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_sensor_msgs</name>
-  <version>0.12.0</version>
+  <version>0.12.2</version>
   <description>ouster_ros message and service definitions</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
- humble PR: []
- related: #288

## Summary of Changes
- Use timeout when waiting for packets to be proceed in case no packets are coming

## Validation
- functionality sustained
- launch a ros2 node then perform a set_config call with STANDBY mode, see the driver idles
- perform a follow set_config call this time with NORMAL mode and verify that driver resumes