### PR TITLE
HOTFIX/ROS-376-initialize-the-sensor-with-launch-config-params

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 ouster_ros v0.13.1
 ==================
-* [BUGFIX]: Make sure to initilaize the sensor with launch file parameters.
+* [BUGFIX]: Make sure to initialize the sensor with launch file parameters.
 
 ouster_ros v0.13.0
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+ouster_ros v0.13.1
+==================
+* [BUGFIX]: Make sure to initilaize the sensor with launch file parameters.
+
 ouster_ros v0.13.0
 ==================
 * [BUGFIX]: LaserScan is not properly aligned with generated point cloud

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 > **Note**  
 > Specifying `Release` as the build type is important to have a reasonable performance of the driver.
 
+> **Note**  
+> For ROS2 we recommend using **CycloneDDS** over **FastDDS**, through out Galactic, Foxy, Humble distros.  
+> **FastDDS** is usually the default ros middleware on most platforms, please follow the
+[Guide](https://docs.ros.org/en/humble/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS.html)
+to learn how to enable **CycloneDDS** on your platform.  
+> We are yet to evaluate Zeonh performance against the ouster-ros driver for later distros.  
+
 Once the build succeeds, you must source the _install_ folder of your ros2 workspace to add launch
 commands to your environment:
 ```bash

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.0</version>
+  <version>0.13.1</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -35,6 +35,7 @@ OusterSensor::OusterSensor(const std::string& name,
       change_state_client{
           create_client<ChangeState>(get_name() + "/change_state"s)} {
     declare_parameters();
+    staged_config = parse_config_from_ros_parameters();
     attempt_reconnect = get_parameter("attempt_reconnect").as_bool();
     dormant_period_between_reconnects = 
         get_parameter("dormant_period_between_reconnects").as_double();


### PR DESCRIPTION
## Related Issues & PRs
- closes #376
- closes #377
- closes #378

## Summary of Changes
- Make sure to initialize the sensor with specified launch file parameters
- Add a note recommending the use of CycloneDDS over FastDDS

## Validation
- launch ouster-ros with some new config and verify the new config is applied upon node startup