### PR TITLE
SW-6906: publish sensor telemetry in ouster ros

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Changelog
 * Added support to enable **loop** for pcap replay + other replay config
 * Added a new launch file parameter ``pub_static_tf`` that allows users to turn off the broadcast
   of sensor TF transforms.
+* Introduced a new topic ``/ouster/telemetry`` that publishes ``ouster_ros::Telemetry`` messages,
+  the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
+
 
 
 ouster_ros v0.13.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,6 @@ Changelog
   the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
 
 
-
 ouster_ros v0.13.0
 ==================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ add_compile_options(-Wall -Wextra)
 option(CMAKE_POSITION_INDEPENDENT_CODE "Build position independent code." ON)
 
 # ==== Catkin ====
-add_message_files(FILES PacketMsg.msg)
+add_message_files(FILES PacketMsg.msg Telemetry.msg)
 add_service_files(FILES GetConfig.srv SetConfig.srv GetMetadata.srv)
 generate_messages(DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "ouster_ros/PacketMsg.h"
+#include "ouster_ros/Telemetry.h"
 #include "ouster_ros/os_point.h"
 
 namespace ouster_ros {
@@ -115,6 +116,20 @@ sensor_msgs::LaserScan lidar_scan_to_laser_scan_msg(
     const std::string& frame, const ouster::sensor::lidar_mode lidar_mode,
     const uint16_t ring, const std::vector<int>& pixel_shift_by_row,
     const int return_index);
+
+
+/**
+ * Parse a LidarPacket and generate the Telemetry message
+ * @param[in] pm packet message populated by read_imu_packet
+ * @param[in] timestamp the timestamp to give the resulting ROS message
+ * @param[in] pf the packet format
+ * @return ROS sensor message with fields populated from the packet
+ */
+Telemetry lidar_packet_to_telemetry_msg(
+    const ouster::sensor::LidarPacket& lidar_packet,
+    const ros::Time& timestamp,
+    const ouster::sensor::packet_format& pf);
+
 
 namespace impl {
 sensor::ChanField suitable_return(sensor::ChanField input_field, bool second);

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -120,7 +120,7 @@ sensor_msgs::LaserScan lidar_scan_to_laser_scan_msg(
 
 /**
  * Parse a LidarPacket and generate the Telemetry message
- * @param[in] pm packet message populated by read_imu_packet
+ * @param[in] lidar_packet lidar packet to parse telemetry data from
  * @param[in] timestamp the timestamp to give the resulting ROS message
  * @param[in] pf the packet format
  * @return ROS sensor message with fields populated from the packet

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -56,7 +56,7 @@
   <arg if="$(arg no_bond)" name="_no_bond" value="--no-bond"/>
   <arg unless="$(arg no_bond)" name="_no_bond" value=" "/>
 
-  <arg name="proc_mask" default="IMU|PCL|SCAN|IMG|RAW" doc="
+  <arg name="proc_mask" default="IMU|PCL|SCAN|IMG|RAW|TLM" doc="
     use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" doc="

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -54,7 +54,7 @@
   <arg name="dynamic_transforms_broadcast_rate" default="1.0"
     doc="set the rate (Hz) of broadcast when using dynamic broadcast; minimum value is 1 Hz"/>
 
-  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" doc="
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN|TLM" doc="
     The IMG flag here is not supported and does not affect anything,
     to disable image topics you would need to omit the os_image node
     from the launch file"/>
@@ -117,6 +117,7 @@
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
+      <param name="~/proc_mask" type="str" value="$(arg proc_mask)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
       <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
       <param name="~/persist_config" value="$(arg persist_config)"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -116,6 +116,8 @@
       <param name="~/udp_profile_lidar" type="str" value="$(arg udp_profile_lidar)"/>
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/ptp_utc_tai_offset" type="double"
+        value="$(arg ptp_utc_tai_offset)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
       <param name="~/proc_mask" type="str" value="$(arg proc_mask)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -62,7 +62,7 @@
   <arg name="dynamic_transforms_broadcast_rate" default="1.0"
     doc="set the rate (Hz) of broadcast when using dynamic broadcast; minimum value is 1 Hz"/>
 
-  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" doc="
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN|TLM" doc="
     The IMG flag here is not supported and does not affect anything,
     to disable image topics you would need to omit the os_image node
     from the launch file"/>
@@ -124,6 +124,7 @@
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
+      <param name="~/proc_mask" type="str" value="$(arg proc_mask)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
       <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
       <param name="~/persist_config" value="$(arg persist_config)"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -123,6 +123,8 @@
       <param name="~/udp_profile_lidar" type="str" value="$(arg udp_profile_lidar)"/>
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/ptp_utc_tai_offset" type="double"
+        value="$(arg ptp_utc_tai_offset)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
       <param name="~/proc_mask" type="str" value="$(arg proc_mask)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -66,7 +66,7 @@
   <arg name="dynamic_transforms_broadcast_rate" default="1.0"
     doc="set the rate (Hz) of broadcast when using dynamic broadcast; minimum value is 1 Hz"/>
 
-  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" doc="
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN|TLM" doc="
     The IMG flag here is not supported and does not affect anything,
     to disable image topics you would need to omit the os_image node
     from the launch file"/>
@@ -130,6 +130,7 @@
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
+      <param name="~/proc_mask" type="str" value="$(arg proc_mask)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>
       <param name="~/azimuth_window_end" value="$(arg azimuth_window_end)"/>
       <param name="~/persist_config" value="$(arg persist_config)"/>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -129,6 +129,8 @@
       <param name="~/udp_profile_lidar" type="str" value="$(arg udp_profile_lidar)"/>
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/ptp_utc_tai_offset" type="double"
+        value="$(arg ptp_utc_tai_offset)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
       <param name="~/proc_mask" type="str" value="$(arg proc_mask)"/>
       <param name="~/azimuth_window_start" value="$(arg azimuth_window_start)"/>

--- a/msg/Telemetry.msg
+++ b/msg/Telemetry.msg
@@ -1,8 +1,9 @@
 # This message defines the telemetry data for Ouster sensors.
 # Message header
 std_msgs/Header header
-# Telemetry fields
+# Telemetry fields for more information on these fields and their meaning, please review:
+# https://static.ouster.dev/sensor-docs/image_route1/image_route2/thermal_int_guide/therm_int_guide.html
 uint16 countdown_thermal_shutdown # the thermal shutdown countdown.
 uint16 countdown_shot_limiting    # the shot limiting countdown.
-uint8 thermal_shutdown            # the thermal shutdown status
-uint8 shot_limiting               # the shot limiting status
+uint8 thermal_shutdown            # the thermal shutdown status. 0 = NORMAL, 1 = SHUTDOWN IMMINENT.
+uint8 shot_limiting               # the shot limiting status. 0 = NORMAL OPERATION.

--- a/msg/Telemetry.msg
+++ b/msg/Telemetry.msg
@@ -1,0 +1,8 @@
+# This message defines the telemetry data for Ouster sensors.
+# Message header
+std_msgs/Header header
+# Telemetry fields
+uint16 countdown_thermal_shutdown # the thermal shutdown countdown.
+uint16 countdown_shot_limiting    # the shot limiting countdown.
+uint8 thermal_shutdown            # the thermal shutdown status
+uint8 shot_limiting               # the shot limiting status

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.2</version>
+  <version>0.13.3</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/imu_packet_handler.h
+++ b/src/imu_packet_handler.h
@@ -22,7 +22,7 @@ class ImuPacketHandler {
     using HandlerType = std::function<HandlerOutput(const sensor::ImuPacket&)>;
 
    public:
-    static HandlerType create_handler(const sensor::sensor_info& info,
+    static HandlerType create(const sensor::sensor_info& info,
                                       const std::string& frame,
                                       const std::string& timestamp_mode,
                                       int64_t ptp_utc_tai_offset) {

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -153,7 +153,7 @@ class LidarPacketHandler {
     void clear_registered_lidar_scan_handlers() { lidar_scan_handlers.clear(); }
 
    public:
-    static HandlerType create_handler(
+    static HandlerType create(
         const sensor::sensor_info& info,
         const std::vector<LidarScanProcessor>& handlers,
         const std::string& timestamp_mode, int64_t ptp_utc_tai_offset) {

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -160,7 +160,7 @@ class OusterCloud : public nodelet::Nodelet {
         double ptp_utc_tai_offset = pnh.param("ptp_utc_tai_offset", -37.0);
 
         if (impl::check_token(tokens, "IMU")) {
-            imu_packet_handler = ImuPacketHandler::create_handler(
+            imu_packet_handler = ImuPacketHandler::create(
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }
@@ -237,7 +237,7 @@ class OusterCloud : public nodelet::Nodelet {
 
         if (impl::check_token(tokens, "PCL") ||
             impl::check_token(tokens, "SCAN")) {
-            lidar_packet_handler = LidarPacketHandler::create_handler(
+            lidar_packet_handler = LidarPacketHandler::create(
                 info, processors, timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -54,8 +54,7 @@ class OusterDriver : public OusterSensor {
     }
 
    private:
-    virtual void on_metadata_updated(const sensor::sensor_info& info) override {
-        OusterSensor::on_metadata_updated(info);
+    void on_metadata_updated(const sensor::sensor_info& info) override {
         // for OusterDriver we are going to always assume static broadcast
         // at least for now
         tf_bcast.parse_parameters(getPrivateNodeHandle());
@@ -114,7 +113,7 @@ class OusterDriver : public OusterSensor {
         double ptp_utc_tai_offset = pnh.param("ptp_utc_tai_offset", -37.0);
 
         if (impl::check_token(tokens, "IMU")) {
-            imu_packet_handler = ImuPacketHandler::create_handler(
+            imu_packet_handler = ImuPacketHandler::create(
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }
@@ -196,7 +195,7 @@ class OusterDriver : public OusterSensor {
         if (impl::check_token(tokens, "PCL") ||
             impl::check_token(tokens, "SCAN") ||
             impl::check_token(tokens, "IMG")) {
-            lidar_packet_handler = LidarPacketHandler::create_handler(
+            lidar_packet_handler = LidarPacketHandler::create(
                 info, processors, timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -109,7 +109,7 @@ class OusterImage : public nodelet::Nodelet {
                 })
         };
 
-        lidar_packet_handler = LidarPacketHandler::create_handler(
+        lidar_packet_handler = LidarPacketHandler::create(
             info, processors, timestamp_mode,
             static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
     }

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -26,6 +26,7 @@ namespace ouster_ros {
 
 namespace sensor = ouster::sensor;
 using namespace ouster::util;
+using ouster::sensor::LidarPacket;
 
 bool is_legacy_lidar_profile(const sensor::sensor_info& info) {
     using sensor::UDPProfileLidar;
@@ -206,6 +207,18 @@ sensor_msgs::LaserScan lidar_scan_to_laser_scan_msg(
     }
 
     return msg;
+}
+
+Telemetry lidar_packet_to_telemetry_msg(
+    const LidarPacket& lidar_packet, const ros::Time& timestamp,
+    const sensor::packet_format& pf) {
+    Telemetry telemetry;
+    telemetry.header.stamp = timestamp;
+    telemetry.countdown_thermal_shutdown = pf.countdown_thermal_shutdown(lidar_packet.buf.data());
+    telemetry.countdown_shot_limiting = pf.countdown_shot_limiting(lidar_packet.buf.data());
+    telemetry.thermal_shutdown = pf.thermal_shutdown(lidar_packet.buf.data());
+    telemetry.shot_limiting = pf.shot_limiting(lidar_packet.buf.data());
+    return telemetry;
 }
 
 }  // namespace ouster_ros

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -21,7 +21,6 @@
 #include "ouster_ros/SetConfig.h"
 #include "ouster_ros/PacketMsg.h"
 #include "ouster_ros/os_sensor_nodelet_base.h"
-#include "telemetry_handler.h"
 
 namespace sensor = ouster::sensor;
 
@@ -117,8 +116,6 @@ class OusterSensor : public OusterSensorNodeletBase {
     bool get_active_config_no_throw(const std::string& sensor_hostname,
                                     sensor::sensor_config& config);
 
-    void process_publish_telemetry(const sensor::LidarPacket& lidar_packet);
-
    private:
     std::string sensor_hostname;
     std::optional<sensor::sensor_config> staged_config;
@@ -131,7 +128,6 @@ class OusterSensor : public OusterSensorNodeletBase {
     ouster::sensor::ImuPacket imu_packet;
     ros::Publisher lidar_packet_pub;
     ros::Publisher imu_packet_pub;
-    ros::Publisher telemetry_pub;
     ros::ServiceServer reset_srv;
     ros::ServiceServer get_config_srv;
     ros::ServiceServer set_config_srv;
@@ -165,9 +161,6 @@ class OusterSensor : public OusterSensorNodeletBase {
     double dormant_period_between_reconnects;
     int reconnect_attempts_available;
     ros::Timer reconnect_timer;
-
-    bool publish_telemetry = false;
-    TelemetryHandler::HandlerType telemetry_handler;
 };
 
 }  // namespace ouster_ros

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -21,6 +21,7 @@
 #include "ouster_ros/SetConfig.h"
 #include "ouster_ros/PacketMsg.h"
 #include "ouster_ros/os_sensor_nodelet_base.h"
+#include "telemetry_handler.h"
 
 namespace sensor = ouster::sensor;
 
@@ -59,6 +60,8 @@ class OusterSensor : public OusterSensorNodeletBase {
     std::string get_sensor_hostname();
 
     void update_metadata(sensor::client& client);
+
+    void metadata_updated(const sensor::sensor_info& info);
 
     void save_metadata();
 
@@ -164,6 +167,7 @@ class OusterSensor : public OusterSensorNodeletBase {
     ros::Timer reconnect_timer;
 
     bool publish_telemetry = false;
+    TelemetryHandler::HandlerType telemetry_handler;
 };
 
 }  // namespace ouster_ros

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -96,11 +96,15 @@ class OusterSensor : public OusterSensorNodeletBase {
 
     void handle_poll_client_error();
 
-    void handle_lidar_packet(sensor::client& client,
-                             const sensor::packet_format& pf);
-
-    void handle_imu_packet(sensor::client& client,
+    void read_lidar_packet(sensor::client& client,
                            const sensor::packet_format& pf);
+
+    void handle_lidar_packet(const sensor::LidarPacket& lidar_packet);
+
+    void read_imu_packet(sensor::client& client,
+                         const sensor::packet_format& pf);
+
+    void handle_imu_packet(const sensor::ImuPacket& imu_packet);
 
     void cleanup();
 
@@ -108,7 +112,9 @@ class OusterSensor : public OusterSensorNodeletBase {
                          const sensor::packet_format& pf);
 
     bool get_active_config_no_throw(const std::string& sensor_hostname,
-                             sensor::sensor_config& config);
+                                    sensor::sensor_config& config);
+
+    void process_publish_telemetry(const sensor::LidarPacket& lidar_packet);
 
    private:
     std::string sensor_hostname;
@@ -122,6 +128,7 @@ class OusterSensor : public OusterSensorNodeletBase {
     ouster::sensor::ImuPacket imu_packet;
     ros::Publisher lidar_packet_pub;
     ros::Publisher imu_packet_pub;
+    ros::Publisher telemetry_pub;
     ros::ServiceServer reset_srv;
     ros::ServiceServer get_config_srv;
     ros::ServiceServer set_config_srv;
@@ -155,6 +162,8 @@ class OusterSensor : public OusterSensorNodeletBase {
     double dormant_period_between_reconnects;
     int reconnect_attempts_available;
     ros::Timer reconnect_timer;
+
+    bool publish_telemetry = false;
 };
 
 }  // namespace ouster_ros

--- a/src/telemetry_handler.h
+++ b/src/telemetry_handler.h
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file imu_packet_handler.h
+ * @brief ...
+ */
+
+#pragma once
+
+// prevent clang-format from altering the location of "ouster_ros/os_ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+
+namespace ouster_ros {
+
+class TelemetryHandler {
+   public:
+    using HandlerOutput = Telemetry;
+    using HandlerType = std::function<HandlerOutput(const sensor::LidarPacket&)>;
+
+    static uint64_t first_valid_ts(const sensor::LidarPacket& lidar_packet,
+                                   const sensor::packet_format& pf) {
+        // scan for the first non-zero column ts
+        uint64_t ts = 0;
+        for (int icol = 0; icol < pf.columns_per_packet; ++icol) {
+            ts = pf.col_timestamp(pf.nth_col(icol, lidar_packet.buf.data()));
+            if (ts != 0)
+                break;
+        }
+        return ts;
+    }
+
+   public:
+    static HandlerType create(const sensor::sensor_info& info,
+                                      const std::string& timestamp_mode,
+                                      int64_t ptp_utc_tai_offset) {
+        const auto& pf = sensor::get_format(info);
+        using Timestamper = std::function<ros::Time(const sensor::LidarPacket&)>;
+
+        Timestamper timestamper;
+        if (timestamp_mode == "TIME_FROM_ROS_TIME") {
+            timestamper = Timestamper{
+                [](const sensor::LidarPacket& lidar_packet) {
+                    return impl::ts_to_ros_time(lidar_packet.host_timestamp);
+                }};
+        } else if (timestamp_mode == "TIME_FROM_PTP_1588") {
+            timestamper = Timestamper{
+                [pf, ptp_utc_tai_offset](const sensor::LidarPacket& lidar_packet) {
+                    uint64_t ts = TelemetryHandler::first_valid_ts(lidar_packet, pf);
+                    ts = impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
+                    return impl::ts_to_ros_time(ts);
+
+                }};
+        } else {
+            timestamper = Timestamper{
+                [pf](const sensor::LidarPacket& lidar_packet) {
+                    uint64_t ts = TelemetryHandler::first_valid_ts(lidar_packet, pf);
+                    return impl::ts_to_ros_time(ts);
+                }};
+        }
+
+        return [pf, timestamper](const sensor::LidarPacket& lidar_packet) {
+            return lidar_packet_to_telemetry_msg(lidar_packet, timestamper(lidar_packet), pf);
+        };
+    }
+};
+
+}  // namespace ouster_ros


### PR DESCRIPTION
## Related Issues & PRs
* Related: #200

## Summary of Changes
* Define a new telemetry message and emit (it from a live sensor or bag file or pcap) 
* Always set timestamps in the PointCloud even for invalid points
* Code refactor for LidarPacketHandler

### TODO(s)
* ~Support emitting Telemetry topic in replay mode (bag|pcap)~
  - ~Probably in a separate PR~ 

## Validation
* Launch a live sensor with telemetry enabled
```bash
roslaunch ouster_ros driver.launch sensor_hostname:=... proce_mask:="...|TLM"
```
* Once sensor is connected, open a separate terminal launch, verify that the telemetry topic is up and running
```bash
rostopic echo /ouster/telemetry
```
* Verify that the telemetry messages are being sent at the same rate as the raw packets topic
```bash
rostopic hz /ouster/telemetry
```