### PR TITLE
ROS-227: Set LIDAR FOV on startup and add an option to persist the config [NOETIC]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Changelog
 * [BREAKING] Set xyz values of individual points in the PointCloud to NaNs when range is zero.
 * Added support to replay pcap format direclty from ouster-ros. The feature needs to be enabled
   explicitly by turning on the ``BUILD_PCAP`` cmake option and having ``libpcap-dev`` installed.
+* Added new launch files args ``azimuth_window_start`` and ``azimuth_window_end`` to allow users
+ to set LIDAR FOV on startup
+* Add a new launch ``persist_config`` option to request the sensor persist the current config
 
 
 ouster_ros v0.10.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,8 @@ Changelog
 * [BREAKING] Added new launch files args ``azimuth_window_start`` and ``azimuth_window_end`` to
   allow users to set LIDAR FOV on startup. The new options will reset the current azimuth window
   to the default
-* Add a new launch ``persist_config`` option to request the sensor persist the current config
+* Added a new launch ``persist_config`` option to request the sensor persist the current config
+* Added a new ``loop`` option to the ``replay.launch`` file.
 
 
 ouster_ros v0.10.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,9 @@ Changelog
 * [BREAKING] Set xyz values of individual points in the PointCloud to NaNs when range is zero.
 * Added support to replay pcap format direclty from ouster-ros. The feature needs to be enabled
   explicitly by turning on the ``BUILD_PCAP`` cmake option and having ``libpcap-dev`` installed.
-* Added new launch files args ``azimuth_window_start`` and ``azimuth_window_end`` to allow users
- to set LIDAR FOV on startup
+* [BREAKING] Added new launch files args ``azimuth_window_start`` and ``azimuth_window_end`` to
+  allow users to set LIDAR FOV on startup. The new options will reset the current azimuth window
+  to the default
 * Add a new launch ``persist_config`` option to request the sensor persist the current config
 
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -66,9 +66,9 @@
     }"/>
 
   <arg name="azimuth_window_start" default="0" doc="azimuth window start;
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end;
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
 
   <arg name="persist_config" default="false"
     doc="request the sensor to persist settings"/>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -70,6 +70,9 @@
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end;
     values range [0, 360000] millideggrees"/>
 
+  <arg name="persist_config" default="false"
+    doc="request the sensor to persist settings"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -99,6 +102,7 @@
       <param name="~/point_type" value="$(arg point_type)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
       <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
+      <param name="~/persist_config" value="$(arg persist_config)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -65,6 +65,11 @@
     xyzir
     }"/>
 
+  <arg name="azimuth_window_start" default="0" doc="azimuth window start;
+    values range [0, 360000] millideggrees"/>
+  <arg name="azimuth_window_end" default="360000" doc="azimuth window end;
+    values range [0, 360000] millideggrees"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -92,6 +97,8 @@
       <param name="~/proc_mask" value="$(arg proc_mask)"/>
       <param name="~/scan_ring" value="$(arg scan_ring)"/>
       <param name="~/point_type" value="$(arg point_type)"/>
+      <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
+      <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
     </node>
   </group>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -68,6 +68,11 @@
     xyzir
     }"/>
 
+  <arg name="azimuth_window_start" default="0" doc="azimuth window start,
+    values range [0, 360000] millideggrees"/>
+  <arg name="azimuth_window_end" default="360000" doc="azimuth window end,
+    values range [0, 360000] millideggrees"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -86,6 +91,8 @@
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
+      <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
+      <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
     </node>
   </group>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -69,9 +69,9 @@
     }"/>
 
   <arg name="azimuth_window_start" default="0" doc="azimuth window start,
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end,
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
 
   <arg name="persist_config" default="false"
     doc="request the sensor to persist settings"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -73,6 +73,9 @@
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end,
     values range [0, 360000] millideggrees"/>
 
+  <arg name="persist_config" default="false"
+    doc="request the sensor to persist settings"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -93,6 +96,7 @@
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
       <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
+      <param name="~/persist_config" value="$(arg persist_config)"/>
     </node>
   </group>
 

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -2,7 +2,7 @@
 
   <param name="use_sim_time" value="true"/>
 
-  <arg name="loop" default="false" doc="request loop playback"/>    
+  <arg name="loop" default="false" doc="request loop playback"/>
   <arg if="$(arg loop)" name="_loop" value="--loop"/>
   <arg unless="$(arg loop)" name="_loop" value=" "/>
 

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -2,6 +2,10 @@
 
   <param name="use_sim_time" value="true"/>
 
+  <arg name="loop" default="false" doc="request loop playback"/>    
+  <arg if="$(arg loop)" name="_loop" value="--loop"/>
+  <arg unless="$(arg loop)" name="_loop" value=" "/>
+
   <remap from="/os_node/imu_packets" to="/ouster/imu_packets"/>
   <remap from="/os_node/lidar_packets" to="/ouster/lidar_packets"/>
 
@@ -96,6 +100,6 @@
   <node if="$(arg _use_bag_file_name)" pkg="rosbag" type="play" name="rosbag_play_recording"
     launch-prefix="bash -c 'sleep 3; $0 $@' "
     output="screen" required="true"
-    args="--clock $(arg bag_file) -l"/>
+    args="--clock $(arg bag_file) $(arg _loop)"/>
 
 </launch>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -2,6 +2,9 @@
 
   <param name="use_sim_time" value="true"/>
 
+  <remap from="/os_node/imu_packets" to="/ouster/imu_packets"/>
+  <remap from="/os_node/lidar_packets" to="/ouster/lidar_packets"/>
+
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" default="" doc="path to read metadata file when replaying sensor data"/>
   <arg name="bag_file" doc="file name to use for the recorded bag file"/>
@@ -93,6 +96,6 @@
   <node if="$(arg _use_bag_file_name)" pkg="rosbag" type="play" name="rosbag_play_recording"
     launch-prefix="bash -c 'sleep 3; $0 $@' "
     output="screen" required="true"
-    args="--clock $(arg bag_file)"/>
+    args="--clock $(arg bag_file) -l"/>
 
 </launch>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -73,6 +73,11 @@
     xyzir
     }"/>
 
+  <arg name="azimuth_window_start" default="0" doc="azimuth window start;
+    values range [0, 360000] millideggrees"/>
+  <arg name="azimuth_window_end" default="360000" doc="azimuth window end;
+    values range [0, 360000] millideggrees"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -90,6 +95,8 @@
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
+      <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
+      <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
     </node>
   </group>
 

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -74,9 +74,9 @@
     }"/>
 
   <arg name="azimuth_window_start" default="0" doc="azimuth window start;
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end;
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
 
   <arg name="persist_config" default="false"
     doc="request the sensor to persist settings"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -78,6 +78,9 @@
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end;
     values range [0, 360000] millideggrees"/>
 
+  <arg name="persist_config" default="false"
+    doc="request the sensor to persist settings"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -97,6 +100,7 @@
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
       <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
+      <param name="~/persist_config" value="$(arg persist_config)"/>
     </node>
   </group>
 

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -78,9 +78,9 @@
     }"/>
 
   <arg name="azimuth_window_start" default="0" doc="azimuth window start,
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end,
-    values range [0, 360000] millideggrees"/>
+    values range [0, 360000] millidegrees"/>
 
   <arg name="persist_config" default="false"
     doc="request the sensor to persist settings"/>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -77,6 +77,11 @@
     xyzir
     }"/>
 
+  <arg name="azimuth_window_start" default="0" doc="azimuth window start,
+    values range [0, 360000] millideggrees"/>
+  <arg name="azimuth_window_end" default="360000" doc="azimuth window end,
+    values range [0, 360000] millideggrees"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true"
@@ -97,6 +102,8 @@
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
+      <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
+      <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
     </node>
   </group>
 

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -82,6 +82,9 @@
   <arg name="azimuth_window_end" default="360000" doc="azimuth window end,
     values range [0, 360000] millideggrees"/>
 
+  <arg name="persist_config" default="false"
+    doc="request the sensor to persist settings"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true"
@@ -104,6 +107,7 @@
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
       <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
+      <param name="~/persist_config" value="$(arg persist_config)"/>
     </node>
   </group>
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.12.4</version>
+  <version>0.12.5</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -320,7 +320,8 @@ sensor::sensor_config OusterSensor::parse_config_from_ros_parameters() {
     persist_config = nh.param("persist_config", false);
     if (persist_config && (lidar_port == 0 || imu_port == 0)) {
         NODELET_WARN("When using persist_config it is recommended to not "
-        "use 0 for port value");
+        "use 0 for port values as this currently will trigger sensor reinit "
+        "event each time");
     }
 
 

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -317,6 +317,13 @@ sensor::sensor_config OusterSensor::parse_config_from_ros_parameters() {
         config.udp_port_imu = imu_port;
     }
 
+    persist_config = nh.param("persist_config", false);
+    if (persist_config && (lidar_port == 0 || imu_port == 0)) {
+        NODELET_WARN("When using persist_config it is recommended to not "
+        "use 0 for port value");
+    }
+
+
     config.udp_profile_lidar = udp_profile_lidar;
     config.operating_mode = sensor::OPERATING_NORMAL;
     if (lidar_mode) config.ld_mode = lidar_mode;
@@ -374,6 +381,11 @@ uint8_t OusterSensor::compose_config_flags(
         force_sensor_reinit = false;
         NODELET_INFO("Forcing sensor to reinitialize");
         config_flags |= ouster::sensor::CONFIG_FORCE_REINIT;
+    }
+
+    if (persist_config) {
+        NODELET_INFO("Configuration will be persisted");
+        config_flags |= ouster::sensor::CONFIG_PERSIST;
     }
 
     return config_flags;

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -141,8 +141,7 @@ class OusterSensor : public OusterSensorNodeletBase {
     bool force_sensor_reinit = false;
     bool reset_last_init_id = true;
 
-    bool last_init_id_initialized = false;
-    uint32_t last_init_id;
+    nonstd::optional<uint32_t> last_init_id;
 
     // TODO: add as a ros parameter
     const int max_poll_client_error_count = 10;

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -138,6 +138,7 @@ class OusterSensor : public OusterSensorNodeletBase {
     std::atomic<bool> lidar_packets_processing_thread_active = {false};
     std::unique_ptr<std::thread> lidar_packets_processing_thread;
 
+    bool persist_config = false;
     bool force_sensor_reinit = false;
     bool reset_last_init_id = true;
 


### PR DESCRIPTION
## Related Issues & PRs
- closes #138
- related #227

## Summary of Changes
* Set LIDAR FOV on startup
* Add an option to persist the config

## Validation
* Run the node with azimuth start and stop as follows 
```bash
roslaunch ouster_ros driver.launch \
    azimuth_window_start:=150000 \
    azimuth_window_end:=250000
```
Verify that the azimuth window is cropped to selection 

* Run the node with `persist_config` set **true** as follows 
```bash
roslaunch ouster_ros driver.launch \
   <pass a selection of settings> \
    persist_config:=true
```
Verify that the new settings persist after power up/down cycle of the sensor