### PR TITLE
Link pcap nodelet only if BUILD_PCAP is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,10 @@ add_definitions(-DEIGEN_MPL2_ONLY)
 set(OUSTER_TARGET_LINKS ouster_client)
 if (BUILD_PCAP)
   list(APPEND OUSTER_TARGET_LINKS ouster_pcap)
+  # Include os_pcap_nodelet.cpp only if BUILD_PCAP is defined
+  set(PCAP_NODELET_SRC src/os_pcap_nodelet.cpp)
+else()
+  set(PCAP_NODELET_SRC "")
 endif()
 
 add_library(ouster_ros src/os_ros.cpp)
@@ -91,7 +95,7 @@ add_library(${PROJECT_NAME}_nodelets
   src/os_sensor_nodelet_base.cpp
   src/os_sensor_nodelet.cpp
   src/os_replay_nodelet.cpp
-  src/os_pcap_nodelet.cpp
+  ${PCAP_NODELET_SRC} # Include os_pcap_nodelet.cpp only if BUILD_PCAP is defined
   src/os_cloud_nodelet.cpp
   src/os_image_nodelet.cpp
   src/os_driver_nodelet.cpp)


### PR DESCRIPTION
## Related Issues & PRs
When using current master with `BUILD_PCAP` set to default value `OFF` i got the following error:
![image](https://github.com/user-attachments/assets/2ddae1a4-9e0d-46cd-8bfe-31da9a85a105)

## Summary of Changes
This seems to stem from that pcap_node is linked into the nodelets library regardless of the `BUILD_PCAP` cmake arg

## Validation
Tested on my robot with ouster lidar. `roslaunch ouster_ros sensor.launch <my_args>` now runs as expected
