### PR TITLE
ROS[NOETIC] Add a pcap source reader nodelet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Changelog
 * [BUGFIX]: Implement lock free ring buffer with throttling to avoid generating partial frames
 * add support for FUSA udp profile ``FUSA_RNG15_RFL8_NIR8_DUAL``.
 * [BREAKING] Set xyz values of individual points in the PointCloud to NaNs when range is zero.
+* Added support to replay pcap format direclty from ouster-ros. The feature needs to be enabled
+  explicitly by turning on the ``BUILD_PCAP`` cmake option and having ``libpcap-dev`` installed.
 
 
 ouster_ros v0.10.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,10 @@ add_service_files(FILES GetConfig.srv SetConfig.srv GetMetadata.srv)
 generate_messages(DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 
 set(_ouster_ros_INCLUDE_DIRS
-  "include;ouster-sdk/ouster_client/include;ouster-sdk/ouster_client/include/optional-lite")
+  "include;"
+  "ouster-sdk/ouster_client/include;"
+  "ouster-sdk/ouster_client/include/optional-lite;"
+  "ouster-sdk/ouster_pcap/include")
 
 catkin_package(
   INCLUDE_DIRS
@@ -61,7 +64,7 @@ set(_SAVE_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 
 option(BUILD_VIZ "Enabled for Python build" OFF)
-option(BUILD_PCAP "Enabled for Python build" OFF)
+option(BUILD_PCAP "Enabled for Python build" ON)
 find_package(OusterSDK REQUIRED)
 
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
@@ -74,7 +77,7 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 
 add_library(ouster_ros src/os_ros.cpp)
 target_link_libraries(ouster_ros PUBLIC ${catkin_LIBRARIES} ouster_build pcl_common PRIVATE
-  -Wl,--whole-archive ouster_client -Wl,--no-whole-archive)
+  -Wl,--whole-archive ouster_client ouster_pcap -Wl,--no-whole-archive)
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
 
 # ==== Executables ====
@@ -82,6 +85,7 @@ add_library(${PROJECT_NAME}_nodelets
   src/os_sensor_nodelet_base.cpp
   src/os_sensor_nodelet.cpp
   src/os_replay_nodelet.cpp
+  src/os_pcap_nodelet.cpp
   src/os_cloud_nodelet.cpp
   src/os_image_nodelet.cpp
   src/os_driver_nodelet.cpp)
@@ -100,7 +104,7 @@ if(CATKIN_ENABLE_TESTING)
     tests/point_cloud_compose_test.cpp
   )
   target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES}
-    ouster_build pcl_common -Wl,--whole-archive ouster_client -Wl,--no-whole-archive)
+    ouster_build pcl_common -Wl,--whole-archive ouster_client ouster_pcap -Wl,--no-whole-archive)
 endif()
 
 # ==== Install ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(_SAVE_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 
 option(BUILD_VIZ "Enabled for Python build" OFF)
-option(BUILD_PCAP "Enabled for Python build" ON)
+option(BUILD_PCAP "Enabled for Python build" OFF)
 find_package(OusterSDK REQUIRED)
 
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
@@ -75,9 +75,15 @@ include_directories(${_ouster_ros_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 # use only MPL-licensed parts of eigen
 add_definitions(-DEIGEN_MPL2_ONLY)
 
+set(OUSTER_TARGET_LINKS ouster_client)
+if (BUILD_PCAP)
+  list(APPEND OUSTER_TARGET_LINKS ouster_pcap)
+endif()
+
 add_library(ouster_ros src/os_ros.cpp)
-target_link_libraries(ouster_ros PUBLIC ${catkin_LIBRARIES} ouster_build pcl_common PRIVATE
-  -Wl,--whole-archive ouster_client ouster_pcap -Wl,--no-whole-archive)
+target_link_libraries(ouster_ros
+  PUBLIC ${catkin_LIBRARIES} ouster_build pcl_common
+  PRIVATE -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive)
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
 
 # ==== Executables ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ if(CATKIN_ENABLE_TESTING)
     tests/point_cloud_compose_test.cpp
   )
   target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES}
-    ouster_build pcl_common -Wl,--whole-archive ouster_client ouster_pcap -Wl,--no-whole-archive)
+    ouster_build pcl_common -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive)
 endif()
 
 # ==== Install ====

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
       - [Sensor Mode](#sensor-mode)
       - [Recording Mode](#recording-mode)
       - [Replay Mode](#replay-mode)
+        - [PCAP Replay Mode](#pcap-replay-mode)
       - [Multicast Mode (experimental)](#multicast-mode-experimental)
     - [Launch Files Arguments](#launch-files-arguments)
     - [Invoking Services](#invoking-services)
@@ -80,6 +81,9 @@ sudo apt install -y         \
 > **Note**  
 > You may choose a different ssl backend for the curl library such as `libcurl4-gnutls-dev` or `libcurl4-nss-dev`
 
+> **Note**  
+> To use the PCAP replay mode you need to have `libpcap-dev` installed
+
 ## Getting Started
 To build the driver using ROS you need to clone the project into the `src` folder of a catkin workspace
 as shown below:
@@ -131,7 +135,7 @@ over `sensor.launch`. `sensor.launch` is mainly provided for backward compatibil
 ```bash
 roslaunch ouster_ros record.launch      \
     sensor_hostname:=<sensor host name> \
-    bag_file:=<optional bag file name>
+    bag_file:=<optional bag file name>  \
     metadata:=<json file name>          # optional
 ```
 #### Replay Mode
@@ -144,6 +148,17 @@ roslaunch ouster_ros replay.launch      \
     bag_file:=<path to rosbag file>     \
     metadata:=<json file name>          # optional if bag file has /metadata topic
 ```
+
+##### PCAP Replay Mode
+> Note
+> To use this feature you need to compile the driver with `BUILD_PCAP` option enabled
+
+```bash
+roslaunch ouster_ros replay_pcap.launch     \
+    pcap_file:=<path to ouster pcap file>   \
+    metadata:=<json file name>              # required
+```
+
 
 #### Multicast Mode (experimental)
 The multicast launch mode supports configuring the sensor to broadcast lidar packets from the same

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -1,10 +1,16 @@
 <launch>
 
+  <param name="use_sim_time" value="true"/>
+
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" default ="" doc="path to read metadata file when replaying sensor data"/>
   <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
-  <arg name="timestamp_mode" default=" " doc="A parameter that allows you to override the timestamp measurements;
+  <param name="use_sim_time" value="false"/>
+  <arg name="timestamp_mode" default="TIME_FROM_INTERNAL_OSC" doc="A parameter that allows you to override the timestamp measurements;
     possible values: {
+    TIME_FROM_INTERNAL_OSC,
+    TIME_FROM_SYNC_PULSE_IN,
+    TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
   <arg name="ptp_utc_tai_offset" default="-37.0"

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -3,8 +3,8 @@
   <param name="use_sim_time" value="true"/>
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
-  <arg name="metadata" default ="" doc="path to read metadata file when replaying sensor data"/>
-  <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
+  <arg name="metadata" default="" doc="path to read metadata file when replaying sensor data"/>
+  <arg name="bag_file" doc="file name to use for the recorded bag file"/>
   <param name="use_sim_time" value="false"/>
   <arg name="timestamp_mode" default="TIME_FROM_INTERNAL_OSC" doc="A parameter that allows you to override the timestamp measurements;
     possible values: {

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -5,7 +5,6 @@
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" default="" doc="path to read metadata file when replaying sensor data"/>
   <arg name="bag_file" doc="file name to use for the recorded bag file"/>
-  <param name="use_sim_time" value="false"/>
   <arg name="timestamp_mode" default="TIME_FROM_INTERNAL_OSC" doc="A parameter that allows you to override the timestamp measurements;
     possible values: {
     TIME_FROM_INTERNAL_OSC,

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -1,10 +1,11 @@
 <launch>
 
-  <param name="use_sim_time" value="false" doc="NOTE: pcap replay node does not implement clock"/>
+  <!-- NOTE: pcap replay node does not implement clock-->
+  <param name="use_sim_time" value="false"/>
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
-  <arg name="metadata" default ="" doc="path to read metadata file when replaying sensor data"/>
-  <arg name="pcap_file" default="" doc="file name to use for the recorded pcap file"/>
+  <arg name="metadata" doc="path to read metadata file when replaying sensor data"/>
+  <arg name="pcap_file" doc="file name to use for the recorded pcap file"/>
   <arg name="timestamp_mode" default="TIME_FROM_INTERNAL_OSC" doc="A parameter that allows you to override the timestamp measurements;
     possible values: {
     TIME_FROM_INTERNAL_OSC,
@@ -57,10 +58,8 @@
       output="screen" required="true" args="manager"/>
   </group>
 
-  <arg name="_use_metadata_file" value="$(eval not (metadata == ''))"/>
-
   <group ns="$(arg ouster_ns)">
-    <node if="$(arg _use_metadata_file)" pkg="nodelet" type="nodelet"
+    <node pkg="nodelet" type="nodelet"
       name="os_node" output="screen" required="true"
       launch-prefix="bash -c 'sleep 3; $0 $@' "
       args="load ouster_ros/OusterPcap os_nodelet_mgr">

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <param name="use_sim_time" value="false" doc="NOTE: pcap node doesn't not implemented a clock"/>
+  <param name="use_sim_time" value="false" doc="NOTE: pcap replay node does not implement clock"/>
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" default ="" doc="path to read metadata file when replaying sensor data"/>

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -1,10 +1,15 @@
 <launch>
 
+  <param name="use_sim_time" value="false" doc="NOTE: pcap node doesn't not implemented a clock"/>
+
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" default ="" doc="path to read metadata file when replaying sensor data"/>
   <arg name="pcap_file" default="" doc="file name to use for the recorded pcap file"/>
-  <arg name="timestamp_mode" default=" " doc="A parameter that allows you to override the timestamp measurements;
+  <arg name="timestamp_mode" default="TIME_FROM_INTERNAL_OSC" doc="A parameter that allows you to override the timestamp measurements;
     possible values: {
+    TIME_FROM_INTERNAL_OSC,
+    TIME_FROM_SYNC_PULSE_IN,
+    TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
   <arg name="ptp_utc_tai_offset" default="-37.0"

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -1,0 +1,88 @@
+<launch>
+
+  <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
+  <arg name="metadata" default ="" doc="path to read metadata file when replaying sensor data"/>
+  <arg name="pcap_file" default="" doc="file name to use for the recorded pcap file"/>
+  <arg name="timestamp_mode" default=" " doc="A parameter that allows you to override the timestamp measurements;
+    possible values: {
+    TIME_FROM_ROS_TIME
+    }"/>
+  <arg name="ptp_utc_tai_offset" default="-37.0"
+    doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
+  <arg name="viz" default="true" doc="whether to run a rviz"/>
+  <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
+
+  <arg name="tf_prefix" default=" " doc="namespace for tf transforms"/>
+  <arg name="sensor_frame" default="os_sensor"
+    doc="sets name of choice for the sensor_frame tf frame, value can not be empty"/>
+  <arg name="lidar_frame" default="os_lidar"
+    doc="sets name of choice for the os_lidar tf frame, value can not be empty"/>
+  <arg name="imu_frame" default="os_imu"
+    doc="sets name of choice for the os_imu tf frame, value can not be empty"/>
+  <arg name="point_cloud_frame" default=" "
+    doc="which frame to be used when publishing PointCloud2 or LaserScan messages.
+    Choose between the value of sensor_frame or lidar_frame, leaving this value empty
+    would set lidar_frame to be the frame used when publishing these messages."/>
+
+  <arg name="dynamic_transforms_broadcast" default="false"
+    doc="static or dynamic transforms broadcast"/>
+  <arg name="dynamic_transforms_broadcast_rate" default="1.0"
+    doc="set the rate (Hz) of broadcast when using dynamic broadcast; minimum value is 1 Hz"/>
+
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" doc="
+    The IMG flag here is not supported and does not affect anything,
+    to disable image topics you would need to omit the os_image node
+    from the launch file"/>
+
+  <arg name="scan_ring" default="0" doc="
+    use this parameter in conjunction with the SCAN flag
+    and choose a value the range [0, sensor_beams_count)"/>
+
+  <arg name="point_type" default="original" doc="point type for the generated point cloud;
+   available options: {
+    original,
+    native,
+    xyz,
+    xyzi,
+    xyzir
+    }"/>
+
+  <group ns="$(arg ouster_ns)">
+    <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
+      output="screen" required="true" args="manager"/>
+  </group>
+
+  <arg name="_use_metadata_file" value="$(eval not (metadata == ''))"/>
+
+  <group ns="$(arg ouster_ns)">
+    <node if="$(arg _use_metadata_file)" pkg="nodelet" type="nodelet"
+      name="os_node" output="screen" required="true"
+      launch-prefix="bash -c 'sleep 3; $0 $@' "
+      args="load ouster_ros/OusterPcap os_nodelet_mgr">
+      <param name="~/metadata" value="$(arg metadata)"/>
+      <param name="~/pcap_file" value="$(arg pcap_file)"/>
+    </node>
+  </group>
+
+  <include file="$(find ouster_ros)/launch/common.launch">
+    <arg name="ouster_ns" value="$(arg ouster_ns)"/>
+    <arg name="viz" value="$(arg viz)"/>
+    <arg name="rviz_config" value="$(arg rviz_config)"/>
+    <arg name="tf_prefix" value="$(arg tf_prefix)"/>
+    <arg name="sensor_frame" value="$(arg sensor_frame)"/>
+    <arg name="lidar_frame" value="$(arg lidar_frame)"/>
+    <arg name="imu_frame" value="$(arg imu_frame)"/>
+    <arg name="point_cloud_frame" value="$(arg point_cloud_frame)"/>
+    <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
+    <arg name="ptp_utc_tai_offset" value="$(arg ptp_utc_tai_offset)"/>
+    <arg name="dynamic_transforms_broadcast"
+      value="$(arg dynamic_transforms_broadcast)"/>
+    <arg name="dynamic_transforms_broadcast_rate"
+      value="$(arg dynamic_transforms_broadcast_rate)"/>
+    <arg name="proc_mask" value="$(arg proc_mask)"/>
+    <arg name="scan_ring" value="$(arg scan_ring)"/>
+    <arg name="point_type" value="$(arg point_type)"/>
+  </include>
+
+
+</launch>

--- a/ouster_ros_nodelets.xml
+++ b/ouster_ros_nodelets.xml
@@ -9,6 +9,11 @@
       A nodelet that can load up existing Ouster recordings and replay them.
     </description>
   </class>
+  <class name="ouster_ros/OusterPcap" type="ouster_ros::OusterPcap" base_class_type="nodelet::Nodelet">
+    <description>
+      A nodelet that can directly load ouster sensor data from a pcap file.
+    </description>
+  </class>
   <class name="ouster_ros/OusterCloud" type="ouster_ros::OusterCloud" base_class_type="nodelet::Nodelet">
     <description>
       A nodelet that process incoming Ouster lidar packets and publishes a corresponding point cloud.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.12.3</version>
+  <version>0.12.4</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/os_pcap_nodelet.cpp
+++ b/src/os_pcap_nodelet.cpp
@@ -214,7 +214,6 @@ class OusterPcap : public OusterSensorNodeletBase {
     PacketMsg imu_packet;
     ros::Publisher lidar_packet_pub;
     ros::Publisher imu_packet_pub;
-    ros::ServiceServer reset_srv;
 
     std::unique_ptr<ThreadSafeRingBuffer> lidar_packets;
     std::unique_ptr<ThreadSafeRingBuffer> imu_packets;
@@ -227,22 +226,6 @@ class OusterPcap : public OusterSensorNodeletBase {
 
     std::atomic<bool> lidar_packets_processing_thread_active = {false};
     std::unique_ptr<std::thread> lidar_packets_processing_thread;
-
-    bool force_sensor_reinit = false;
-    bool reset_last_init_id = true;
-
-    bool last_init_id_initialized = false;
-    uint32_t last_init_id;
-
-    // TODO: add as a ros parameter
-    const int max_poll_client_error_count = 10;
-    int poll_client_error_count = 0;
-    // TODO: add as a ros parameter
-    const int max_read_lidar_packet_errors = 60;
-    int read_lidar_packet_errors = 0;
-    // TODO: add as a ros parameter
-    const int max_read_imu_packet_errors = 60;
-    int read_imu_packet_errors = 0;
 
     bool pause = false;
 };

--- a/src/os_pcap_nodelet.cpp
+++ b/src/os_pcap_nodelet.cpp
@@ -49,8 +49,8 @@ class OusterPcap : public OusterSensorNodeletBase {
         auto meta_file =
             getPrivateNodeHandle().param("metadata", std::string{});
         if (!is_arg_set(meta_file)) {
-            NODELET_ERROR("Must specify metadata file in replay mode");
-            throw std::runtime_error("metadata no specificed");
+            NODELET_FATAL("Must specify metadata file in replay mode");
+            throw std::runtime_error("metadata param not set");
         }
         return meta_file;
     }
@@ -59,8 +59,8 @@ class OusterPcap : public OusterSensorNodeletBase {
         auto pcap_file =
             getPrivateNodeHandle().param("pcap_file", std::string{});
         if (!is_arg_set(pcap_file)) {
-            NODELET_ERROR("Must specify pcap file in pcap replay mode");
-            throw std::runtime_error("metadata no specificed");
+            NODELET_FATAL("Must specify pcap file in pcap replay mode");
+            throw std::runtime_error("pcap_file param not set");
         }
         return pcap_file;
     }
@@ -73,7 +73,7 @@ class OusterPcap : public OusterSensorNodeletBase {
         } catch (const std::runtime_error& e) {
             cached_metadata.clear();
             NODELET_ERROR_STREAM(
-                "Error when running in replay mode: " << e.what());
+                "Error loading metadata: " << e.what());
         }
     }
 

--- a/src/os_pcap_nodelet.cpp
+++ b/src/os_pcap_nodelet.cpp
@@ -17,6 +17,8 @@
 
 #include <string>
 #include <thread>
+#include <chrono>
+#include <iomanip>
 
 #include "ouster_ros/os_sensor_nodelet_base.h"
 #include "ouster_ros/PacketMsg.h"
@@ -202,7 +204,9 @@ class OusterPcap : public OusterSensorNodeletBase {
                                     pf.lidar_packet_size);
                     });
             } else {
-                std::cout << "unknown packet" << std::endl;
+                NODELET_WARN_STREAM_THROTTLE(1,
+                    "unknown packet /w port: "
+                    << packet_info.dst_port);
             }
             auto prev_packet_ts = packet_info.timestamp;
             payload_size = pcap.next_packet();

--- a/src/os_pcap_nodelet.cpp
+++ b/src/os_pcap_nodelet.cpp
@@ -25,6 +25,7 @@
 
 namespace sensor = ouster::sensor;
 using ouster::sensor_utils::PcapReader;
+using namespace std::chrono;
 
 namespace ouster_ros {
 
@@ -181,8 +182,13 @@ class OusterPcap : public OusterSensorNodeletBase {
     void read_packets(PcapReader& pcap, const sensor::packet_format& pf) {
         size_t payload_size = pcap.next_packet();
         auto packet_info = pcap.current_info();
+        auto file_start = packet_info.timestamp;
+        auto last_update = file_start;
+        using namespace std::chrono_literals;
+        const auto UPDATE_PERIOD = duration_cast<microseconds>(1s / 3);
+
         while (payload_size) {
-            auto start = std::chrono::high_resolution_clock::now();
+            auto start = high_resolution_clock::now();
             if (packet_info.dst_port == info.config.udp_port_imu) {
                 imu_packets->write_overwrite(
                     [this, &pcap, &pf, &packet_info](uint8_t* buffer) {
@@ -202,9 +208,17 @@ class OusterPcap : public OusterSensorNodeletBase {
             payload_size = pcap.next_packet();
             packet_info = pcap.current_info();
             auto curr_packet_ts = packet_info.timestamp;
-            auto end = std::chrono::high_resolution_clock::now();
+            auto end = high_resolution_clock::now();
             auto dt = (curr_packet_ts - prev_packet_ts) - (end - start);
             std::this_thread::sleep_for(dt);  // pace packet generation
+
+            if (curr_packet_ts - last_update > UPDATE_PERIOD) {
+                last_update = curr_packet_ts;
+                std::cout << "\rtime passed: "
+                    << std::fixed << std::setprecision(3)
+                    << (curr_packet_ts - file_start).count() / 1e6f
+                    << " s" << std::flush;
+            }
         }
     }
 
@@ -226,8 +240,6 @@ class OusterPcap : public OusterSensorNodeletBase {
 
     std::atomic<bool> lidar_packets_processing_thread_active = {false};
     std::unique_ptr<std::thread> lidar_packets_processing_thread;
-
-    bool pause = false;
 };
 
 }  // namespace ouster_ros

--- a/src/os_pcap_nodelet.cpp
+++ b/src/os_pcap_nodelet.cpp
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file os_pcap_nodelet.cpp
+ * @brief This nodelet mainly handles publishing saved metadata
+ *
+ */
+
+// prevent clang-format from altering the location of "ouster_ros/ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+
+#include <pluginlib/class_list_macros.h>
+
+#include <string>
+#include <thread>
+
+#include "ouster_ros/os_sensor_nodelet_base.h"
+#include "ouster_ros/PacketMsg.h"
+#include "thread_safe_ring_buffer.h"
+#include <ouster/os_pcap.h>
+
+namespace sensor = ouster::sensor;
+
+namespace ouster_ros {
+
+class OusterPcap : public OusterSensorNodeletBase {
+   private:
+    virtual void onInit() override {
+        auto meta_file = get_meta_file();
+        auto pcap_file = get_pcap_file();
+        create_metadata_publisher();
+        load_metadata_from_file(meta_file);
+        allocate_buffers();
+        create_publishers();
+        open_pcap(pcap_file);
+        publish_metadata();
+        create_get_metadata_service();
+        start_packet_processing_threads();
+        start_packet_read_thread();
+        NODELET_INFO("Running in replay mode");
+    }
+
+    std::string get_meta_file() const {
+        auto meta_file =
+            getPrivateNodeHandle().param("metadata", std::string{});
+        if (!is_arg_set(meta_file)) {
+            NODELET_ERROR("Must specify metadata file in replay mode");
+            throw std::runtime_error("metadata no specificed");
+        }
+        return meta_file;
+    }
+
+    std::string get_pcap_file() const {
+        auto pcap_file =
+            getPrivateNodeHandle().param("pcap_file", std::string{});
+        if (!is_arg_set(pcap_file)) {
+            NODELET_ERROR("Must specify pcap file in pcap replay mode");
+            throw std::runtime_error("metadata no specificed");
+        }
+        return pcap_file;
+    }
+
+    void load_metadata_from_file(const std::string& meta_file) {
+        try {
+            cached_metadata = read_text_file(meta_file);
+            info = sensor::parse_metadata(cached_metadata);
+            display_lidar_info(info);
+        } catch (const std::runtime_error& e) {
+            cached_metadata.clear();
+            NODELET_ERROR_STREAM(
+                "Error when running in replay mode: " << e.what());
+        }
+    }
+
+    void allocate_buffers() {
+        auto& pf = sensor::get_format(info);
+
+        lidar_packet.buf.resize(pf.lidar_packet_size);
+        // TODO: gauge necessary queue size for lidar packets
+        lidar_packets =
+            std::make_unique<ThreadSafeRingBuffer>(pf.lidar_packet_size, 1024);
+
+        imu_packet.buf.resize(pf.imu_packet_size);
+        // TODO: gauge necessary queue size for lidar packets
+        imu_packets =
+            std::make_unique<ThreadSafeRingBuffer>(pf.imu_packet_size, 1024);
+    }
+
+    void create_publishers() {
+        auto& nh = getNodeHandle();
+        lidar_packet_pub = nh.advertise<PacketMsg>("lidar_packets", 1280);
+        imu_packet_pub = nh.advertise<PacketMsg>("imu_packets", 100);
+    }
+
+    void open_pcap(const std::string& pcap_file) {
+        pcap_handle = ouster::sensor_utils::replay_initialize(pcap_file);
+        ouster::sensor_utils::replay_reset(*pcap_handle);    // not sure if this is needed
+    }
+
+    void start_packet_read_thread() {
+        packet_read_active = true;
+        packet_read_thread = std::make_unique<std::thread>([this]() {
+            auto& pf = sensor::get_format(info);
+            while (packet_read_active) {
+                read_packets(*pcap_handle, pf);
+            }
+            NODELET_DEBUG("packet_read_thread done.");
+        });
+    }
+
+    void stop_packet_read_thread() {
+        NODELET_DEBUG("packet_read_thread stopping.");
+        if (packet_read_thread->joinable()) {
+            packet_read_active = false;
+            packet_read_thread->join();
+        }
+    }
+
+    void start_packet_processing_threads() {
+        imu_packets_processing_thread_active = true;
+        imu_packets_processing_thread = std::make_unique<std::thread>([this]() {
+            while (imu_packets_processing_thread_active) {
+                imu_packets->read([this](const uint8_t* buffer) {
+                    on_imu_packet_msg(buffer);
+                });
+            }
+            NODELET_DEBUG("imu_packets_processing_thread done.");
+        });
+
+        lidar_packets_processing_thread_active = true;
+        lidar_packets_processing_thread = std::make_unique<std::thread>([this]() {
+            while (lidar_packets_processing_thread_active) {
+                lidar_packets->read([this](const uint8_t* buffer) {
+                    on_lidar_packet_msg(buffer);
+                });
+            }
+
+            NODELET_DEBUG("lidar_packets_processing_thread done.");
+        });
+    }
+
+    void stop_packet_processing_threads() {
+        NODELET_DEBUG("stopping packet processing threads.");
+
+        if (imu_packets_processing_thread->joinable()) {
+            imu_packets_processing_thread_active = false;
+            imu_packets_processing_thread->join();
+        }
+
+        if (lidar_packets_processing_thread->joinable()) {
+            lidar_packets_processing_thread_active = false;
+            lidar_packets_processing_thread->join();
+        }
+    }
+
+    void on_lidar_packet_msg(const uint8_t* raw_lidar_packet) {
+        // copying the data from queue buffer into the message buffer
+        // this can be avoided by constructing an abstraction where
+        // OusterSensor has its own RingBuffer of PacketMsg but for
+        // now we are focusing on optimizing the code for OusterDriver
+        std::memcpy(lidar_packet.buf.data(), raw_lidar_packet,
+                    lidar_packet.buf.size());
+        lidar_packet_pub.publish(lidar_packet);
+    }
+
+    void on_imu_packet_msg(const uint8_t* raw_imu_packet) {
+        // copying the data from queue buffer into the message buffer
+        // this can be avoided by constructing an abstraction where
+        // OusterSensor has its own RingBuffer of PacketMsg but for
+        // now we are focusing on optimizing the code for OusterDriver
+        std::memcpy(imu_packet.buf.data(), raw_imu_packet, imu_packet.buf.size());
+        imu_packet_pub.publish(imu_packet);
+    }
+
+    void read_packets(ouster::sensor_utils::playback_handle& handle,
+                     const sensor::packet_format& pf) {
+
+        // Buffer to store raw packet data
+        ouster::sensor::LidarPacket packet(pf.lidar_packet_size);
+        ouster::sensor_utils::packet_info packet_info;
+        auto fps = ouster::sensor::frequency_of_lidar_mode(info.mode);
+        auto n_cols = ouster::sensor::n_cols_of_lidar_mode(info.mode);
+        auto n_packets = n_cols / pf.columns_per_packet;
+        auto ts_spacing = std::chrono::nanoseconds(static_cast<int64_t>(1e9 / (fps * n_packets)));
+
+
+        // TODO: restructure code to permit peeking into next packet before attempting to read
+        // without having to rely on sensor hz
+        while (ouster::sensor_utils::next_packet_info(handle, packet_info)) {
+
+            if (packet_info.dst_port == info.config.udp_port_imu) {
+
+                    imu_packets->write_overwrite(
+                    [this, &handle, &pf, &packet_info](uint8_t* buffer) {
+
+                    auto packet_size = ouster::sensor_utils::read_packet(
+                        handle, buffer, pf.imu_packet_size);
+
+                    if (packet_size == pf.imu_packet_size &&
+                        packet_info.dst_port == info.config.udp_port_imu) {
+                    } else {
+                        ROS_ERROR_STREAM("Inconsistent packet_size=" << packet_size
+                            << " vs expected=" << pf.imu_packet_size);
+                    }
+                });
+            } else if (packet_info.dst_port == info.config.udp_port_lidar) {
+                lidar_packets->write_overwrite(
+                    [this, &handle, &pf, &packet_info](uint8_t* buffer) {
+
+                    auto packet_size = ouster::sensor_utils::read_packet(
+                        handle, buffer, pf.lidar_packet_size);
+
+                    // make sure packet is valid
+                    if (packet_size == pf.lidar_packet_size &&
+                        packet_info.dst_port == info.config.udp_port_lidar) {
+                    } else {
+                        ROS_ERROR_STREAM("Inconsistent packet_size=" << packet_size
+                            << " vs expected=" << pf.lidar_packet_size);
+                    }
+
+                });
+
+                // only pace lidar packets (this approximates)
+                std::this_thread::sleep_for(ts_spacing);
+
+            }
+        }
+    }
+
+   private:
+    std::shared_ptr<ouster::sensor_utils::playback_handle> pcap_handle;
+    PacketMsg lidar_packet;
+    PacketMsg imu_packet;
+    ros::Publisher lidar_packet_pub;
+    ros::Publisher imu_packet_pub;
+    ros::ServiceServer reset_srv;
+
+    std::unique_ptr<ThreadSafeRingBuffer> lidar_packets;
+    std::unique_ptr<ThreadSafeRingBuffer> imu_packets;
+
+    std::atomic<bool> packet_read_active = {false};
+    std::unique_ptr<std::thread> packet_read_thread;
+
+    std::atomic<bool> imu_packets_processing_thread_active = {false};
+    std::unique_ptr<std::thread> imu_packets_processing_thread;
+
+    std::atomic<bool> lidar_packets_processing_thread_active = {false};
+    std::unique_ptr<std::thread> lidar_packets_processing_thread;
+
+    bool force_sensor_reinit = false;
+    bool reset_last_init_id = true;
+
+    bool last_init_id_initialized = false;
+    uint32_t last_init_id;
+
+    // TODO: add as a ros parameter
+    const int max_poll_client_error_count = 10;
+    int poll_client_error_count = 0;
+    // TODO: add as a ros parameter
+    const int max_read_lidar_packet_errors = 60;
+    int read_lidar_packet_errors = 0;
+    // TODO: add as a ros parameter
+    const int max_read_imu_packet_errors = 60;
+    int read_imu_packet_errors = 0;
+
+};
+
+}  // namespace ouster_ros
+
+PLUGINLIB_EXPORT_CLASS(ouster_ros::OusterPcap, nodelet::Nodelet)


### PR DESCRIPTION
## Related Issues & PRs
- related #353 
- related #355 
- closes #7 
- closes #13
- related #48
- #172
- closes #192
- related #333

## Summary of Changes
- Implement a pcap reader nodelet
- Pace scans by the packets timestamps
- Conditionality enable and link the pcap library
- Display progress

## Validation
* Enable `PCAP_BUILD` flag and build the driver then execute:
 
```bash
roslaunch ouster_ros replay_pcap.launch \
pcap_file:=... \
metadata:= ..
```