### PR TITLE
Workaround for unsupported params file syntax in composable node python launch [Foxy]

### DIFF
--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -29,4 +29,5 @@ ouster/os_cloud:
                   # value the range [0, sensor_beams_count)
     point_type: original # choose from: {original, native, xyz, xyzi, xyzir}
 ouster/os_image:
+  ros__parameters:
     use_system_default_qos: False # needs to match the value defined for os_sensor node


### PR DESCRIPTION
## Related Issues & PRs
* https://github.com/ouster-lidar/ouster-ros/issues/324
* https://github.com/ouster-lidar/ouster-ros/issues/212

## Summary of Changes
* This wraps the composable node launch description definitions into a separate function that reads the parameters file directly and extracts parameters for each node.
* The function is then called as an `OpaqueFunction` launch entity, which allows access to the inner values of `LaunchConfiguration` entities.
* This also maintains correct support for the user-provided `params_file` and `ouster_ns` arguments.
* Added missing `ros__parameters` key in params for `os_image`.

## Validation
* With default namespace:
  1. Configure parameters in `os_sensor_cloud_params.yaml`
  2. Colcon build and source workspace
  3. Use the launch file: `ros2 launch ouster_ros sensor.composite.launch.py`
* With custom namespace:
  1. Configure parameters in `os_sensor_cloud_params.yaml` with the custom namespace value
  2. Colcon build and source workspace
  3. Use the launch file: `ros2 launch ouster_ros sensor.composite.launch.py ouster_ns:=<custom-namespace-value>`
  4. The topics in rviz visualization must be changed manually using the custom namespace.
* All other launch files should still continue working correctly.


## Target platforms
* ROS2 version -> `foxy`
* Operating system -> `5.15.0-105-generic #115~20.04.1-Ubuntu`
