### PR TITLE
ROS2 enable replay auto start

### DIFF
--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -112,15 +112,6 @@
     </node_container>
   </group>
 
-  <!-- HACK: configure and activate the replay node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable if="$(var _use_metadata_file)"
-    cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_replay configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable if="$(var _use_metadata_file)"
-    cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_replay activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
-
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>
     <arg name="rviz_config" value="$(var rviz_config)"/>

--- a/ouster-ros/src/os_replay_node.cpp
+++ b/ouster-ros/src/os_replay_node.cpp
@@ -20,6 +20,16 @@ class OusterReplay : public OusterSensorNodeBase {
     explicit OusterReplay(const rclcpp::NodeOptions& options)
         : OusterSensorNodeBase("os_replay", options) {
         declare_parameters();
+        bool auto_start = get_parameter("auto_start").as_bool();
+
+        if (auto_start) {
+            RCLCPP_WARN(get_logger(), "auto start requested");
+            auto request_transitions = std::vector<uint8_t>{
+                lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE,
+                lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE};
+            execute_transitions_sequence(request_transitions, 0);
+            RCLCPP_WARN(get_logger(), "auto start initiated");
+        }
     }
 
     LifecycleNodeInterface::CallbackReturn on_configure(
@@ -96,7 +106,10 @@ class OusterReplay : public OusterSensorNodeBase {
     }
 
    private:
-    void declare_parameters() { declare_parameter<std::string>("metadata"); }
+    void declare_parameters() {
+        declare_parameter("auto_start", true);
+        declare_parameter<std::string>("metadata");
+    }
 
     std::string parse_parameters() {
         auto meta_file = get_parameter("metadata").as_string();


### PR DESCRIPTION
## Related Issues & PRs
- Related #389

## Summary of Changes
- Avoid the need to use execute commands by enabling `auto_start` similar to the `os_pcap` node. 

## Validation
The launch file works with no issues
```
ros2 ouster_ros replay.launch bag_file:=<...>
```