### PR TITLE
SW-6906: publish sensor telemetry in ouster ros

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,9 @@ Changelog
 * Added support to enable **loop** for pcap replay + other replay config.
 * Added a new launch file parameter ``pub_static_tf`` that allows users to turn off the braodcast
   of sensor TF transforms.
-
+* Introduced a new topic ``/ouster/telemetry`` that publishes ``ouster_ros::Telemetry`` messages,
+  the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
+[BUGFIX]: NEAR_IR data is not populated with data for organized point clouds that have no range.
 
 ouster_ros v0.13.2
 ==================

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "ouster_sensor_msgs/msg/packet_msg.hpp"
+#include "ouster_sensor_msgs/msg/telemetry.hpp"
 #include "ouster_ros/os_point.h"
 
 namespace ouster_ros {
@@ -120,7 +121,20 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     const uint16_t ring, const std::vector<int>& pixel_shift_by_row,
     const int return_index);
 
+/**
+ * Parse a LidarPacket and generate the Telemetry message
+ * @param[in] lidar_packet lidar packet to parse telemetry data from
+ * @param[in] timestamp the timestamp to give the resulting ROS message
+ * @param[in] pf the packet format
+ * @return ROS sensor message with fields populated from the packet
+ */
+ouster_sensor_msgs::msg::Telemetry lidar_packet_to_telemetry_msg(
+    const ouster::sensor::LidarPacket& lidar_packet,
+    const rclcpp::Time& timestamp,
+    const ouster::sensor::packet_format& pf);
+
 namespace impl {
+
 sensor::ChanField suitable_return(sensor::ChanField input_field, bool second);
 
 struct read_and_cast {

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -63,7 +63,7 @@
   <arg name="use_system_default_qos" default="true"
     description="Use the default system QoS settings"/>
 
-  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN|TLM" description="
     use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -61,7 +61,7 @@
   <arg name="use_system_default_qos" default="false"
     description="Use the default system QoS settings"/>
   
-  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN" description="
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN|TLM" description="
     use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -69,7 +69,7 @@
   <arg name="use_system_default_qos" default="false"
     description="Use the default system QoS settings"/>
 
-  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN"
+  <arg name="proc_mask" default="IMG|PCL|IMU|SCAN|TLM"
     description="Use any combination of the 4 flags to enable or disable specific processors"/>
 
   <arg name="scan_ring" default="0" description="

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.4</version>
+  <version>0.13.5</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/imu_packet_handler.h
+++ b/ouster-ros/src/imu_packet_handler.h
@@ -22,10 +22,10 @@ class ImuPacketHandler {
     using HandlerType = std::function<HandlerOutput(const sensor::ImuPacket&)>;
 
    public:
-    static HandlerType create_handler(const sensor::sensor_info& info,
-                                      const std::string& frame,
-                                      const std::string& timestamp_mode,
-                                      int64_t ptp_utc_tai_offset) {
+    static HandlerType create(const sensor::sensor_info& info,
+                              const std::string& frame,
+                              const std::string& timestamp_mode,
+                              int64_t ptp_utc_tai_offset) {
         const auto& pf = sensor::get_format(info);
         using Timestamper = std::function<rclcpp::Time(const sensor::ImuPacket&)>;
         Timestamper timestamper;

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -25,6 +25,7 @@
 #include "point_cloud_processor.h"
 #include "laser_scan_processor.h"
 #include "point_cloud_processor_factory.h"
+#include "telemetry_handler.h"
 
 namespace ouster_ros {
 
@@ -96,7 +97,7 @@ class OusterCloud : public OusterProcessingNodeBase {
         if (impl::check_token(tokens, "IMU")) {
             imu_pub =
                 create_publisher<sensor_msgs::msg::Imu>("imu", selected_qos);
-            imu_packet_handler = ImuPacketHandler::create_handler(
+            imu_packet_handler = ImuPacketHandler::create(
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
             imu_packet_sub = create_subscription<PacketMsg>(
@@ -189,18 +190,39 @@ class OusterCloud : public OusterProcessingNodeBase {
         }
 
         if (impl::check_token(tokens, "PCL") || impl::check_token(tokens, "SCAN")) {
-            lidar_packet_handler = LidarPacketHandler::create_handler(
+            lidar_packet_handler = LidarPacketHandler::create(
                 info, processors, timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+        }
+
+        if (impl::check_token(tokens, "TLM")) {
+            telemetry_pub =
+                create_publisher<ouster_sensor_msgs::msg::Telemetry>("telemetry",
+                                                                     selected_qos);
+            telemetry_handler = TelemetryHandler::create(
+                info, timestamp_mode,
+                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+        }
+
+        if (impl::check_token(tokens, "PCL") ||
+            impl::check_token(tokens, "SCAN") ||
+            impl::check_token(tokens, "TLM")) {
             lidar_packet_sub = create_subscription<PacketMsg>(
                 "lidar_packets", selected_qos,
                 [this](const PacketMsg::ConstSharedPtr msg) {
+                    // TODO[UN]: this is not ideal since we can't reuse the msg buffer
+                    // Need to redefine the Packet object and allow use of array_views
+                    sensor::LidarPacket lidar_packet(msg->buf.size());
+                    memcpy(lidar_packet.buf.data(), msg->buf.data(), msg->buf.size());
+                    lidar_packet.host_timestamp =
+                        static_cast<uint64_t>(rclcpp::Clock(RCL_ROS_TIME).now().nanoseconds());
+
+                    if (telemetry_handler) {
+                        auto telemetry = telemetry_handler(lidar_packet);
+                        telemetry_pub->publish(telemetry);
+                    }
+
                     if (lidar_packet_handler) {
-                        // TODO[UN]: this is not ideal since we can't reuse the msg buffer
-                        // Need to redefine the Packet object and allow use of array_views
-                        sensor::LidarPacket lidar_packet(msg->buf.size());
-                        memcpy(lidar_packet.buf.data(), msg->buf.data(), msg->buf.size());
-                        lidar_packet.host_timestamp = static_cast<uint64_t>(rclcpp::Clock(RCL_ROS_TIME).now().nanoseconds());
                         lidar_packet_handler(lidar_packet);
                     }
                 });
@@ -221,6 +243,9 @@ class OusterCloud : public OusterProcessingNodeBase {
 
     ImuPacketHandler::HandlerType imu_packet_handler;
     LidarPacketHandler::HandlerType lidar_packet_handler;
+
+    rclcpp::Publisher<ouster_sensor_msgs::msg::Telemetry>::SharedPtr telemetry_pub;
+    TelemetryHandler::HandlerType telemetry_handler;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -104,7 +104,7 @@ class OusterImage : public OusterProcessingNodeBase {
                 })
         };
 
-        lidar_packet_handler = LidarPacketHandler::create_handler(
+        lidar_packet_handler = LidarPacketHandler::create(
             info, processors, timestamp_mode,
             static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         lidar_packet_sub = create_subscription<PacketMsg>(

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -27,6 +27,8 @@ namespace ouster_ros {
 namespace sensor = ouster::sensor;
 using namespace ouster::util;
 using ouster_sensor_msgs::msg::PacketMsg;
+using ouster_sensor_msgs::msg::Telemetry;
+using ouster::sensor::LidarPacket;
 
 
 bool is_legacy_lidar_profile(const sensor::sensor_info& info) {
@@ -210,6 +212,18 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     }
 
     return msg;
+}
+
+Telemetry lidar_packet_to_telemetry_msg(
+    const LidarPacket& lidar_packet, const rclcpp::Time& timestamp,
+    const sensor::packet_format& pf) {
+    Telemetry telemetry;
+    telemetry.header.stamp = timestamp;
+    telemetry.countdown_thermal_shutdown = pf.countdown_thermal_shutdown(lidar_packet.buf.data());
+    telemetry.countdown_shot_limiting = pf.countdown_shot_limiting(lidar_packet.buf.data());
+    telemetry.thermal_shutdown = pf.thermal_shutdown(lidar_packet.buf.data());
+    telemetry.shot_limiting = pf.shot_limiting(lidar_packet.buf.data());
+    return telemetry;
 }
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -72,6 +72,8 @@ class OusterSensor : public OusterSensorNodeBase {
 
     void update_metadata(sensor::client& client);
 
+    void metadata_updated(const sensor::sensor_info& info);
+
     void save_metadata();
 
     // param init_id_reset is overriden to true when force_reinit is true
@@ -109,11 +111,15 @@ class OusterSensor : public OusterSensorNodeBase {
 
     void handle_poll_client_error();
 
-    void handle_lidar_packet(sensor::client& client,
-                             const sensor::packet_format& pf);
-
-    void handle_imu_packet(sensor::client& client,
+    void read_lidar_packet(sensor::client& client,
                            const sensor::packet_format& pf);
+
+    void handle_lidar_packet(const sensor::LidarPacket& lidar_packet);
+
+    void read_imu_packet(sensor::client& client,
+                         const sensor::packet_format& pf);
+
+    void handle_imu_packet(const sensor::ImuPacket& imu_packet);
 
     void connection_loop(sensor::client& client,
                          const sensor::packet_format& pf);
@@ -123,7 +129,7 @@ class OusterSensor : public OusterSensorNodeBase {
     void stop_sensor_connection_thread();
 
     bool get_active_config_no_throw(const std::string& sensor_hostname,
-                             sensor::sensor_config& config);
+                                    sensor::sensor_config& config);
 
    private:
     std::string sensor_hostname;

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -138,25 +138,22 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
             const auto tgt_idx =
                 organized ? (u / rows_step) * ls.w + v : cloud.size();
 
-            if (xyz.isNaN().any()) {
-                if (organized) {
-                    cloud.is_dense = false;
-                    auto& pt = cloud.points[tgt_idx];
-                    pt.x = static_cast<decltype(pt.x)>(xyz(0));
-                    pt.y = static_cast<decltype(pt.y)>(xyz(1));
-                    pt.z = static_cast<decltype(pt.z)>(xyz(2));
-                }
-                continue;
-            } else {
-                if (!organized) cloud.points.emplace_back();
-            }
-
             // as opposed to the point cloud destaggering if it is disabled
             // then timestamps needs to be staggered.
             auto ts_idx =
                 destagger ? v : (v + ls.w + pixel_shift_by_row[u]) % ls.w;
             auto ts =
                 timestamp[ts_idx] > scan_ts ? timestamp[ts_idx] - scan_ts : 0UL;
+
+            if (organized) {
+                cloud.is_dense &= xyz.isNaN().any();
+            } else {
+                if (xyz.isNaN().any())
+                    continue;
+                else
+                    cloud.points.emplace_back();
+            }
+
 
             // if target point and staging point has matching type bind the
             // target directly and avoid performing transform_point at the end

--- a/ouster-ros/src/telemetry_handler.h
+++ b/ouster-ros/src/telemetry_handler.h
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file imu_packet_handler.h
+ * @brief ...
+ */
+
+#pragma once
+
+// prevent clang-format from altering the location of "ouster_ros/os_ros.h", the
+// header file needs to be the first include due to PCL_NO_PRECOMPILE flag
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+
+namespace ouster_ros {
+
+class TelemetryHandler {
+   public:
+    using HandlerOutput = ouster_sensor_msgs::msg::Telemetry;
+    using HandlerType = std::function<HandlerOutput(const sensor::LidarPacket&)>;
+
+    static uint64_t first_valid_ts(const sensor::LidarPacket& lidar_packet,
+                                   const sensor::packet_format& pf) {
+        // scan for the first non-zero column ts
+        uint64_t ts = 0;
+        for (int icol = 0; icol < pf.columns_per_packet; ++icol) {
+            ts = pf.col_timestamp(pf.nth_col(icol, lidar_packet.buf.data()));
+            if (ts != 0)
+                break;
+        }
+        return ts;
+    }
+
+   public:
+    static HandlerType create(const sensor::sensor_info& info,
+                                      const std::string& timestamp_mode,
+                                      int64_t ptp_utc_tai_offset) {
+        const auto& pf = sensor::get_format(info);
+        using Timestamper = std::function<rclcpp::Time(const sensor::LidarPacket&)>;
+
+        Timestamper timestamper;
+        if (timestamp_mode == "TIME_FROM_ROS_TIME") {
+            timestamper = Timestamper{
+                [](const sensor::LidarPacket& lidar_packet) {
+                    return rclcpp::Time(lidar_packet.host_timestamp);
+                }};
+        } else if (timestamp_mode == "TIME_FROM_PTP_1588") {
+            timestamper = Timestamper{
+                [pf, ptp_utc_tai_offset](const sensor::LidarPacket& lidar_packet) {
+                    uint64_t ts = TelemetryHandler::first_valid_ts(lidar_packet, pf);
+                    ts = impl::ts_safe_offset_add(ts, ptp_utc_tai_offset);
+                    return rclcpp::Time(ts);
+
+                }};
+        } else {
+            timestamper = Timestamper{
+                [pf](const sensor::LidarPacket& lidar_packet) {
+                    uint64_t ts = TelemetryHandler::first_valid_ts(lidar_packet, pf);
+                    return rclcpp::Time(ts);
+                }};
+        }
+
+        return [pf, timestamper](const sensor::LidarPacket& lidar_packet) {
+            return lidar_packet_to_telemetry_msg(lidar_packet, timestamper(lidar_packet), pf);
+        };
+    }
+};
+
+}  // namespace ouster_ros

--- a/ouster-sensor-msgs/CMakeLists.txt
+++ b/ouster-sensor-msgs/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PacketMsg.msg"
+  "msg/Telemetry.msg"
   "srv/GetConfig.srv"
   "srv/SetConfig.srv"
   "srv/GetMetadata.srv"

--- a/ouster-sensor-msgs/msg/Telemetry.msg
+++ b/ouster-sensor-msgs/msg/Telemetry.msg
@@ -1,0 +1,26 @@
+# This message defines the telemetry data for Ouster sensors.
+
+# ThermalShutdownStatus thermal_shutdown
+uint8 THERMAL_SHUTDOWN_NORMAL=0    # Normal operation
+uint8 THERMAL_SHUTDOWN_IMMINENT=1  # Thermal Shutdown imminent
+
+# ShotLimitingStatus shot_limiting
+uint8 SHOT_LIMITING_NORMAL=0          # Normal operation
+uint8 SHOT_LIMITING_IMMINENT=1        # Shot limiting imminent
+uint8 SHOT_LIMITING_REDUCTION_0_10=2  # Shot limiting reduction by 0 to 10%
+uint8 SHOT_LIMITING_REDUCTION_10_20=3 # Shot limiting reduction by 10 to 20%
+uint8 SHOT_LIMITING_REDUCTION_20_30=4 # Shot limiting reduction by 20 to 30%
+uint8 SHOT_LIMITING_REDUCTION_30_40=5 # Shot limiting reduction by 30 to 40%
+uint8 SHOT_LIMITING_REDUCTION_40_50=6 # Shot limiting reduction by 40 to 50%
+uint8 SHOT_LIMITING_REDUCTION_50_60=7 # Shot limiting reduction by 50 to 60%
+uint8 SHOT_LIMITING_REDUCTION_60_70=8 # Shot limiting reduction by 60 to 70%
+uint8 SHOT_LIMITING_REDUCTION_70_75=9 # Shot limiting reduction by 70 to 80%
+
+# Message header
+std_msgs/Header header
+# Telemetry fields for more information on these fields and their meaning, please review:
+# https://static.ouster.dev/sensor-docs/image_route1/image_route2/thermal_int_guide/therm_int_guide.html
+uint16 countdown_thermal_shutdown # the thermal shutdown countdown.
+uint16 countdown_shot_limiting    # the shot limiting countdown.
+uint8 thermal_shutdown            # the thermal shutdown status. 0 = NORMAL, 1 = SHUTDOWN IMMINENT.
+uint8 shot_limiting               # the shot limiting status. 0 = NORMAL OPERATION.


### PR DESCRIPTION
## Related Issues & PRs
* Related: #200
* Related: #413 
* Rrelated: #419 
* Related: #420 

## Summary of Changes
* Define a new telemetry message and emit (it from a live sensor or bag file or pcap) 
* Always set timestamps in the PointCloud even for invalid points
* Code refactor for LidarPacketHandler
* Always copy fill all fields for organized point clouds to have NEAR_IR channel populated regardless of having a valid range
At the same time fill the other fields even for invalid range such that the data is overwritten


## Validation
* Launch a live sensor with telemetry enabled
```bash
ros2 ouster_ros driver.launch.py sensor_hostname:=... proce_mask:="...|TLM"
```
* Once sensor is connected, open a separate terminal launch, verify that the telemetry topic is up and running
```bash
ros2 topic echo /ouster/telemetry
```
* Verify that the telemetry messages are being sent at the same rate as the raw packets topic
```bash
ros2 topic hz /ouster/telemetry
```