### PR TITLE
ROS-396: retrieve xyz for non hit

### DIFF
--- a/ouster-ros/src/impl/cartesian.h
+++ b/ouster-ros/src/impl/cartesian.h
@@ -55,7 +55,9 @@ void cartesianT(PointsT<T>& points,
         const auto idx_y = col_y + i;
         const auto idx_z = col_z + i;
         if (r <= min_r || r >= max_r) {
-            pts[idx_x] = pts[idx_y] = pts[idx_z] = invalid;
+            pts[idx_x] = invalid * dir[idx_x] + ofs[idx_x];
+            pts[idx_y] = invalid * dir[idx_y] + ofs[idx_y];
+            pts[idx_z] = invalid * dir[idx_z] + ofs[idx_z];
         } else {
             pts[idx_x] = r * dir[idx_x] + ofs[idx_x];
             pts[idx_y] = r * dir[idx_y] + ofs[idx_y];

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -84,7 +84,7 @@ class PointCloudProcessor {
             auto range = lidar_scan.field<uint32_t>(range_channel);
             ouster::cartesianT(points, range, lut_direction, lut_offset,
                                min_range_, max_range_,
-                               std::numeric_limits<float>::quiet_NaN());
+                               1.0f);
 
             scan_to_cloud_fn(cloud, points, scan_ts, lidar_scan,
                                         pixel_shift_by_row, i);


### PR DESCRIPTION
## Related Issues & PRs
- closes #396 

## Summary of Changes
- Allow users to assign a value for no-returns (no hit)

### TODO(s):
- Expose a parameter that allows user to enable this feature and adjust the invalid (out-of-range) value.

## Validation
This image was generated by manually setting the invalid (out-of-range) value to 1m distance. 
![image](https://github.com/user-attachments/assets/e594b00e-9fc1-4a30-b75e-e5549cfab4da)
