### PR TITLE
Implement lock free ring buffer with throttling [FOXY]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
   * address an issue where LaserScan appeared different on FW prior to 2.4
 * [BUGFIX]: LaserScan does not work when using dual mode
 * [BUGFIX]: ROS2 crashes when standby mode is set and then set to normal
+* [BUGFIX]: Implement lock free ring buffer with throttling to reduce partial frames
 
 ouster_ros v0.12.0
 ==================

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -169,12 +169,14 @@ rclcpp_components_register_node(os_driver_component
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(${PROJECT_NAME}_test
-    test/ring_buffer_test.cpp
-    src/os_ros.cpp
-    test/point_accessor_test.cpp
-    test/point_transform_test.cpp
-    test/point_cloud_compose_test.cpp
-  )
+  src/os_ros.cpp
+  test/test_main.cpp
+  test/ring_buffer_test.cpp
+  test/lock_free_ring_buffer_test.cpp
+  test/point_accessor_test.cpp
+  test/point_transform_test.cpp
+  test/point_cloud_compose_test.cpp
+)
   ament_target_dependencies(${PROJECT_NAME}_test
     rclcpp
     ouster_sensor_msgs

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -169,14 +169,14 @@ rclcpp_components_register_node(os_driver_component
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(${PROJECT_NAME}_test
-  src/os_ros.cpp
-  test/test_main.cpp
-  test/ring_buffer_test.cpp
-  test/lock_free_ring_buffer_test.cpp
-  test/point_accessor_test.cpp
-  test/point_transform_test.cpp
-  test/point_cloud_compose_test.cpp
-)
+    src/os_ros.cpp
+    test/test_main.cpp
+    test/ring_buffer_test.cpp
+    test/lock_free_ring_buffer_test.cpp
+    test/point_accessor_test.cpp
+    test/point_transform_test.cpp
+    test/point_cloud_compose_test.cpp
+  )
   ament_target_dependencies(${PROJECT_NAME}_test
     rclcpp
     ouster_sensor_msgs

--- a/ouster-ros/config/community_driver.rviz
+++ b/ouster-ros/config/community_driver.rviz
@@ -28,11 +28,6 @@ Panels:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: rviz_common/Time
-    Experimental: false
-    Name: Time
-    SyncMode: 0
-    SyncSource: PointCloud2
 Visualization Manager:
   Class: ""
   Displays:

--- a/ouster-ros/config/viz-reliable.rviz
+++ b/ouster-ros/config/viz-reliable.rviz
@@ -28,11 +28,6 @@ Panels:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: rviz_common/Time
-    Experimental: false
-    Name: Time
-    SyncMode: 0
-    SyncSource: PointCloud2
 Visualization Manager:
   Class: ""
   Displays:

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.12.2</version>
+  <version>0.12.3</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -16,6 +16,9 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 
+#include "lock_free_ring_buffer.h"
+#include <thread>
+
 namespace {
 
 template <typename T, typename UnaryPredicate>
@@ -73,12 +76,26 @@ class LidarPacketHandler {
                        const std::vector<LidarScanProcessor>& handlers,
                        const std::string& timestamp_mode,
                        int64_t ptp_utc_tai_offset)
-        : lidar_scan_handlers{handlers} {
+        : ring_buffer(LIDAR_SCAN_COUNT), lidar_scan_handlers{handlers} {
         // initialize lidar_scan processor and buffer
         scan_batcher = std::make_unique<ouster::ScanBatcher>(info);
-        lidar_scan = std::make_unique<ouster::LidarScan>(
-            info.format.columns_per_frame, info.format.pixels_per_column,
-            info.format.udp_profile_lidar);
+
+        lidar_scans.resize(LIDAR_SCAN_COUNT);
+        mutexes.resize(LIDAR_SCAN_COUNT);
+
+        for (size_t i = 0; i < lidar_scans.size(); ++i) {
+            lidar_scans[i] = std::make_unique<ouster::LidarScan>(
+                info.format.columns_per_frame, info.format.pixels_per_column,
+                info.format.udp_profile_lidar);
+            mutexes[i] = std::make_shared<std::mutex>();   // make_unique?
+        }
+
+        lidar_scans_processing_thread = std::make_unique<std::thread>([this]() {
+            while (lidar_scans_processing_active) {
+                process_scans();
+            }
+            // TODO: NODELET_DEBUG("lidar_scans_processing_thread done.");
+        });
 
         // initalize time handlers
         scan_col_ts_spacing_ns = compute_scan_col_ts_spacing_ns(info.mode);
@@ -125,12 +142,35 @@ class LidarPacketHandler {
             info, handlers, timestamp_mode, ptp_utc_tai_offset);
         return [handler](const uint8_t* lidar_buf) {
             if (handler->lidar_packet_accumlator(lidar_buf)) {
-                for (auto h : handler->lidar_scan_handlers) {
-                    h(*handler->lidar_scan, handler->lidar_scan_estimated_ts,
-                      handler->lidar_scan_estimated_msg_ts);
-                }
+                handler->ring_buffer_has_elements.notify_one();
             }
         };
+    }
+
+    const std::string getName() const { return "lidar_packet_hander"; }
+
+    void process_scans() {
+
+        {
+            std::unique_lock<std::mutex> index_lock(ring_buffer_mutex);
+            ring_buffer_has_elements.wait(index_lock, [this] {
+                return !ring_buffer.empty();
+            });
+        }
+
+        std::unique_lock<std::mutex> lock(*mutexes[ring_buffer.read_head()]);
+
+        for (auto h : lidar_scan_handlers) {
+            h(*lidar_scans[ring_buffer.read_head()], lidar_scan_estimated_ts,
+                lidar_scan_estimated_msg_ts);
+        }
+
+        size_t read_step = 1;
+        if (ring_buffer.size() > 7) {
+            // TODO: NODELET_WARN("lidar_scans full, THROTTLING");
+            read_step = 2;
+        }
+        ring_buffer.read(read_step);
     }
 
     // time interpolation methods
@@ -221,21 +261,45 @@ class LidarPacketHandler {
 
     bool lidar_handler_sensor_time(const sensor::packet_format&,
                                    const uint8_t* lidar_buf) {
-        if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
-        lidar_scan_estimated_ts = compute_scan_ts(lidar_scan->timestamp());
+
+        if (ring_buffer.full()) {
+            // TODO: NODELET_WARN("lidar_scans full, DROPPING PACKET");
+            return false;
+        }
+
+        std::unique_lock<std::mutex> lock(*(mutexes[ring_buffer.write_head()]));
+
+        if (!(*scan_batcher)(lidar_buf, *lidar_scans[ring_buffer.write_head()])) return false;
+        lidar_scan_estimated_ts = compute_scan_ts(lidar_scans[ring_buffer.write_head()]->timestamp());
         lidar_scan_estimated_msg_ts = rclcpp::Time(lidar_scan_estimated_ts);
+
+        ring_buffer.write();
+
         return true;
     }
 
     bool lidar_handler_sensor_time_ptp(const sensor::packet_format&,
                                        const uint8_t* lidar_buf,
                                        int64_t ptp_utc_tai_offset) {
-        if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
-        auto ts_v = lidar_scan->timestamp();
+
+        if (ring_buffer.full()) {
+            // TODO: NODELET_WARN("lidar_scans full, DROPPING PACKET");
+            return false;
+        }
+
+        std::unique_lock<std::mutex> lock(
+            *(mutexes[ring_buffer.write_head()]));
+
+        if (!(*scan_batcher)(lidar_buf, *lidar_scans[ring_buffer.write_head()])) return false;
+        auto ts_v = lidar_scans[ring_buffer.write_head()]->timestamp();
         for (int i = 0; i < ts_v.rows(); ++i)
             ts_v[i] = impl::ts_safe_offset_add(ts_v[i], ptp_utc_tai_offset);
         lidar_scan_estimated_ts = compute_scan_ts(ts_v);
-        lidar_scan_estimated_msg_ts = rclcpp::Time(lidar_scan_estimated_ts);
+        lidar_scan_estimated_msg_ts =
+            rclcpp::Time(lidar_scan_estimated_ts);
+
+        ring_buffer.write();
+
         return true;
     }
 
@@ -247,12 +311,24 @@ class LidarPacketHandler {
                 pf, lidar_buf, packet_receive_time);  // first point cloud time
             lidar_handler_ros_time_frame_ts_initialized = true;
         }
-        if (!(*scan_batcher)(lidar_buf, *lidar_scan)) return false;
-        lidar_scan_estimated_ts = compute_scan_ts(lidar_scan->timestamp());
+
+        if (ring_buffer.full()) {
+            // TODO: NODELET_WARN("lidar_scans full, DROPPING PACKET");
+            return false;
+        }
+
+        std::unique_lock<std::mutex> lock(
+            *(mutexes[ring_buffer.write_head()]));
+
+        if (!(*scan_batcher)(lidar_buf, *lidar_scans[ring_buffer.write_head()])) return false;
+        lidar_scan_estimated_ts = compute_scan_ts(lidar_scans[ring_buffer.write_head()]->timestamp());
         lidar_scan_estimated_msg_ts = lidar_handler_ros_time_frame_ts;
         // set time for next point cloud msg
         lidar_handler_ros_time_frame_ts =
             extrapolate_frame_ts(pf, lidar_buf, packet_receive_time);
+
+        ring_buffer.write();
+
         return true;
     }
 
@@ -265,7 +341,12 @@ class LidarPacketHandler {
 
    private:
     std::unique_ptr<ouster::ScanBatcher> scan_batcher;
-    std::unique_ptr<ouster::LidarScan> lidar_scan;
+    const int LIDAR_SCAN_COUNT = 10;
+    LockFreeRingBuffer ring_buffer;
+    std::mutex ring_buffer_mutex;
+    std::vector<std::unique_ptr<ouster::LidarScan>> lidar_scans;
+    std::vector<std::shared_ptr<std::mutex>> mutexes;
+
     uint64_t lidar_scan_estimated_ts;
     rclcpp::Time lidar_scan_estimated_msg_ts;
 
@@ -284,6 +365,10 @@ class LidarPacketHandler {
     std::vector<LidarScanProcessor> lidar_scan_handlers;
 
     LidarPacketAccumlator lidar_packet_accumlator;
+
+    bool lidar_scans_processing_active = true;
+    std::unique_ptr<std::thread> lidar_scans_processing_thread;
+    std::condition_variable ring_buffer_has_elements;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/lock_free_ring_buffer.h
+++ b/ouster-ros/src/lock_free_ring_buffer.h
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2018-2024, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file thread_safe_ring_buffer.h
+ * @brief File contains thread safe implementation of a ring buffer
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+#include <atomic>
+
+/**
+ * @class LockFreeRingBuffer thread safe ring buffer.
+ * 
+ * @remarks current implementation has effective (capacity-1) when writing elements
+ */
+class LockFreeRingBuffer {
+   public:
+    LockFreeRingBuffer(size_t capacity)
+        : capacity_(capacity),
+          write_idx_(0),
+          read_idx_(0) {}
+
+    /**
+     * Gets the maximum number of items that this ring buffer can hold.
+     */
+    size_t capacity() const { return capacity_; }
+
+    /**
+     * Gets the number of item that currently occupy the ring buffer. This
+     * number would vary between 0 and the capacity().
+     *
+     * @remarks
+     *  if returned value was 0 or the value was equal to the buffer capacity(),
+     *  this does not guarantee that a subsequent call to read() or write()
+     *  wouldn't cause the calling thread to be blocked.
+     */
+    size_t size() const {
+        return write_idx_ >= read_idx_ ?
+            write_idx_ - read_idx_ :
+            write_idx_ + capacity_ - read_idx_;
+    }
+
+    size_t available() const {
+        return capacity_ - 1 - size();
+    }
+
+    /**
+     * Checks if the ring buffer is empty.
+     */
+    bool empty() const {
+        return read_idx_ == write_idx_;
+    }
+
+    /**
+     * Checks if the ring buffer is full.
+     */
+    bool full() const {
+        return read_idx_ == (write_idx_ + 1) % capacity_;
+    }
+
+    /**
+     */
+    bool write(size_t count = 1) {
+        if (count > available()) return false;
+        write_idx_ = (write_idx_ + count) % capacity_;
+        return true;
+    }
+
+    /**
+     */
+    bool read(size_t count = 1) {
+        if (count > size()) return false;
+        read_idx_ = (read_idx_ + count) % capacity_;
+        return true;
+    }
+
+    size_t write_head() const { return write_idx_; }
+    size_t read_head() const { return read_idx_; }
+
+   private:
+    const size_t capacity_;
+    std::atomic<size_t> write_idx_;
+    std::atomic<size_t> read_idx_;
+};

--- a/ouster-ros/test/lock_free_ring_buffer_test.cpp
+++ b/ouster-ros/test/lock_free_ring_buffer_test.cpp
@@ -1,0 +1,193 @@
+#include <thread>
+#include <cstring>
+#include <random>
+#include <gtest/gtest.h>
+#include "../src/lock_free_ring_buffer.h"
+
+using namespace std::chrono_literals;
+
+class LockFreeRingBufferTest : public ::testing::Test {
+  protected:
+    static constexpr int ITEM_COUNT = 3;  // number of item the buffer could hold
+
+    void SetUp() override {
+        buffer = std::make_unique<LockFreeRingBuffer>(ITEM_COUNT);
+    }
+
+    void TearDown() override {
+        buffer.reset();
+    }
+
+    std::unique_ptr<LockFreeRingBuffer> buffer;
+};
+
+
+TEST_F(LockFreeRingBufferTest, ReadWriteToBufferFullEmpty) {
+
+    assert (ITEM_COUNT > 1 && "or this test can't run");
+
+    EXPECT_EQ(buffer->capacity(), ITEM_COUNT);
+    EXPECT_EQ(buffer->available(), ITEM_COUNT - 1);
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_FALSE(buffer->full());
+
+    for (int i = 0; i < ITEM_COUNT - 1; ++i) {
+      buffer->write();
+    }
+
+    EXPECT_FALSE(buffer->empty());
+    EXPECT_TRUE(buffer->full());
+
+    // remove one item
+    buffer->read();
+
+    EXPECT_FALSE(buffer->empty());
+    EXPECT_FALSE(buffer->full());
+
+    for (int i = 1; i < ITEM_COUNT - 1; ++i) {
+      buffer->read();
+    }
+
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_FALSE(buffer->full());
+}
+
+TEST_F(LockFreeRingBufferTest, ReadWriteToBufferCheckReturn) {
+
+    assert (ITEM_COUNT > 1 && "or this test can't run");
+
+    EXPECT_TRUE(buffer->empty());
+
+    for (int i = 0; i < ITEM_COUNT - 1; ++i) {
+      EXPECT_TRUE(buffer->write());
+    }
+
+    EXPECT_TRUE(buffer->full());
+    EXPECT_FALSE(buffer->write());
+
+    // remove one item and re-write
+    EXPECT_TRUE(buffer->read());
+    EXPECT_TRUE(buffer->write());
+
+    for (int i = 0; i < ITEM_COUNT - 1; ++i) {
+      EXPECT_TRUE(buffer->read());
+    }
+
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_FALSE(buffer->read());
+}
+
+
+TEST_F(LockFreeRingBufferTest, ReadWriteToBufferSizeAvailable) {
+
+    assert (ITEM_COUNT == 3 && "or this test can't run");
+
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_FALSE(buffer->full());
+
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->write_head(), 0);
+    EXPECT_EQ(buffer->read_head(), 0);
+
+    EXPECT_TRUE(buffer->write());
+    EXPECT_EQ(buffer->size(), 1);
+    EXPECT_EQ(buffer->available(), 1);
+    EXPECT_EQ(buffer->write_head(), 1);
+    EXPECT_EQ(buffer->read_head(), 0);
+
+    EXPECT_TRUE(buffer->write());
+    EXPECT_EQ(buffer->size(), 2);
+    EXPECT_EQ(buffer->available(), 0);
+    EXPECT_EQ(buffer->write_head(), 2);
+    EXPECT_EQ(buffer->read_head(), 0);
+
+    EXPECT_TRUE(buffer->read());
+    EXPECT_EQ(buffer->size(), 1);
+    EXPECT_EQ(buffer->available(), 1);
+    EXPECT_EQ(buffer->write_head(), 2);
+    EXPECT_EQ(buffer->read_head(), 1);
+
+    EXPECT_TRUE(buffer->write());
+    EXPECT_EQ(buffer->size(), 2);
+    EXPECT_EQ(buffer->available(), 0);
+    EXPECT_EQ(buffer->write_head(), 0);
+    EXPECT_EQ(buffer->read_head(), 1);
+
+    // Next write should fail, so size shouldn't change
+    EXPECT_FALSE(buffer->write());
+    EXPECT_EQ(buffer->size(), 2);
+    EXPECT_EQ(buffer->available(), 0);
+    EXPECT_EQ(buffer->write_head(), 0);
+    EXPECT_EQ(buffer->read_head(), 1);
+
+    EXPECT_TRUE(buffer->read());
+    EXPECT_EQ(buffer->size(), 1);
+    EXPECT_EQ(buffer->available(), 1);
+    EXPECT_EQ(buffer->write_head(), 0);
+    EXPECT_EQ(buffer->read_head(), 2);
+
+    EXPECT_TRUE(buffer->read());
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->write_head(), 0);
+    EXPECT_EQ(buffer->read_head(), 0);
+
+    // Next read should fail, so size shouldn't change
+    EXPECT_FALSE(buffer->read());
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->write_head(), 0);
+    EXPECT_EQ(buffer->read_head(), 0);
+}
+
+TEST_F(LockFreeRingBufferTest, ReadWriteToBufferAdvanceMultiple) {
+
+    assert (ITEM_COUNT == 3 && "or this test can't run");
+
+    EXPECT_TRUE(buffer->empty());
+    EXPECT_FALSE(buffer->full());
+
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+
+    EXPECT_TRUE(buffer->write(2));
+    EXPECT_EQ(buffer->size(), 2);
+    EXPECT_EQ(buffer->available(), 0);
+
+    // This write should fail since we advance beyond capacity, so size shouldn't change
+    EXPECT_FALSE(buffer->write(2));
+    EXPECT_EQ(buffer->size(), 2);
+    EXPECT_EQ(buffer->available(), 0);
+
+    EXPECT_TRUE(buffer->read());
+    EXPECT_EQ(buffer->size(), 1);
+    EXPECT_EQ(buffer->available(), 1);
+
+    EXPECT_TRUE(buffer->read());
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+
+    EXPECT_TRUE(buffer->write(2));
+    EXPECT_EQ(buffer->size(), 2);
+    EXPECT_EQ(buffer->available(), 0);
+
+    // Any additional write will also fail, size shouldn't change
+    EXPECT_FALSE(buffer->write());
+    EXPECT_EQ(buffer->size(), 2);
+    EXPECT_EQ(buffer->available(), 0);
+
+    EXPECT_TRUE(buffer->read(2));
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+
+    // This read should fail since we advance beyond available, so size shouldn't change
+    EXPECT_FALSE(buffer->read(2));
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+
+    // Any subsequent read will also fail, size shouldn't change
+    EXPECT_FALSE(buffer->read());
+    EXPECT_EQ(buffer->size(), 0);
+    EXPECT_EQ(buffer->available(), 2);
+}

--- a/ouster-ros/test/lock_free_ring_buffer_test.cpp
+++ b/ouster-ros/test/lock_free_ring_buffer_test.cpp
@@ -8,7 +8,7 @@ using namespace std::chrono_literals;
 
 class LockFreeRingBufferTest : public ::testing::Test {
   protected:
-    static constexpr int ITEM_COUNT = 3;  // number of item the buffer could hold
+    static constexpr size_t ITEM_COUNT = 3;  // number of item the buffer could hold
 
     void SetUp() override {
         buffer = std::make_unique<LockFreeRingBuffer>(ITEM_COUNT);
@@ -31,7 +31,7 @@ TEST_F(LockFreeRingBufferTest, ReadWriteToBufferFullEmpty) {
     EXPECT_TRUE(buffer->empty());
     EXPECT_FALSE(buffer->full());
 
-    for (int i = 0; i < ITEM_COUNT - 1; ++i) {
+    for (size_t i = 0; i < ITEM_COUNT - 1; ++i) {
       buffer->write();
     }
 
@@ -44,7 +44,7 @@ TEST_F(LockFreeRingBufferTest, ReadWriteToBufferFullEmpty) {
     EXPECT_FALSE(buffer->empty());
     EXPECT_FALSE(buffer->full());
 
-    for (int i = 1; i < ITEM_COUNT - 1; ++i) {
+    for (size_t i = 1; i < ITEM_COUNT - 1; ++i) {
       buffer->read();
     }
 
@@ -58,7 +58,7 @@ TEST_F(LockFreeRingBufferTest, ReadWriteToBufferCheckReturn) {
 
     EXPECT_TRUE(buffer->empty());
 
-    for (int i = 0; i < ITEM_COUNT - 1; ++i) {
+    for (size_t i = 0; i < ITEM_COUNT - 1; ++i) {
       EXPECT_TRUE(buffer->write());
     }
 
@@ -69,7 +69,7 @@ TEST_F(LockFreeRingBufferTest, ReadWriteToBufferCheckReturn) {
     EXPECT_TRUE(buffer->read());
     EXPECT_TRUE(buffer->write());
 
-    for (int i = 0; i < ITEM_COUNT - 1; ++i) {
+    for (size_t i = 0; i < ITEM_COUNT - 1; ++i) {
       EXPECT_TRUE(buffer->read());
     }
 
@@ -85,60 +85,60 @@ TEST_F(LockFreeRingBufferTest, ReadWriteToBufferSizeAvailable) {
     EXPECT_TRUE(buffer->empty());
     EXPECT_FALSE(buffer->full());
 
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
-    EXPECT_EQ(buffer->write_head(), 0);
-    EXPECT_EQ(buffer->read_head(), 0);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
+    EXPECT_EQ(buffer->write_head(), 0U);
+    EXPECT_EQ(buffer->read_head(), 0U);
 
     EXPECT_TRUE(buffer->write());
-    EXPECT_EQ(buffer->size(), 1);
-    EXPECT_EQ(buffer->available(), 1);
-    EXPECT_EQ(buffer->write_head(), 1);
-    EXPECT_EQ(buffer->read_head(), 0);
+    EXPECT_EQ(buffer->size(), 1U);
+    EXPECT_EQ(buffer->available(), 1U);
+    EXPECT_EQ(buffer->write_head(), 1U);
+    EXPECT_EQ(buffer->read_head(), 0U);
 
     EXPECT_TRUE(buffer->write());
-    EXPECT_EQ(buffer->size(), 2);
-    EXPECT_EQ(buffer->available(), 0);
-    EXPECT_EQ(buffer->write_head(), 2);
-    EXPECT_EQ(buffer->read_head(), 0);
+    EXPECT_EQ(buffer->size(), 2U);
+    EXPECT_EQ(buffer->available(), 0U);
+    EXPECT_EQ(buffer->write_head(), 2U);
+    EXPECT_EQ(buffer->read_head(), 0U);
 
     EXPECT_TRUE(buffer->read());
-    EXPECT_EQ(buffer->size(), 1);
-    EXPECT_EQ(buffer->available(), 1);
-    EXPECT_EQ(buffer->write_head(), 2);
-    EXPECT_EQ(buffer->read_head(), 1);
+    EXPECT_EQ(buffer->size(), 1U);
+    EXPECT_EQ(buffer->available(), 1U);
+    EXPECT_EQ(buffer->write_head(), 2U);
+    EXPECT_EQ(buffer->read_head(), 1U);
 
     EXPECT_TRUE(buffer->write());
-    EXPECT_EQ(buffer->size(), 2);
-    EXPECT_EQ(buffer->available(), 0);
-    EXPECT_EQ(buffer->write_head(), 0);
-    EXPECT_EQ(buffer->read_head(), 1);
+    EXPECT_EQ(buffer->size(), 2U);
+    EXPECT_EQ(buffer->available(), 0U);
+    EXPECT_EQ(buffer->write_head(), 0U);
+    EXPECT_EQ(buffer->read_head(), 1U);
 
     // Next write should fail, so size shouldn't change
     EXPECT_FALSE(buffer->write());
-    EXPECT_EQ(buffer->size(), 2);
-    EXPECT_EQ(buffer->available(), 0);
-    EXPECT_EQ(buffer->write_head(), 0);
-    EXPECT_EQ(buffer->read_head(), 1);
+    EXPECT_EQ(buffer->size(), 2U);
+    EXPECT_EQ(buffer->available(), 0U);
+    EXPECT_EQ(buffer->write_head(), 0U);
+    EXPECT_EQ(buffer->read_head(), 1U);
 
     EXPECT_TRUE(buffer->read());
-    EXPECT_EQ(buffer->size(), 1);
-    EXPECT_EQ(buffer->available(), 1);
-    EXPECT_EQ(buffer->write_head(), 0);
-    EXPECT_EQ(buffer->read_head(), 2);
+    EXPECT_EQ(buffer->size(), 1U);
+    EXPECT_EQ(buffer->available(), 1U);
+    EXPECT_EQ(buffer->write_head(), 0U);
+    EXPECT_EQ(buffer->read_head(), 2U);
 
     EXPECT_TRUE(buffer->read());
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
-    EXPECT_EQ(buffer->write_head(), 0);
-    EXPECT_EQ(buffer->read_head(), 0);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
+    EXPECT_EQ(buffer->write_head(), 0U);
+    EXPECT_EQ(buffer->read_head(), 0U);
 
     // Next read should fail, so size shouldn't change
     EXPECT_FALSE(buffer->read());
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
-    EXPECT_EQ(buffer->write_head(), 0);
-    EXPECT_EQ(buffer->read_head(), 0);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
+    EXPECT_EQ(buffer->write_head(), 0U);
+    EXPECT_EQ(buffer->read_head(), 0U);
 }
 
 TEST_F(LockFreeRingBufferTest, ReadWriteToBufferAdvanceMultiple) {
@@ -148,46 +148,46 @@ TEST_F(LockFreeRingBufferTest, ReadWriteToBufferAdvanceMultiple) {
     EXPECT_TRUE(buffer->empty());
     EXPECT_FALSE(buffer->full());
 
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
 
     EXPECT_TRUE(buffer->write(2));
-    EXPECT_EQ(buffer->size(), 2);
-    EXPECT_EQ(buffer->available(), 0);
+    EXPECT_EQ(buffer->size(), 2U);
+    EXPECT_EQ(buffer->available(), 0U);
 
     // This write should fail since we advance beyond capacity, so size shouldn't change
     EXPECT_FALSE(buffer->write(2));
-    EXPECT_EQ(buffer->size(), 2);
-    EXPECT_EQ(buffer->available(), 0);
+    EXPECT_EQ(buffer->size(), 2U);
+    EXPECT_EQ(buffer->available(), 0U);
 
     EXPECT_TRUE(buffer->read());
-    EXPECT_EQ(buffer->size(), 1);
-    EXPECT_EQ(buffer->available(), 1);
+    EXPECT_EQ(buffer->size(), 1U);
+    EXPECT_EQ(buffer->available(), 1U);
 
     EXPECT_TRUE(buffer->read());
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
 
     EXPECT_TRUE(buffer->write(2));
-    EXPECT_EQ(buffer->size(), 2);
-    EXPECT_EQ(buffer->available(), 0);
+    EXPECT_EQ(buffer->size(), 2U);
+    EXPECT_EQ(buffer->available(), 0U);
 
     // Any additional write will also fail, size shouldn't change
     EXPECT_FALSE(buffer->write());
-    EXPECT_EQ(buffer->size(), 2);
-    EXPECT_EQ(buffer->available(), 0);
+    EXPECT_EQ(buffer->size(), 2U);
+    EXPECT_EQ(buffer->available(), 0U);
 
     EXPECT_TRUE(buffer->read(2));
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
 
     // This read should fail since we advance beyond available, so size shouldn't change
     EXPECT_FALSE(buffer->read(2));
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
 
     // Any subsequent read will also fail, size shouldn't change
     EXPECT_FALSE(buffer->read());
-    EXPECT_EQ(buffer->size(), 0);
-    EXPECT_EQ(buffer->available(), 2);
+    EXPECT_EQ(buffer->size(), 0U);
+    EXPECT_EQ(buffer->available(), 2U);
 }

--- a/ouster-ros/test/ring_buffer_test.cpp
+++ b/ouster-ros/test/ring_buffer_test.cpp
@@ -8,8 +8,8 @@ using namespace std::chrono_literals;
 
 class ThreadSafeRingBufferTest : public ::testing::Test {
   protected:
-    static const int ITEM_SIZE = 4;   // predefined size for all items used in
-    static const int ITEM_COUNT = 3;  // number of item the buffer could hold
+    static constexpr int ITEM_SIZE = 4;   // predefined size for all items used in
+    static constexpr int ITEM_COUNT = 3;  // number of item the buffer could hold
 
     void SetUp() override {
         buffer = std::make_unique<ThreadSafeRingBuffer>(ITEM_SIZE, ITEM_COUNT);
@@ -172,10 +172,4 @@ TEST_F(ThreadSafeRingBufferTest, ReadWriteToBufferWithOverwrite) {
         std::cout << "source " << source[i] << ", target " << target[i] << std::endl;
         EXPECT_EQ(target[i], "0000"); 
     }
-}
-
-int main(int argc, char** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/ouster-ros/test/test_main.cpp
+++ b/ouster-ros/test/test_main.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Related Issues & PRs
- Closes #240
- Closes #272
- Related #302
- ROS1[NOETIC] #319 
- ROS2[HUMBLE/IRON] #321 

## Problem Analysis
- When adding multiple subscribers or when having a bad network or low performing system, LidarScan composition and processing could eventually take more time, this leads to a build up in the packets buffer which will eventually be exhausted and the current mechanism of the thread_safe_ring_buffer::write_overwrite made things only worse. The solution can be in one of two things either ensure that the LidarScan composition + processing takes less time than the time needed to add new packets, or decouple packet addition from LidarScan consumption, if the consumption thread can't keep up then throttle. 

## Summary of Changes
- Implement lock free ring buffer with unit tests
- Decouple packet reception from packet processing
- Throttle the ring buffer as we reach 70% capacity
- Drop packets only when the ring buffer has been completely exhausted

#### TODO(s):
- Replace the **LockFreeRingBuffer** implementation with **ThreadSafeRingBuffer** within `os_sensor_nodelet`.
  - Alternatively, forward the packets directly to LidarScan without a staging buffers.  

## Validation
- Run the driver as usual with RIVZ, add multiple subscribers to `/ouster/points`
- Verify the problem with missing columns is eliminated or reduced.
- Observe that the point cloud publish frequency isn't affected significantly