### PR TITLE
Add parameter to optionally disable the publication  of the static tf

### DIFF
--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -67,7 +67,9 @@ class OusterCloud : public OusterProcessingNodeBase {
         RCLCPP_INFO(get_logger(),
                     "OusterCloud: retrieved new sensor metadata!");
         info = sensor::parse_metadata(metadata_msg->data);
-        tf_bcast.broadcast_transforms(info);
+        if (tf_bcast.publish_static_tf()) {
+            tf_bcast.broadcast_transforms(info);
+        }
         create_publishers_subscriptions(info);
     }
 

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -47,7 +47,9 @@ class OusterDriver : public OusterSensor {
 
     virtual void on_metadata_updated(const sensor::sensor_info& info) override {
         OusterSensor::on_metadata_updated(info);
-        tf_bcast.broadcast_transforms(info);
+        if (tf_bcast.publish_static_tf()) {
+          tf_bcast.broadcast_transforms(info);
+        }
     }
 
     virtual void create_publishers() override {

--- a/ouster-ros/src/os_static_transforms_broadcaster.h
+++ b/ouster-ros/src/os_static_transforms_broadcaster.h
@@ -23,6 +23,7 @@ class OusterStaticTransformsBroadcaster {
         node->declare_parameter("lidar_frame", "os_lidar");
         node->declare_parameter("imu_frame", "os_imu");
         node->declare_parameter("point_cloud_frame", "");
+        node->declare_parameter("pub_static_tf", true);
     }
 
     void parse_parameters() {
@@ -31,6 +32,7 @@ class OusterStaticTransformsBroadcaster {
         imu_frame = node->get_parameter("imu_frame").as_string();
         point_cloud_frame =
             node->get_parameter("point_cloud_frame").as_string();
+        pub_static_tf = node->get_parameter("pub_static_tf").as_bool();
 
         // validate point_cloud_frame
         if (point_cloud_frame.empty()) {
@@ -65,6 +67,7 @@ class OusterStaticTransformsBroadcaster {
     bool apply_lidar_to_sensor_transform() const {
         return point_cloud_frame == sensor_frame;
     }
+    bool publish_static_tf() const { return pub_static_tf; }
 
    private:
     NodeT* node;
@@ -73,6 +76,7 @@ class OusterStaticTransformsBroadcaster {
     std::string lidar_frame;
     std::string sensor_frame;
     std::string point_cloud_frame;
+    bool pub_static_tf;
 };
 
 }  // namespace ouster_ros


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes

This PR adds the parameter `pub_static_tf`, by default `True`, to control if the user wants or not to have the driver node publishing the static transform between the sensor frames.
It is useful to have it disabled in systems where a calibration process directly modifies the tf of the point cloud frame.

## Validation
