### PR TITLE
ROS-350[HUMBLE/IRON/JAZZY]: 't' timestamp field content is not plausible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+[unreleased]
+============
+* [BUGFIX]: correctly align timestamps to the generated point cloud.
+
 ouster_ros v0.13.2
 ==================
 * [BUGFIX]: Make sure to initialize the sensor with launch file parameters.

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.2</version>
+  <version>0.13.3</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -152,7 +152,7 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud,
                     cloud.points.emplace_back();
             }
 
-            auto ts = timestamp[v_shift];
+            auto ts = timestamp[v];
             ts = ts > scan_ts ? ts - scan_ts : 0UL;
 
             // if target point and staging point has matching type bind the

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -117,10 +117,9 @@ using Cloud = pcl::PointCloud<T>;
 // TODO[UN]: make this a functor
 template <std::size_t N, const ChanFieldTable<N>& PROFILE, typename PointT,
           typename PointS>
-void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud,
-                     PointS& staging_point,
-                     const ouster::PointsF& points,
-                     uint64_t scan_ts, const ouster::LidarScan& ls,
+void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
+                     const ouster::PointsF& points, uint64_t scan_ts,
+                     const ouster::LidarScan& ls,
                      const std::vector<int>& pixel_shift_by_row,
                      bool organized = false, bool destagger = true,
                      int rows_step = 1) {
@@ -132,11 +131,12 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud,
 
     for (auto u = 0; u < ls.h; u += rows_step) {
         for (auto v = 0; v < ls.w; ++v) {   // TODO[UN]: consider cols_step in future
-            const auto v_shift = destagger ?
-                (v + ls.w - pixel_shift_by_row[u]) % ls.w : v;
+            const auto v_shift =
+                destagger ? (v + ls.w - pixel_shift_by_row[u]) % ls.w : v;
             const auto src_idx = u * ls.w + v_shift;
             const auto xyz = points.row(src_idx);
-            const auto tgt_idx = organized ? (u / rows_step) * ls.w + v : cloud.size();
+            const auto tgt_idx =
+                organized ? (u / rows_step) * ls.w + v : cloud.size();
 
             if (xyz.isNaN().any()) {
                 if (organized) {
@@ -148,12 +148,15 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud,
                 }
                 continue;
             } else {
-                if (!organized)
-                    cloud.points.emplace_back();
+                if (!organized) cloud.points.emplace_back();
             }
 
-            auto ts = timestamp[v];
-            ts = ts > scan_ts ? ts - scan_ts : 0UL;
+            // as opposed to the point cloud destaggering if it is disabled
+            // then timestamps needs to be staggered.
+            auto ts_idx =
+                destagger ? v : (v + ls.w + pixel_shift_by_row[u]) % ls.w;
+            auto ts =
+                timestamp[ts_idx] > scan_ts ? timestamp[ts_idx] - scan_ts : 0UL;
 
             // if target point and staging point has matching type bind the
             // target directly and avoid performing transform_point at the end


### PR DESCRIPTION
## Related Issues & PRs
- resolves #350

## Summary of Changes
- Don't apply offset to destaggered timestamps within the point cloud
- Make sure the the timestamps align correctly when destaggerd is option is OFF

## Validation
* run the driver with default option (destaggered=ON, organized=ON)
  -  observe that the timestamps are consistent
* run the driver with default option (destaggered=OFF, organized=ON)
  - observe that the timestamps appear staggerd