### PR TITLE
Set the default value of the bag file param in replay to an empty string

### DIFF
--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -15,7 +15,7 @@
 
   <arg name="ouster_ns" default="ouster" doc="Override the default namespace of all ouster nodes"/>
   <arg name="metadata" default="" doc="path to read metadata file when replaying sensor data"/>
-  <arg name="bag_file" doc="file name to use for the recorded bag file"/>
+  <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="timestamp_mode" default="TIME_FROM_INTERNAL_OSC"
     doc="A parameter that allows you to override the timestamp measurements; possible values: {
     TIME_FROM_INTERNAL_OSC,


### PR DESCRIPTION
## Related Issues & PRs
- closes #403

## Summary of Changes
Set the default value of the bag file param in replay to an empty string so that the launch will not crash on this line: https://github.com/ouster-lidar/ouster-ros/blob/1dbdbb4317fa8f38ffb442513f889e379fe125ab/launch/replay.launch#L121

## Validation
Run `roslaunch ouster_ros replay.launch` and see that it does not crash