### PR TITLE
Atomic refactor for lock-free ringbuffer [Foxy]

### DIFF
--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -186,13 +186,13 @@ class OusterDriver : public OusterSensor {
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
     }
 
-    virtual void on_lidar_packet_msg(const uint8_t* raw_lidar_packet) override {
-        if (lidar_packet_handler) lidar_packet_handler(raw_lidar_packet);
+    void process_lidar_packet() override {
+        if (lidar_packet_handler) lidar_packet_handler(lidar_packet.buf.data());
     }
 
-    virtual void on_imu_packet_msg(const uint8_t* raw_imu_packet) override {
+    void process_imu_packet() override {
         if (imu_packet_handler)
-            imu_pub->publish(imu_packet_handler(raw_imu_packet));
+            imu_pub->publish(imu_packet_handler(imu_packet.buf.data()));
     }
 
     virtual void cleanup() override {

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -840,7 +840,7 @@ void OusterSensor::on_lidar_packet_msg(const uint8_t* raw_lidar_packet) {
     // now we are focusing on optimizing the code for OusterDriver
     std::memcpy(lidar_packet.buf.data(), raw_lidar_packet,
                 lidar_packet.buf.size());
-    lidar_packet_pub->publish(lidar_packet);
+    process_lidar_packet();
 }
 
 void OusterSensor::on_imu_packet_msg(const uint8_t* raw_imu_packet) {
@@ -849,8 +849,14 @@ void OusterSensor::on_imu_packet_msg(const uint8_t* raw_imu_packet) {
     // OusterSensor has its own RingBuffer of PacketMsg but for
     // now we are focusing on optimizing the code for OusterDriver
     std::memcpy(imu_packet.buf.data(), raw_imu_packet, imu_packet.buf.size());
-    imu_packet_pub->publish(imu_packet);
+    process_imu_packet();
 }
+
+void OusterSensor::process_lidar_packet() {
+  lidar_packet_pub->publish(lidar_packet);
+}
+
+void OusterSensor::process_imu_packet() { imu_packet_pub->publish(imu_packet); }
 
 }  // namespace ouster_ros
 

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -61,9 +61,9 @@ class OusterSensor : public OusterSensorNodeBase {
 
     virtual void create_publishers();
 
-    virtual void on_lidar_packet_msg(const uint8_t* raw_lidar_packet);
+    virtual void process_lidar_packet();
 
-    virtual void on_imu_packet_msg(const uint8_t* raw_imu_packet);
+    virtual void process_imu_packet();
 
     virtual void cleanup();
 
@@ -141,6 +141,14 @@ class OusterSensor : public OusterSensorNodeBase {
 
     void stop_packet_processing_threads();
 
+    void on_lidar_packet_msg(const uint8_t* raw_lidar_packet);
+
+    void on_imu_packet_msg(const uint8_t* raw_imu_packet);
+
+   protected:
+    ouster_sensor_msgs::msg::PacketMsg lidar_packet;
+    ouster_sensor_msgs::msg::PacketMsg imu_packet;
+
    private:
     std::string sensor_hostname;
     std::string staged_config;
@@ -148,8 +156,6 @@ class OusterSensor : public OusterSensorNodeBase {
     std::string mtp_dest;
     bool mtp_main;
     std::shared_ptr<sensor::client> sensor_client;
-    ouster_sensor_msgs::msg::PacketMsg lidar_packet;
-    ouster_sensor_msgs::msg::PacketMsg imu_packet;
     rclcpp_lifecycle::LifecyclePublisher<ouster_sensor_msgs::msg::PacketMsg>::SharedPtr
         lidar_packet_pub;
     rclcpp_lifecycle::LifecyclePublisher<ouster_sensor_msgs::msg::PacketMsg>::SharedPtr

--- a/ouster-ros/src/thread_safe_ring_buffer.h
+++ b/ouster-ros/src/thread_safe_ring_buffer.h
@@ -135,10 +135,18 @@ class ThreadSafeRingBuffer {
   protected:
     /**
      * Resets the write_idx to an initial value.
-     * @remarks Should be mostly used by tests to allow reading of the final
-     * item left in the buffer.
+     * @remarks
+     *  Should be mostly used by tests to allow reading of the final item left
+     *  in the buffer or restarting the test scenario.
      */
     void reset_write_idx() { write_idx = SIZE_MAX; }
+
+    /**
+     * Resets the read_idx to an initial value.
+     * @remarks
+     *  Should be mostly used by tests to allow restarting the test scenario.
+     */
+    void reset_read_idx() { read_idx = SIZE_MAX; }
 
    private:
      /**

--- a/ouster-ros/src/thread_safe_ring_buffer.h
+++ b/ouster-ros/src/thread_safe_ring_buffer.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <vector>
@@ -22,13 +23,15 @@ class ThreadSafeRingBuffer {
           item_size(item_size_),
           max_items_count(items_count_),
           active_items_count(0),
-          write_idx(0),
-          read_idx(0) {}
+          write_idx(SIZE_MAX),
+          read_idx(SIZE_MAX),
+          new_data_lock(mutex, std::defer_lock),
+          free_space_lock(mutex, std::defer_lock) {}
 
     /**
      * Gets the maximum number of items that this ring buffer can hold.
      */
-    size_t capacity() const { return max_items_count; }
+    [[nodiscard]] size_t capacity() const { return max_items_count; }
 
     /**
      * Gets the number of item that currently occupy the ring buffer. This
@@ -39,10 +42,7 @@ class ThreadSafeRingBuffer {
      *  this does not guarantee that a subsequent call to read() or write()
      *  wouldn't cause the calling thread to be blocked.
      */
-    size_t size() const {
-        std::lock_guard<std::mutex> lock(mutex);
-        return active_items_count;
-    }
+    [[nodiscard]] size_t size() const { return active_items_count.load(); }
 
     /**
      * Checks if the ring buffer is empty.
@@ -51,10 +51,7 @@ class ThreadSafeRingBuffer {
      *  if empty() returns true this does not guarantee that calling the write()
      *  operation directly right after wouldn't block the calling thread.
      */
-    bool empty() const {
-        std::lock_guard<std::mutex> lock(mutex);
-        return active_items_count == 0;
-    }
+    [[nodiscard]] bool empty() const { return active_items_count.load() == 0; }
 
     /**
      * Checks if the ring buffer is full.
@@ -63,84 +60,172 @@ class ThreadSafeRingBuffer {
      *  if full() returns true this does not guarantee that calling the read()
      *  operation directly right after wouldn't block the calling thread.
      */
-    bool full() const {
-        std::lock_guard<std::mutex> lock(mutex);
-        return active_items_count == max_items_count;
+    [[nodiscard]] bool full() const {
+        return active_items_count.load() == capacity();
     }
 
     /**
-     * Writes to the buffer safely, the method will keep blocking until the
+     * Writes to the buffer safely, this method will keep blocking until the
      * there is a space available within the buffer.
      */
     template <class BufferWriteFn>
     void write(BufferWriteFn&& buffer_write) {
-        std::unique_lock<std::mutex> lock(mutex);
-        fullCondition.wait(lock,
-                           [this] { return active_items_count < capacity(); });
-        buffer_write(&buffer[write_idx * item_size]);
-        write_idx = (write_idx + 1) % capacity();
-        ++active_items_count;
-        emptyCondition.notify_one();
+        free_space_lock.lock();
+        free_space_condition.wait(free_space_lock, [this] { return !full(); });
+        free_space_lock.unlock();
+        perform_write(buffer_write);
     }
 
     /**
-     * Writes to the buffer safely, if there is not space left then this method
-     * will overite the last item.
+     * Writes to the buffer safely, if there is no space left, then this method
+     * will overwrite the last item.
      */
     template <class BufferWriteFn>
     void write_overwrite(BufferWriteFn&& buffer_write) {
-        std::unique_lock<std::mutex> lock(mutex);
-        buffer_write(&buffer[write_idx * item_size]);
-        write_idx = (write_idx + 1) % capacity();
-        if (active_items_count < capacity()) {
-            ++active_items_count;
-        } else {
-            read_idx = (read_idx + 1) % capacity();
-        }
-        emptyCondition.notify_one();
+        perform_write(buffer_write);
     }
 
     /**
-     * Gives access to read the buffer through a callback, the method will block
-     * until there is something to read is available.
+     * Writes to the buffer safely, this method will return immediately and if
+     * there is no space left, the data will not be written (will be dropped).
+     */
+    template <class BufferWriteFn>
+    void write_nonblock(BufferWriteFn&& buffer_write) {
+        if (!full()) perform_write(buffer_write);
+    }
+
+    /**
+     * Gives access to read the buffer through a callback, this method will block
+     * until there is something to read available.
      */
     template <typename BufferReadFn>
     void read(BufferReadFn&& buffer_read) {
-        std::unique_lock<std::mutex> lock(mutex);
-        emptyCondition.wait(lock, [this] { return active_items_count > 0; });
-        buffer_read(&buffer[read_idx * item_size]);
-        read_idx = (read_idx + 1) % capacity();
-        --active_items_count;
-        fullCondition.notify_one();
+        new_data_lock.lock();
+        new_data_condition.wait(new_data_lock, [this] { return !empty(); });
+        new_data_lock.unlock();
+        perform_read(buffer_read);
     }
 
     /**
      * Gives access to read the buffer through a callback, if buffer is
-     * inaccessible the method will timeout and buffer_read gets a nullptr.
+     * inaccessible this method will timeout and the callback is not performed.
      */
     template <typename BufferReadFn>
     void read_timeout(BufferReadFn&& buffer_read,
                       std::chrono::seconds timeout) {
-        std::unique_lock<std::mutex> lock(mutex);
-        if (emptyCondition.wait_for(
-                lock, timeout, [this] { return active_items_count > 0; })) {
-            buffer_read(&buffer[read_idx * item_size]);
-            read_idx = (read_idx + 1) % capacity();
-            --active_items_count;
-            fullCondition.notify_one();
-        } else {
-            buffer_read((uint8_t*)nullptr);
+        new_data_lock.lock();
+        if (new_data_condition.wait_for(
+                new_data_lock, timeout, [this] { return !empty(); })) {
+          new_data_lock.unlock();
+          perform_read(buffer_read);
+          return;
         }
+        new_data_lock.unlock();
     }
 
+    /**
+     * Gives access to read the buffer through a callback, this method will return
+     * immediately and the callback is performed only when there is data available.
+     */
+    template <typename BufferReadFn>
+    void read_nonblock(BufferReadFn&& buffer_read) {
+        if (!empty()) perform_read(buffer_read);
+    }
+
+  protected:
+    /**
+     * Resets the write_idx to an initial value.
+     * @remarks Should be mostly used by tests to allow reading of the final
+     * item left in the buffer.
+     */
+    void reset_write_idx() { write_idx = SIZE_MAX; }
+
    private:
+     /**
+      * Performs the actual sequence of operations for writing.
+      * @tparam BufferWriteFn
+      * @param buffer_write
+      */
+     template <class BufferWriteFn>
+     void perform_write(BufferWriteFn&& buffer_write) {
+       buffer_write(&buffer[increment_with_capacity(write_idx) * item_size]);
+       push();
+       new_data_condition.notify_all();
+     }
+
+     /**
+      * Performs the actual sequence of operations for reading.
+      * @tparam BufferReadFn
+      * @param buffer_read
+      * @remarks
+      *  If this function attempts to read using an index currently held by the
+      *  writer, it will not perform the operations.
+      */
+     template <typename BufferReadFn>
+     void perform_read(BufferReadFn&& buffer_read) {
+       if (incremented_with_capacity(read_idx.load()) != write_idx.load()) {
+         buffer_read(&buffer[increment_with_capacity(read_idx) * item_size]);
+         pop();
+         free_space_condition.notify_one();
+       }
+     }
+
+    /**
+     * Atomically increments a given index, wrapping around with the buffer capacity.
+     * Also returns the incremented value so that only a single atomic load is
+     * performed for this operation.
+     * @param idx Reference to the index to be incremented.
+     * @return The new incremented value of the index.
+     */
+    [[nodiscard]] size_t increment_with_capacity(std::atomic_size_t &idx) const {
+        const size_t incremented = (idx.load() + 1) % capacity();
+        idx = incremented;
+        return incremented;
+    }
+
+    /**
+     * Returns an incremented value of the given index, wrapping around with the
+     * buffer capacity. This function does not modify the given index.
+     * @param idx Current index value.
+     * @return Incremented value of the given index.
+     */
+    [[nodiscard]] size_t incremented_with_capacity(const size_t idx) const {
+        return (idx + 1) % capacity();
+    }
+
+    /**
+     * Atomically increments the buffer active elements count, clamping at the
+     * buffer capacity.
+     */
+    void push() {
+      size_t overflow = capacity() + 1;
+      ++active_items_count;
+      active_items_count.compare_exchange_strong(overflow, capacity());
+    }
+
+    /**
+     * Atomically decrements the buffer active elements count, clamping at zero.
+     */
+    void pop() {
+      size_t overflow = SIZE_MAX;
+      --active_items_count;
+      active_items_count.compare_exchange_strong(overflow, 0);
+    }
+
     std::vector<uint8_t> buffer;
-    size_t item_size;
-    size_t max_items_count;
-    size_t active_items_count;
-    size_t write_idx;
-    size_t read_idx;
-    mutable std::mutex mutex;
-    std::condition_variable fullCondition;
-    std::condition_variable emptyCondition;
+
+    const size_t item_size;
+    const size_t max_items_count;
+
+    std::atomic_size_t active_items_count;
+    std::atomic_size_t write_idx;
+    std::atomic_size_t read_idx;
+
+    std::mutex mutex;
+    std::condition_variable new_data_condition;
+    std::unique_lock<std::mutex> new_data_lock;
+    std::condition_variable free_space_condition;
+    std::unique_lock<std::mutex> free_space_lock;
+
+    friend class ThreadSafeRingBufferTest;
 };

--- a/ouster-ros/test/ring_buffer_test.cpp
+++ b/ouster-ros/test/ring_buffer_test.cpp
@@ -8,15 +8,15 @@ using namespace std::chrono_literals;
 
 class ThreadSafeRingBufferTest : public ::testing::Test {
   protected:
-    static const int ITEM_SIZE = 4;   // predefined size for all items used in
-    static const int ITEM_COUNT = 3;  // number of item the buffer could hold
+    static constexpr int ITEM_SIZE = 4;   // predefined size for all items used in
+    static constexpr int ITEM_COUNT = 3;  // number of item the buffer could hold
 
     void SetUp() override {
         buffer = std::make_unique<ThreadSafeRingBuffer>(ITEM_SIZE, ITEM_COUNT);
     }
 
     void TearDown() override {
-        buffer.reset();
+        buffer.reset(nullptr);
     }
 
     std::string rand_str(int size) {
@@ -47,6 +47,10 @@ class ThreadSafeRingBufferTest : public ::testing::Test {
       return output;
     }
 
+    void reset_writing() { buffer->reset_write_idx(); }
+
+    void reset_reading() { buffer->reset_read_idx(); }
+
     std::unique_ptr<ThreadSafeRingBuffer> buffer;
 };
 
@@ -54,7 +58,7 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferSimple) {
 
     assert (ITEM_COUNT > 1 && "or this test can't run");
 
-    const int TOTAL_ITEMS = 10; // total items to process
+    static constexpr int TOTAL_ITEMS = 10; // total items to process
     const std::vector<std::string> source = rand_vector_str(TOTAL_ITEMS, ITEM_SIZE);
     std::vector<std::string> target = known_vector_str(TOTAL_ITEMS, "0000");
 
@@ -77,7 +81,12 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferSimple) {
 
     EXPECT_FALSE(buffer->empty());
     EXPECT_FALSE(buffer->full());
+    EXPECT_EQ(buffer->size(), static_cast<size_t>(ITEM_COUNT - 1));
 
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
     for (int i = 1; i < ITEM_COUNT; ++i) {
       buffer->read([i, &target](uint8_t* buffer){
           std::memcpy(&target[i][0], buffer, ITEM_SIZE);
@@ -93,9 +102,9 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferSimple) {
     }
 }
 
-TEST_F(ThreadSafeRingBufferTest, ReadWriteToBuffer) {
+TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferBlocking) {
 
-    const int TOTAL_ITEMS = 10; // total items to process
+    static constexpr int TOTAL_ITEMS = 10; // total items to process
     const std::vector<std::string> source = rand_vector_str(TOTAL_ITEMS, ITEM_SIZE);
     std::vector<std::string> target = known_vector_str(TOTAL_ITEMS, "0000");
 
@@ -108,12 +117,18 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBuffer) {
                 std::memcpy(buffer, &source[i][0], ITEM_SIZE);
             });
         }
+
+        // Due to the lock-free implementation, that last item would not be read, since
+        // the reader can not know if it's still being written to. So we have to reset
+        // the write index before reading out the buffer.
+        reset_writing();
     });
 
     std::thread consumer([this, &target]() {
-        for (int i = 0; i < TOTAL_ITEMS; ++i) {
-            buffer->read([i, &target](uint8_t* buffer){
-                std::memcpy(&target[i][0], buffer, ITEM_SIZE);
+        int i = 0;
+        while (i < TOTAL_ITEMS) {
+            buffer->read([&i, &target](uint8_t* buffer){
+                std::memcpy(&target[i++][0], buffer, ITEM_SIZE);
             });
         }
     });
@@ -123,13 +138,16 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBuffer) {
 
     for (int i = 0; i < TOTAL_ITEMS; ++i) {
         std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
-        EXPECT_EQ(target[i], source[i]); 
+        EXPECT_EQ(target[i], source[i]);
     }
+
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_FALSE(buffer->full());
 }
 
 TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferWithOverwrite) {
 
-    const int TOTAL_ITEMS = 10; // total items to process
+    static constexpr int TOTAL_ITEMS = 10; // total items to process
     const std::vector<std::string> source = rand_vector_str(TOTAL_ITEMS, ITEM_SIZE);
     std::vector<std::string> target = known_vector_str(TOTAL_ITEMS, "0000");
 
@@ -142,6 +160,11 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferWithOverwrite) {
                 std::memcpy(buffer, &source[i][0], ITEM_SIZE);
             });
         }
+
+        // Due to the lock-free implementation, that last item would not be read, since
+        // the reader can not know if it's still being written to. So we have to reset
+        // the write index before reading out the buffer.
+        reset_writing();
     });
 
     // wait for 1 second before starting the consumer thread
@@ -151,8 +174,7 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferWithOverwrite) {
     std::thread consumer([this, &target]() {
         for (int i = 0; i < TOTAL_ITEMS; ++i) {
             buffer->read_timeout([i, &target](uint8_t* buffer){
-                if (buffer != nullptr)
-                    std::memcpy(&target[i][0], buffer, ITEM_SIZE);
+                  std::memcpy(&target[i][0], buffer, ITEM_SIZE);
             }, 1s);
         }
     });
@@ -160,18 +182,457 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferWithOverwrite) {
     producer.join();
     consumer.join();
 
-    // Since our buffer can host only up to ITEM_COUNT simultanously only the
+    // Since our buffer can host only up to ITEM_COUNT simultaneously only the
     // last ITEM_COUNT items would have remained in the buffer by the time
     // the consumer started processing.
-    for (int i = 0; i < ITEM_COUNT; ++i) {
-        std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
-        EXPECT_EQ(target[i], source[TOTAL_ITEMS-ITEM_COUNT+i]); 
+    // If TOTAL_ITEMS is not divisible by ITEM_COUNT, the beginning of the buffer,
+    // will contain a section of ITEM_COUNT items with the latest overwritten data.
+    for (int i = 0; i < TOTAL_ITEMS % ITEM_COUNT; ++i) {
+      std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+      EXPECT_EQ(target[i], source[TOTAL_ITEMS - (TOTAL_ITEMS % ITEM_COUNT) + i]);
+    }
+    // If TOTAL_ITEMS is divisible by ITEM_COUNT, the whole buffer will contain
+    // exactly the last ITEM_COUNT items. Otherwise, the end of the buffer will
+    // contain a section of ITEM_COUNT items with older data.
+    for (int i = TOTAL_ITEMS % ITEM_COUNT; i < ITEM_COUNT; ++i) {
+      std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+      EXPECT_EQ(target[i], source[TOTAL_ITEMS - (TOTAL_ITEMS % ITEM_COUNT) - ITEM_COUNT + i]);
+    }
+    // The remaining part of the target will not have any new data, since the buffer,
+    // will now be completely read out.
+    for (int i = ITEM_COUNT; i < TOTAL_ITEMS; ++i) {
+      std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+      EXPECT_EQ(target[i], "0000");
     }
 
-    for (int i = ITEM_COUNT; i < TOTAL_ITEMS; ++i) {
-        std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
-        EXPECT_EQ(target[i], "0000"); 
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_FALSE(buffer->full());
+}
+
+TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferNonblocking) {
+
+  static constexpr int TOTAL_ITEMS = 10; // total items to process
+  const std::vector<std::string> source = rand_vector_str(TOTAL_ITEMS, ITEM_SIZE);
+  std::vector<std::string> target = known_vector_str(TOTAL_ITEMS, "0000");
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
+
+  std::thread producer([this, &source]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->write_nonblock([i, &source](uint8_t* buffer){
+        std::memcpy(buffer, &source[i][0], ITEM_SIZE);
+      });
     }
+
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
+  });
+
+  // wait for 1 second before starting the consumer thread
+  // allowing sufficient time for the producer thread to be
+  // completely done
+  std::this_thread::sleep_for(1s);
+  std::thread consumer([this, &target]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->read_nonblock([i, &target](uint8_t* buffer){
+        std::memcpy(&target[i][0], buffer, ITEM_SIZE);
+      });
+    }
+  });
+
+  producer.join();
+  consumer.join();
+
+  // Since our buffer can host only up to ITEM_COUNT simultaneously only the
+  // first ITEM_COUNT items will be written into the buffer, with the rest being
+  // ignored.
+  for (int i = 0; i < ITEM_COUNT; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], source[i]);
+  }
+  // The remaining part of the target will not have any new data, since the buffer,
+  // will now be completely read out.
+  for (int i = ITEM_COUNT; i < TOTAL_ITEMS; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], "0000");
+  }
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
+}
+
+TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferBlockingThrottling) {
+
+  static constexpr int TOTAL_ITEMS = 10; // total items to process
+  const std::vector<std::string> source = rand_vector_str(TOTAL_ITEMS, ITEM_SIZE);
+  std::vector<std::string> target = known_vector_str(TOTAL_ITEMS, "0000");
+  static constexpr std::chrono::milliseconds period(10);
+  static constexpr int period_slowing_factor = 4;
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
+
+  // First, the consumer will read faster than the producer can write.
+  std::thread slower_producer([this, &source]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->write([i, &source](uint8_t* buffer){
+        std::memcpy(buffer, &source[i][0], ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period * period_slowing_factor);
+    }
+
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
+  });
+
+  std::thread faster_consumer([this, &target]() {
+    int i = 0;
+    while (i < TOTAL_ITEMS) {
+      buffer->read([&i, &target](uint8_t* buffer){
+        std::memcpy(&target[i++][0], buffer, ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period);
+    }
+  });
+
+  slower_producer.join();
+  faster_consumer.join();
+
+  // Blocking read and write should always be synchronized even if one thread is faster.
+  std::cout << "Slower producer, faster consumer:" << std::endl;
+  for (int i = 0; i < TOTAL_ITEMS; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], source[i]);
+  }
+
+  ASSERT_TRUE(buffer->empty());
+  ASSERT_FALSE(buffer->full());
+  target = known_vector_str(TOTAL_ITEMS, "0000");
+  reset_writing();
+  reset_reading();
+
+  // Then, the producer will write to the buffer faster than the consumer can read.
+  std::thread faster_producer([this, &source]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->write([i, &source](uint8_t* buffer){
+        std::memcpy(buffer, &source[i][0], ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period);
+    }
+
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
+  });
+
+  std::thread slower_consumer([this, &target]() {
+    int i = 0;
+    while (i < TOTAL_ITEMS) {
+      buffer->read([&i, &target](uint8_t* buffer){
+        std::memcpy(&target[i++][0], buffer, ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period * period_slowing_factor);
+    }
+  });
+
+  faster_producer.join();
+  slower_consumer.join();
+
+  // Blocking read and write should always be synchronized even if one thread is faster.
+  std::cout << "Faster producer, slower consumer:" << std::endl;
+  for (int i = 0; i < TOTAL_ITEMS; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], source[i]);
+  }
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
+}
+
+TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferWithOverwriteThrottling) {
+
+  static constexpr int TOTAL_ITEMS = 10; // total items to process
+  const std::vector<std::string> source = rand_vector_str(TOTAL_ITEMS, ITEM_SIZE);
+  std::vector<std::string> target = known_vector_str(TOTAL_ITEMS, "0000");
+  static constexpr std::chrono::milliseconds period(10);
+  static constexpr int period_slowing_factor = 4;
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
+
+  // First, the consumer will read faster than the producer can write.
+  std::thread slower_producer([this, &source]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->write_overwrite([i, &source](uint8_t* buffer){
+        std::memcpy(buffer, &source[i][0], ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period * period_slowing_factor);
+    }
+
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
+  });
+
+  std::thread faster_consumer([this, &target]() {
+    int i = 0;
+    while (i < TOTAL_ITEMS) {
+      buffer->read_timeout([&i, &target](uint8_t* buffer){
+        std::memcpy(&target[i++][0], buffer, ITEM_SIZE);
+      }, 1s);
+      std::this_thread::sleep_for(period);
+    }
+  });
+
+  slower_producer.join();
+  faster_consumer.join();
+
+  // If the consumer is faster, it should always keep up with the latest data
+  // and outputs should be synchronized.
+  std::cout << "Slower producer, faster consumer:" << std::endl;
+  for (int i = 0; i < TOTAL_ITEMS; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], source[i]);
+  }
+
+  ASSERT_TRUE(buffer->empty());
+  ASSERT_FALSE(buffer->full());
+  target = known_vector_str(TOTAL_ITEMS, "0000");
+  reset_writing();
+  reset_reading();
+
+  // Then, the producer will write to the buffer faster than the consumer can read.
+  std::thread faster_producer([this, &source]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->write_overwrite([i, &source](uint8_t* buffer){
+        std::memcpy(buffer, &source[i][0], ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period);
+    }
+
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
+  });
+
+  std::thread slower_consumer([this, &target]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->read_timeout([i, &target](uint8_t* buffer){
+        std::memcpy(&target[i][0], buffer, ITEM_SIZE);
+      }, 1s);
+      std::this_thread::sleep_for(period * period_slowing_factor);
+    }
+  });
+
+  faster_producer.join();
+  slower_consumer.join();
+
+  // This part should be automated for reasonable combinations of ITEM_COUNT and
+  // TOTAL_ITEMS. Assuming ITEM_COUNT == 3, TOTAL_ITEMS == 10, and period_slowing_factor == 4
+  // we should expect the following behavior:
+  // The first read attempt will start before the producer takes ownership of the next
+  // index, so the first item will not be filled.
+  // By the second read attempt, the producer will have performed 1*4 writes,
+  // ending back at index 0. So the second item is not filled.
+  // By the third read attempt, the producer wil have performed 2*4 writes,
+  // now ending at index 1. The consumer will fill one item.
+  // By the fourth attempt, the producer will have finished writing with the last
+  // 2 writes. The consumer will fill the last items from the buffer.
+  // The remaining items will not be filled, since there were no more writes
+  // being made.
+  assert ((TOTAL_ITEMS - ITEM_COUNT) > 2 && "or this test section can't run");
+
+  static constexpr int complete_writes = TOTAL_ITEMS / period_slowing_factor;
+  static constexpr int read_attempts = (((10 * TOTAL_ITEMS) / period_slowing_factor)
+                                        > 10 * complete_writes) ? complete_writes + 1 : complete_writes;
+  int reading_buffer_idx = 0, written_buffer_idx = 0;
+  int expected_source_idx = 0, written_source_idx = 0;
+
+  std::cout << "Faster producer, slower consumer:" << std::endl;
+  std::cout << "source " << source[0] << ", target " << target[0] << std::endl;
+  EXPECT_EQ(target[0], "0000");
+
+  // Checking all read attempts happening after a full batch of writes, and
+  // the final writes plus one extra read.
+  for (int i = 1; i <= read_attempts + 1; ++i) {
+    written_source_idx = std::min(i * period_slowing_factor, TOTAL_ITEMS) - 1;
+    written_buffer_idx = written_source_idx % ITEM_COUNT;
+    expected_source_idx = written_source_idx - written_buffer_idx + reading_buffer_idx;
+    if (written_buffer_idx < reading_buffer_idx)
+      expected_source_idx -= ITEM_COUNT;
+
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    if ((written_buffer_idx == reading_buffer_idx) && (written_source_idx != (TOTAL_ITEMS - 1))) {
+      EXPECT_EQ(target[i], "0000");
+    } else {
+      reading_buffer_idx = (reading_buffer_idx + 1) % ITEM_COUNT;
+      EXPECT_EQ(target[i], source[expected_source_idx]);
+    }
+  }
+
+  // We're not checking all final reads, since that would depend more on the
+  // relationship between TOTAL_ITEMS and ITEM_COUNT, and not the running behavior.
+  // So, just printing out any skipped items for completion.
+  int items_left_in_buffer = ITEM_COUNT;
+  if (written_buffer_idx < reading_buffer_idx)
+    items_left_in_buffer += written_buffer_idx + 1 - reading_buffer_idx;
+  for (int i = read_attempts + 2; i <= read_attempts + items_left_in_buffer; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+  }
+
+  // Since the producer finished with overwrites faster that the consumer
+  // could read them out, some final items should stay empty.
+  for (int i = read_attempts + items_left_in_buffer + 1; i < TOTAL_ITEMS; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], "0000");
+  }
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
+}
+
+TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferNonblockingThrottling) {
+
+  static constexpr int TOTAL_ITEMS = 10; // total items to process
+  const std::vector<std::string> source = rand_vector_str(TOTAL_ITEMS, ITEM_SIZE);
+  std::vector<std::string> target = known_vector_str(TOTAL_ITEMS, "0000");
+  static constexpr std::chrono::milliseconds period(10);
+  static constexpr int period_slowing_factor = 4;
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
+
+  // First, the consumer will read faster than the producer can write.
+  std::thread slower_producer([this, &source]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->write_nonblock([i, &source](uint8_t* buffer){
+        std::memcpy(buffer, &source[i][0], ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period * period_slowing_factor);
+    }
+
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
+  });
+
+  std::thread faster_consumer([this, &target]() {
+    int i = 0;
+    while (i < TOTAL_ITEMS) {
+      buffer->read_nonblock([&i, &target](uint8_t* buffer){
+        std::memcpy(&target[i++][0], buffer, ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period);
+    }
+  });
+
+  slower_producer.join();
+  faster_consumer.join();
+
+  // If the consumer is faster, it should always keep up with the latest data
+  // and outputs should be synchronized.
+  std::cout << "Slower producer, faster consumer:" << std::endl;
+  for (int i = 0; i < TOTAL_ITEMS; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], source[i]);
+  }
+
+  ASSERT_TRUE(buffer->empty());
+  ASSERT_FALSE(buffer->full());
+  target = known_vector_str(TOTAL_ITEMS, "0000");
+  reset_writing();
+  reset_reading();
+
+  // Then, the producer will write to the buffer faster than the consumer can read.
+  std::thread faster_producer([this, &source]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->write_nonblock([i, &source](uint8_t* buffer){
+        std::memcpy(buffer, &source[i][0], ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period);
+    }
+
+    // Due to the lock-free implementation, that last item would not be read, since
+    // the reader can not know if it's still being written to. So we have to reset
+    // the write index before reading out the buffer.
+    reset_writing();
+  });
+
+  std::thread slower_consumer([this, &target]() {
+    for (int i = 0; i < TOTAL_ITEMS; ++i) {
+      buffer->read_nonblock([i, &target](uint8_t* buffer){
+        std::memcpy(&target[i][0], buffer, ITEM_SIZE);
+      });
+      std::this_thread::sleep_for(period * period_slowing_factor);
+    }
+  });
+
+  faster_producer.join();
+  slower_consumer.join();
+
+  // This part should be automated for reasonable combinations of ITEM_COUNT and
+  // TOTAL_ITEMS. Assuming ITEM_COUNT == 3, TOTAL_ITEMS == 10, and period_slowing_factor == 4
+  // we should expect the following behavior:
+  // The first read attempt will start before the producer takes ownership of the next
+  // index, so the first item will not be filled.
+  // By the second read attempt, the producer will have performed 1*4 writes,
+  // filling the buffer and dropping the last write. The consumer will fill in
+  // the first item.
+  // By the third read attempt, the producer will have performed 2*4 writes,
+  // filling only one item and dropping the rest. The consumer will read the second
+  // item.
+  // By the fourth attempt, the producer will have finished with the last 2 writes,
+  // filling only one item and dropping the final one.
+  // The consumer will read the last items from the buffer.
+  // The remaining items will not be filled, since there were no more writes
+  // being made.
+  assert ((TOTAL_ITEMS - ITEM_COUNT) > 2 && "or this test section can't run");
+  assert(period_slowing_factor > 2 && "or this test section can't run");
+
+  static constexpr int full_writes = ITEM_COUNT / period_slowing_factor;
+  static constexpr int consecutive_reads = std::min(ITEM_COUNT + full_writes, TOTAL_ITEMS - 1);
+  static constexpr int saturated_reads =
+      (TOTAL_ITEMS + (TOTAL_ITEMS % period_slowing_factor) - consecutive_reads) / period_slowing_factor;
+  int expected_source_idx = 0;
+
+  std::cout << "Faster producer, slower consumer:" << std::endl;
+  std::cout << "source " << source[0] << ", target " << target[0] << std::endl;
+  EXPECT_EQ(target[0], "0000");
+
+  // The buffer should always be filled with consecutive items upto the point,
+  // when the producer catches up with the consumer on its second pass.
+  for (int i = 1; i <= consecutive_reads; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], source[i - 1]);
+  }
+
+  // Since the producer cannot overwrite, it would always fill just the first item,
+  // in its iteration.
+  int writing_iteration = 1;
+  for (int i = consecutive_reads + 1; i <= consecutive_reads + saturated_reads; ++i) {
+    expected_source_idx = (full_writes + writing_iteration++) * period_slowing_factor;
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], source[expected_source_idx]);
+  }
+
+  // Since the producer finished with writes faster that the consumer
+  // could read them out, some final items should stay empty.
+  for (int i = consecutive_reads + saturated_reads + 1; i < TOTAL_ITEMS; ++i) {
+    std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
+    EXPECT_EQ(target[i], "0000");
+  }
+
+  EXPECT_TRUE(buffer->empty());
+  EXPECT_FALSE(buffer->full());
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Related Issues & PRs
* https://github.com/ouster-lidar/ouster-ros/issues/240
* possibly related to https://github.com/ouster-lidar/ouster-ros/issues/272
* possibly related to https://github.com/ouster-lidar/ouster-ros/issues/280

## Summary of Changes

A proposed refactor of the `ThreadSafeRingBuffer` using `std::atomic` variables for lock-free access.

Changes:
1. Blocking `read` and `write` methods continue to rely on condition variables for buffer `full` and `empty` estimation. The locks are only held for the duration of `wait` and once `wait` is finished, the operations are performed atomically.
2. The `write_overwrite` method is now non-blocking, meaning it will atomically overwrite the last item imemdiately. This will not push the `read_idx` forward if an overwrite occurs.
3. The `read_timeout` method continues to rely on the condition variable for buffer `empty` estimation. Lock is only held for the duration of `wait_for`. If the `wait_for` is successful, it will perform the read atomically. If the `wait_for` timeouts, it will simply not perform the callback (instead of returning a `nullptr`) and unlock the lock.
4. Implemented non-blocking `write_nonblock` and `read_nonblock` methods, which return immediately and only perform the `read` or `write` operation if the `empty` and `full` conditions are met. These conditions are checked atomically.
5. The read and write indexes are atomically incremented before the the actual operation takes place, instead of after. This way we can for example assume that the writer currently has "ownership" of the data pointed to by the current `write_idx` and might be performing a write. If the index was incremented afterwards, it's current/actual value would be basically meaningless.

I've taken some liberty with the following changes, which may not be desired but make more sense in my limited understanding:
1. We will not be returning a `nullptr` in any case. If the corresponding conditions for a nonblocking or timeouted operation are not met we simply don't perform the callback operation and don't modify the buffer active size. I find it safer to just ignore the callback instead of returning an invalid pointer, which then must be handled safely by the caller.
2. The overwriting method will not push the reading index forward if the buffer is being overwritten. This is no longer desirable if both, the reading and writing thread modify the index asynchronously. The writer can keep overwriting the buffer as many times and as fast as it can, and the reader will simply continue at it's own pace. The only thing we have to make sure of is that they both never attempt to access the same field at the same time, which is assured by atomic access to the indexes.
3. To make sure the reader and writer will not attempt to acces the same index at the same time, there are two rules:
    1. The writer can modify any data at any time (overwrite method), or any data as long as it has available space (other methods).
    2. The reader must check that the index it wants to read from is not the same as the current write index. The read is only performed if this condition is met.

## Validation

> <s>TODO: add images or videos of vizualizations, with comparisons between old, new, and community</s>
> <s>TODO: add debug outputs from running driver</s>
> <s>TODO: finish implementing new tests</s>
1. Validated using a real product (`OS-0-128, sn: 122312000594, firmware rev: v3.0.1`):
    - [x] `write`/`read`
    - [x] `write_overwrite`/`read_timeout`
    - [x] `write_nonblock`/`read_nonblock`
3. Validated with passing tests:
    - [x] `write`/`read`
    - [x] `write_overwrite`/`read_timeout`
    - [x] `write_nonblock`/`read_nonblock`