### PR TITLE
ROS-119: ouster-ros driver automatic reconnection [HUMBLE/IRON/JAZZY]

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,7 @@ jobs:
           - rolling
           - humble
           - iron
+          - jazzy
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,7 @@ jobs:
           - iron
           - jazzy
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build the Docker image

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,11 @@ Changelog
   explicitly by turning on the ``BUILD_PCAP`` cmake option and having ``libpcap-dev`` installed.
 * [BREAKING] Added new launch files args ``azimuth_window_start`` and ``azimuth_window_end`` to
   allow users to set LIDAR FOV on startup. The new options will reset the current azimuth window
-  to the default
+  to the default [0, 360] azimuth if not configured.
 * Added a new launch ``persist_config`` option to request the sensor persist the current config
 * Added a new ``loop`` option to the ``replay.launch.xml`` file.
+* Added support for automatic sensor reconnection. Consult ``attempt_reconnect`` launch file arg
+  documentation and the associated params to enable.
 
 ouster_ros v0.12.0
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changelog
 * Added support for automatic sensor reconnection. Consult ``attempt_reconnect`` launch file arg
   documentation and the associated params to enable. Known Issues:
   - Doesn't handle detect and handle invalid configurations
+* Added an automatic start mode to make it easier to start the node without using time actions.
+  - To disable set ``auto_start`` to ``false`` during launch
 
 
 ouster_ros v0.12.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,9 @@ Changelog
 * Added a new launch ``persist_config`` option to request the sensor persist the current config
 * Added a new ``loop`` option to the ``replay.launch.xml`` file.
 * Added support for automatic sensor reconnection. Consult ``attempt_reconnect`` launch file arg
-  documentation and the associated params to enable.
+  documentation and the associated params to enable. Known Issues:
+  - Doesn't handle detect and handle invalid configurations
+
 
 ouster_ros v0.12.0
 ==================

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Official ROS driver for Ouster sensors
 
 [ROS1 (melodic/noetic)](https://github.com/ouster-lidar/ouster-ros/tree/master) |
-[ROS2 (rolling/humble/iron)](https://github.com/ouster-lidar/ouster-ros/tree/ros2) |
+[ROS2 (rolling/humble/iron/jazzy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2) |
 [ROS2 (galactic/foxy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2-foxy)
 
 <p style="float: right;"><img width="20%" src="docs/images/logo.png" /></p>
@@ -9,7 +9,7 @@
 | ROS Version | Build Status (Linux) |
 |:-----------:|:------:|
 | ROS1 (melodic/noetic) | [![melodic/noetic](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=master)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
-| ROS2 (rolling/humble/iron) | [![rolling/humble/iron](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
+| ROS2 (rolling/humble/iron/jazzy) | [![rolling/humble/iron/jazzy](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 | ROS2 (galactic/foxy) | [![galactic/foxy](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2-foxy)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 
 - [Official ROS driver for Ouster sensors](#official-ros-driver-for-ouster-sensors)
@@ -57,9 +57,9 @@ You can obtain detailed specs sheet about the sensors and obtain updated FW thro
 [downloads](https://ouster.com/downloads) section.
 
 ## Requirements
-This branch is only intended for use with **Rolling**, **Humble** and **Iron** ROS 2 distros. Please
-refer to ROS 2 online documentation on how to setup ROS on your machine before proceeding with the
-remainder of this guide.
+This branch is only intended for use with **Rolling**, **Humble**, **Iron** and **Jazzy** ROS 2 distros.
+Please refer to ROS 2 online documentation on how to setup ROS on your machine before proceeding with
+the remainder of this guide.
 
 > **Note**  
 > If you have _rosdep_ tool installed on your system you can then use the following command to get all
@@ -77,7 +77,7 @@ sudo apt install -y             \
     ros-$ROS_DISTRO-tf2-eigen   \
     ros-$ROS_DISTRO-rviz2
 ```
-where `$ROS_DISTRO` can be either ``rolling``, ``humble`` or ``iron``.
+where `$ROS_DISTRO` can be either ``rolling``, ``humble``, ``iron`` or ``jazzy``.
 
 > **Note**  
 > Installing `ros-$ROS_DISTRO-rviz` package is optional in case you didn't need to visualize the
@@ -120,7 +120,7 @@ git clone -b ros2 --recurse-submodules https://github.com/ouster-lidar/ouster-ro
 
 Next to compile the driver you need to source the ROS environemt into the active termainl:
 ```bash
-source /opt/ros/<ros-distro>/setup.bash # replace ros-distro with 'rolling', 'humble', or 'iron'
+source /opt/ros/<ros-distro>/setup.bash # replace ros-distro with 'rolling', 'humble', 'iron' or 'jazzy'
 ```
 
 Finally, invoke `colcon build` command from within the catkin workspace as shown below:

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -93,3 +93,12 @@ ouster/os_driver:
     azimuth_window_end: 360000
     # persist_config[optional]: request the sensor to persist settings
     persist_config: false
+    # attempt_config[optional]: attempting to reconnect to the sensor after
+    # connection loss or sensor powered down
+    attempt_reconnect: false
+    # dormant_period_between_reconnects[optional]: wait time in seconds between
+    # reconnection attempts
+    dormant_period_between_reconnects: 1.0
+    # max_failed_reconnect_attempts[optional]: maximum number of attempts trying
+    # to communicate with the sensor. Counter resets upon successful connection.
+    max_failed_reconnect_attempts: 2147483647

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -14,7 +14,7 @@ ouster/os_sensor:
     metadata: ''
     lidar_port: 0
     imu_port: 0
-    use_system_default_qos: False
+    use_system_default_qos: false
     azimuth_window_start: 0
     azimuth_window_end: 360000
     persist_config: false
@@ -27,9 +27,9 @@ ouster/os_cloud:
     timestamp_mode: ''  # this value needs to match os_sensor/timestamp_mode
     ptp_utc_tai_offset: -37.0 # UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588
     proc_mask: IMU|PCL|SCAN # pick IMU, PCL, SCAN or any combination of the three options
-    use_system_default_qos: False # needs to match the value defined for os_sensor node
+    use_system_default_qos: false # needs to match the value defined for os_sensor node
     scan_ring: 0  # Use this parameter in conjunction with the SCAN flag and choose a
                   # value the range [0, sensor_beams_count)
     point_type: original # choose from: {original, native, xyz, xyzi, xyzir}
 ouster/os_image:
-    use_system_default_qos: False # needs to match the value defined for os_sensor node
+    use_system_default_qos: false # needs to match the value defined for os_sensor node

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -18,6 +18,9 @@ ouster/os_sensor:
     azimuth_window_start: 0
     azimuth_window_end: 360000
     persist_config: false
+    attempt_reconnect: false
+    dormant_period_between_reconnects: 1.0
+    max_failed_reconnect_attempts: 2147483647
 ouster/os_cloud:
   ros__parameters:
     sensor_frame: os_sensor

--- a/ouster-ros/include/ouster_ros/os_sensor_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_sensor_node_base.h
@@ -30,7 +30,7 @@ class OusterSensorNodeBase : public rclcpp_lifecycle::LifecycleNode {
 
     void create_get_metadata_service();
 
-    void create_metadata_publisher();
+    void create_metadata_pub();
 
     void publish_metadata();
 

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -60,9 +60,7 @@
     description="Use the default system QoS settings"/>
 
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    The IMG flag here is not supported and does not affect anything,
-    to disable image topics you would need to omit the os_image node
-    from the launch file"/>
+    use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
@@ -85,6 +83,15 @@
   <arg name="persist_config" default="false"
     description="request the sensor to persist settings"/>
 
+  <arg name="attempt_reconnect" default="false"
+    description="attempting to reconnect to the sensor after connection loss or
+    sensor powered down"/>
+  <arg name="dormant_period_between_reconnects" default="1.0"
+    description="wait time in seconds between reconnection attempts"/>
+  <arg name="max_failed_reconnect_attempts" default="2147483647"
+    description="maximum number of attempts trying to communicate with the sensor.
+         Counter resets upon successful connection"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="os_container" output="screen" namespace="">
@@ -103,6 +110,11 @@
         <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
         <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
         <param name="persist_config" value="$(var persist_config)"/>
+        <param name="~/attempt_reconnect" value="$(var attempt_reconnect)"/>
+        <param name="~/dormant_period_between_reconnects"
+              value="$(var dormant_period_between_reconnects)"/>
+        <param name="~/max_failed_reconnect_attempts"
+              value="$(var max_failed_reconnect_attempts)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
         <param name="sensor_frame" value="$(var sensor_frame)"/>
@@ -118,6 +130,7 @@
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+        <param name="proc_mask" value="$(var proc_mask)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -92,6 +92,9 @@
     description="maximum number of attempts trying to communicate with the sensor.
          Counter resets upon successful connection"/>
 
+  <arg name="auto_start" default="true"
+    description="automatically configure and activate the node"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="os_container" output="screen" namespace="">
@@ -110,11 +113,12 @@
         <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
         <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
         <param name="persist_config" value="$(var persist_config)"/>
-        <param name="~/attempt_reconnect" value="$(var attempt_reconnect)"/>
-        <param name="~/dormant_period_between_reconnects"
+        <param name="attempt_reconnect" value="$(var attempt_reconnect)"/>
+        <param name="dormant_period_between_reconnects"
               value="$(var dormant_period_between_reconnects)"/>
-        <param name="~/max_failed_reconnect_attempts"
+        <param name="max_failed_reconnect_attempts"
               value="$(var max_failed_reconnect_attempts)"/>
+        <param name="auto_start" value="$(var auto_start)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterCloud" name="os_cloud">
         <param name="sensor_frame" value="$(var sensor_frame)"/>
@@ -134,13 +138,6 @@
       </composable_node>
     </node_container>
   </group>
-
-  <!-- HACK: configure and activate the sensor node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -47,9 +47,7 @@
     description="Use the default system QoS settings"/>
 
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    The IMG flag here is not supported and does not affect anything,
-    to disable image topics you would need to omit the os_image node
-    from the launch file"/>
+    use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
@@ -85,6 +83,7 @@
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+        <param name="proc_mask" value="$(var proc_mask)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -38,9 +38,7 @@
     description="Use the default system QoS settings"/>
 
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    The IMG flag here is not supported and does not affect anything,
-    to disable image topics you would need to omit the os_image node
-    from the launch file"/>
+    use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
@@ -77,6 +75,7 @@
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+      <param name="proc_mask" value="$(var proc_mask)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -90,6 +90,9 @@
     description="maximum number of attempts trying to communicate with the sensor.
          Counter resets upon successful connection"/>
 
+  <arg name="auto_start" default="true"
+    description="automatically configure and activate the node"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -115,20 +118,14 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
-      <param name="~/attempt_reconnect" value="$(var attempt_reconnect)"/>
-      <param name="~/dormant_period_between_reconnects"
+      <param name="attempt_reconnect" value="$(var attempt_reconnect)"/>
+      <param name="dormant_period_between_reconnects"
              value="$(var dormant_period_between_reconnects)"/>
-      <param name="~/max_failed_reconnect_attempts"
+      <param name="max_failed_reconnect_attempts"
              value="$(var max_failed_reconnect_attempts)"/>
+      <param name="auto_start" value="$(var auto_start)"/>
     </node>
   </group>
-
-  <!-- HACK: configure and activate the sensor node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -81,6 +81,15 @@
   <arg name="persist_config" default="false"
     description="request the sensor to persist settings"/>
 
+  <arg name="attempt_reconnect" default="false"
+    description="attempting to reconnect to the sensor after connection loss or
+    sensor powered down"/>
+  <arg name="dormant_period_between_reconnects" default="1.0"
+    description="wait time in seconds between reconnection attempts"/>
+  <arg name="max_failed_reconnect_attempts" default="2147483647"
+    description="maximum number of attempts trying to communicate with the sensor.
+         Counter resets upon successful connection"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -106,6 +115,11 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
+      <param name="~/attempt_reconnect" value="$(var attempt_reconnect)"/>
+      <param name="~/dormant_period_between_reconnects"
+             value="$(var dormant_period_between_reconnects)"/>
+      <param name="~/max_failed_reconnect_attempts"
+             value="$(var max_failed_reconnect_attempts)"/>
     </node>
   </group>
 

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -89,6 +89,10 @@
   <arg name="max_failed_reconnect_attempts" default="2147483647"
     description="maximum number of attempts trying to communicate with the sensor.
          Counter resets upon successful connection"/>
+
+  <arg name="auto_start" default="true"
+    description="automatically configure and activate the node"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_sensor" name="os_sensor" output="screen">
@@ -106,11 +110,12 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
-      <param name="~/attempt_reconnect" value="$(var attempt_reconnect)"/>
-      <param name="~/dormant_period_between_reconnects"
+      <param name="attempt_reconnect" value="$(var attempt_reconnect)"/>
+      <param name="dormant_period_between_reconnects"
              value="$(var dormant_period_between_reconnects)"/>
-      <param name="~/max_failed_reconnect_attempts"
+      <param name="max_failed_reconnect_attempts"
              value="$(var max_failed_reconnect_attempts)"/>
+      <param name="auto_start" value="$(var auto_start)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
       <param name="sensor_frame" value="$(var sensor_frame)"/>
@@ -129,13 +134,6 @@
       <param name="proc_mask" value="$(var proc_mask)"/>
     </node>
   </group>
-
-  <!-- HACK: configure and activate the sensor node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -58,9 +58,7 @@
     description="Use the default system QoS settings"/>
 
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
-    The IMG flag here is not supported and does not affect anything,
-    to disable image topics you would need to omit the os_image node
-    from the launch file"/>
+    use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="
     use this parameter in conjunction with the SCAN flag
@@ -83,6 +81,14 @@
   <arg name="persist_config" default="false"
     description="request the sensor to persist settings"/>
 
+  <arg name="attempt_reconnect" default="false"
+    description="attempting to reconnect to the sensor after connection loss or
+    sensor powered down"/>
+  <arg name="dormant_period_between_reconnects" default="1.0"
+    description="wait time in seconds between reconnection attempts"/>
+  <arg name="max_failed_reconnect_attempts" default="2147483647"
+    description="maximum number of attempts trying to communicate with the sensor.
+         Counter resets upon successful connection"/>
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_sensor" name="os_sensor" output="screen">
@@ -100,6 +106,11 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
+      <param name="~/attempt_reconnect" value="$(var attempt_reconnect)"/>
+      <param name="~/dormant_period_between_reconnects"
+             value="$(var dormant_period_between_reconnects)"/>
+      <param name="~/max_failed_reconnect_attempts"
+             value="$(var max_failed_reconnect_attempts)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
       <param name="sensor_frame" value="$(var sensor_frame)"/>
@@ -115,6 +126,7 @@
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen">
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
+      <param name="proc_mask" value="$(var proc_mask)"/>
     </node>
   </group>
 

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -89,6 +89,18 @@
   <arg name="persist_config" default="false"
     description="request the sensor to persist settings"/>
 
+  <arg name="attempt_reconnect" default="false"
+    description="attempting to reconnect to the sensor after connection loss or
+    sensor powered down"/>
+  <arg name="dormant_period_between_reconnects" default="1.0"
+    description="wait time in seconds between reconnection attempts"/>
+  <arg name="max_failed_reconnect_attempts" default="2147483647"
+    description="maximum number of attempts trying to communicate with the sensor.
+         Counter resets upon successful connection"/>
+
+  <arg name="auto_start" default="true"
+    description="automatically configure and activate the node"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -114,15 +126,14 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
+      <param name="attempt_reconnect" value="$(var attempt_reconnect)"/>
+      <param name="dormant_period_between_reconnects"
+            value="$(var dormant_period_between_reconnects)"/>
+      <param name="max_failed_reconnect_attempts"
+            value="$(var max_failed_reconnect_attempts)"/>
+      <param name="auto_start" value="$(var auto_start)"/>
     </node>
   </group>
-
-  <!-- HACK: configure and activate the sensor node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.12.6</version>
+  <version>0.12.7</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -48,7 +48,7 @@ class OusterPcap : public OusterSensorNodeBase {
         try {
             auto meta_file = get_meta_file();
             auto pcap_file = get_pcap_file();
-            create_metadata_publisher();
+            create_metadata_pub();
             load_metadata_from_file(meta_file);
             open_pcap(pcap_file);
             publish_metadata();

--- a/ouster-ros/src/os_replay_node.cpp
+++ b/ouster-ros/src/os_replay_node.cpp
@@ -28,7 +28,7 @@ class OusterReplay : public OusterSensorNodeBase {
 
         try {
             auto meta_file = parse_parameters();
-            create_metadata_publisher();
+            create_metadata_pub();
             load_metadata_from_file(meta_file);
             publish_metadata();
             create_get_metadata_service();

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -334,7 +334,7 @@ void OusterSensor::execute_transitions_sequence(
             if (at < transitions_sequence.size() - 1) {
                 execute_transitions_sequence(transitions_sequence, at + 1);
             } else {
-                RCLCPP_WARN_STREAM(get_logger(), "transitions sequence completed");
+                RCLCPP_DEBUG_STREAM(get_logger(), "transitions sequence completed");
             }
         } else {
             RCLCPP_DEBUG_STREAM(

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -127,6 +127,10 @@ LifecycleNodeInterface::CallbackReturn OusterSensor::on_configure(
                 }
             });
             return LifecycleNodeInterface::CallbackReturn::FAILURE;
+        } else {
+            // reset counter
+            reconnect_attempts_available =
+                get_parameter("max_failed_reconnect_attempts").as_int();
         }
     } catch (const std::exception& ex) {
         RCLCPP_ERROR_STREAM(

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -79,7 +79,7 @@ LifecycleNodeInterface::CallbackReturn OusterSensor::on_configure(
         sensor_client = create_sensor_client(sensor_hostname, config);
         if (!sensor_client)
             return LifecycleNodeInterface::CallbackReturn::FAILURE;
-        create_metadata_publisher();
+        create_metadata_pub();
         update_config_and_metadata(*sensor_client);
         create_services();
     } catch (const std::exception& ex) {

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -30,7 +30,7 @@ void OusterSensorNodeBase::create_get_metadata_service() {
     RCLCPP_INFO(get_logger(), "get_metadata service created");
 }
 
-void OusterSensorNodeBase::create_metadata_publisher() {
+void OusterSensorNodeBase::create_metadata_pub() {
     auto latching_qos = rclcpp::QoS(rclcpp::KeepLast(1));
     latching_qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
     latching_qos.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);


### PR DESCRIPTION
## Related Issues & PRs
- related #55
- resolves #119
- resolves #233
- related #332
- resolves #337

## Summary of Changes
- Implement sensor reconnection behavior
- Handle sensor reconfiguration from a cold start
- Add a flag to enable sensor reconnect (default disabled)
- properly handle config change outside of the ros driver
- only persist config startup config if persist_config was set
- only `auto_udp` if startup config didn't set an address
- added a parameter to set the dromant period between re-connection attempts
- added a parameter to set the maximum number of subsequent failed re-connection attempts
- added ROS Jazzy to the build :tada:
- added `auto_start` flag

### Known Issues
- Doesn't handle invalid configurations gracefully

## Validation
* Use the driver with default configuration to connect to a sensor & verify normal activity
* Enable the `attempt_reconnect` parameter and verify that it works as expected for the following scenarios
  - Starting from an under powered or unconnected sensor
    - Connect or power up the sensor
    - Verify the driver connects successfully within 10-15 seconds
  - Using a powered up and connected sensor
    - Disconnect the sensor and reconnect it
    - Verify the driver connects successfully within 10-15 seconds
  - Using a powered up and connected sensor
    - power down the sensor and power it up
    - Verify the driver connects successfully within 10-15 seconds (and adjusts to sensor persisted config if different)
  - Using a powered up and connected sensor
    - Use set_config to change sensor configuration
    - Verify the driver reconnects successfully within 10-15 seconds
  - Using a powered up and connected sensor
    - Change some setting on through the sensor configuration page
    - Verify the driver reconnects successfully within 10-15 seconds

### Additional parameters to test
```yaml
# dormant_period_between_reconnects[optional]: wait time in seconds between
# reconnection attempts
dormant_period_between_reconnects: 1.0
# max_failed_reconnect_attempts[optional]: maximum number of attempts trying
# to communicate with the sensor. Counter resets upon successful connection.
max_failed_reconnect_attempts: 2147483647
```