### PR TITLE
Check sensor connection thread validity before joining

### DIFF
--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -644,7 +644,7 @@ void OusterSensor::start_sensor_connection_thread() {
 
 void OusterSensor::stop_sensor_connection_thread() {
     NODELET_DEBUG("sensor_connection_thread stopping.");
-    if (sensor_connection_thread->joinable()) {
+    if ((sensor_connection_thread != nullptr) && sensor_connection_thread->joinable()) {
         sensor_connection_active = false;
         sensor_connection_thread->join();
     }


### PR DESCRIPTION
## Related Issues & PRs
#410

## Summary of Changes
Perform a check for a nullptr on unique pointer type before usage, that otherwise has the capacity to be null when not initialised due to the sensor not being powered on start-up.

## Validation
Tested on-site