### PR TITLE
ROS-268-min-valid-cols-lidar-scan

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,12 @@ Changelog
 [unreleased]
 ============
 * [BUGFIX]: correctly align timestamps to the generated point cloud
-* Added support to enable **loop** for pcap replay + other replay config
-* Added a new launch file parameter ``pub_static_tf`` that allows users to turn off the broadcast
-  of sensor TF transforms.
-* Introduced a new topic ``/ouster/telemetry`` that publishes ``ouster_ros::Telemetry`` messages,
-  the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
 * [BUGFIX]: NEAR_IR data is not populated with data for organized point clouds that have no range.
+* Add support to enable **loop** for pcap replay + other replay config
+* Add a new launch file parameter ``pub_static_tf`` that allows users to turn off the broadcast
+  of sensor TF transforms.
+* Introduce a new topic ``/ouster/telemetry`` that publishes ``ouster_ros::Telemetry`` messages,
+  the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
 * Add a new launch file parameter ``min_scan_valid_columns_ratio`` to allow users to set the minimum
   ratio of valid columns in a scan for it to be processed. Default value is ``0.0``.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Changelog
 * Introduced a new topic ``/ouster/telemetry`` that publishes ``ouster_ros::Telemetry`` messages,
   the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
 * [BUGFIX]: NEAR_IR data is not populated with data for organized point clouds that have no range.
+* Add a new launch file parameter ``min_scan_valid_columns_ratio`` to allow users to set the minimum
+  ratio of valid columns in a scan for it to be processed. Default value is ``0.0``.
 
 
 ouster_ros v0.13.0

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -51,6 +51,9 @@
   <arg name="min_range" doc="minimum lidar range to consider (meters)"/>
   <arg name="max_range" doc="maximum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio"
+    doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
       output="screen" required="true"
@@ -74,6 +77,8 @@
       <param name="~/destagger" value="$(arg destagger)"/>
       <param name="~/min_range" value="$(arg min_range)"/>
       <param name="~/max_range" value="$(arg max_range)"/>
+      <param name="~/min_scan_valid_columns_ratio"
+        value="$(arg min_scan_valid_columns_ratio)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -99,6 +99,9 @@
   <arg name="max_range" default="10000.0"
     doc="maximum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -139,6 +142,8 @@
       <param name="~/destagger" value="$(arg destagger)"/>
       <param name="~/min_range" value="$(arg min_range)"/>
       <param name="~/max_range" value="$(arg max_range)"/>
+      <param name="~/min_scan_valid_columns_ratio"
+        value="$(arg min_scan_valid_columns_ratio)"/>
     </node>
   </group>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -99,6 +99,9 @@
     doc="maximum number of attempts trying to communicate with the sensor.
          Counter resets upon successful connection"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -154,6 +157,8 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="~/min_scan_valid_columns_ratio"
+        value="$(arg min_scan_valid_columns_ratio)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -77,6 +77,9 @@
   <arg name="max_range" default="10000.0"
     doc="maximum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -116,6 +119,8 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="~/min_scan_valid_columns_ratio"
+        value="$(arg min_scan_valid_columns_ratio)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -72,6 +72,9 @@
   <arg name="max_range" default="10000.0"
     doc="maximum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -112,6 +115,8 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="~/min_scan_valid_columns_ratio"
+        value="$(arg min_scan_valid_columns_ratio)"/>
   </include>
 
 

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -107,6 +107,9 @@
   <arg name="max_range" default="10000.0"
     doc="maximum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -162,6 +165,8 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="~/min_scan_valid_columns_ratio"
+        value="$(arg min_scan_valid_columns_ratio)"/>
   </include>
 
 </launch>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -111,6 +111,9 @@
   <arg name="max_range" default="10000.0"
     doc="maximum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -168,6 +171,8 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="~/min_scan_valid_columns_ratio"
+        value="$(arg min_scan_valid_columns_ratio)"/>
   </include>
 
 </launch>

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -383,7 +383,7 @@ class LidarPacketHandler {
 
     int64_t ptp_utc_tai_offset_;
 
-    float min_scan_valid_columns_ratio_ = 0.7;
+    float min_scan_valid_columns_ratio_ = 0.0f;
 };
 
 }  // namespace ouster_ros

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -135,10 +135,10 @@ class LidarPacketHandler {
                         auto status = lidar_scan.status();
                         size_t valid_cols = std::count_if(status.data(), status.data() + status.size(),
                                [](const uint32_t s) { return (s & 0x01); });
-                        if (valid_cols < static_cast<size_t>(min_scan_valid_columns_ratio_ * lidar_scan.status().size())) {
-                            NODELET_WARN_STREAM("number of valid columns per scan " << valid_cols
+                        if (valid_cols < static_cast<size_t>(min_scan_valid_columns_ratio_ * status.size())) {
+                            NODELET_WARN_STREAM("number of valid columns per scan " << valid_cols << "/" << status.size()
                              <<" which is below the ratio " << std::setprecision(4) << (100 * min_scan_valid_columns_ratio_)
-                             << "%% SKIPPING SCAN");
+                             << "%, SKIPPING SCAN");
                             result = false;
                         }
                     }

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -180,6 +180,13 @@ class OusterCloud : public nodelet::Nodelet {
         }
 
         std::vector<LidarScanProcessor> processors;
+
+        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0);
+        if (min_scan_valid_columns_ratio < 0.0 || min_scan_valid_columns_ratio > 1.0) {
+            NODELET_FATAL("min_scan_valid_columns_ratio needs to be in the range [0, 1]");
+            throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
+        }
+
         if (impl::check_token(tokens, "PCL")) {
             auto point_type = pnh.param("point_type", std::string{"original"});
             auto organized = pnh.param("organized", true);
@@ -200,6 +207,7 @@ class OusterCloud : public nodelet::Nodelet {
             uint32_t min_range = impl::ulround(min_range_m * 1000);
             uint32_t max_range = impl::ulround(max_range_m * 1000);
             auto rows_step = pnh.param("rows_step", 1);
+
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(
                     point_type, info, tf_bcast.point_cloud_frame_id(),
@@ -254,7 +262,8 @@ class OusterCloud : public nodelet::Nodelet {
             impl::check_token(tokens, "SCAN")) {
             lidar_packet_handler = LidarPacketHandler::create(
                 info, processors, timestamp_mode,
-                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+                static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
+                min_scan_valid_columns_ratio);
         }
 
         if (impl::check_token(tokens, "TLM")) {

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -179,13 +179,13 @@ class OusterCloud : public nodelet::Nodelet {
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }
 
-        std::vector<LidarScanProcessor> processors;
-
         auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0);
         if (min_scan_valid_columns_ratio < 0.0 || min_scan_valid_columns_ratio > 1.0) {
             NODELET_FATAL("min_scan_valid_columns_ratio needs to be in the range [0, 1]");
             throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
         }
+
+        std::vector<LidarScanProcessor> processors;
 
         if (impl::check_token(tokens, "PCL")) {
             auto point_type = pnh.param("point_type", std::string{"original"});

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -179,8 +179,8 @@ class OusterCloud : public nodelet::Nodelet {
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }
 
-        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0);
-        if (min_scan_valid_columns_ratio < 0.0 || min_scan_valid_columns_ratio > 1.0) {
+        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0f);
+        if (min_scan_valid_columns_ratio < 0.0f || min_scan_valid_columns_ratio > 1.0f) {
             NODELET_FATAL("min_scan_valid_columns_ratio needs to be in the range [0, 1]");
             throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
         }

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -125,8 +125,8 @@ class OusterDriver : public OusterSensor {
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
         }
 
-        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0);
-        if (min_scan_valid_columns_ratio < 0.0 || min_scan_valid_columns_ratio > 1.0) {
+        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0f);
+        if (min_scan_valid_columns_ratio < 0.0f || min_scan_valid_columns_ratio > 1.0f) {
             NODELET_FATAL("min_scan_valid_columns_ratio needs to be in the range [0, 1]");
             throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
         }

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -99,6 +99,12 @@ class OusterImage : public nodelet::Nodelet {
         auto timestamp_mode = pnh.param("timestamp_mode", std::string{});
         double ptp_utc_tai_offset = pnh.param("ptp_utc_tai_offset", -37.0);
 
+        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0);
+        if (min_scan_valid_columns_ratio < 0.0 || min_scan_valid_columns_ratio > 1.0) {
+            NODELET_FATAL("min_scan_valid_columns_ratio needs to be in the range [0, 1]");
+            throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
+        }
+
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
                 info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
@@ -111,7 +117,8 @@ class OusterImage : public nodelet::Nodelet {
 
         lidar_packet_handler = LidarPacketHandler::create(
             info, processors, timestamp_mode,
-            static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+            static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
+            min_scan_valid_columns_ratio);
     }
 
    private:

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -99,8 +99,8 @@ class OusterImage : public nodelet::Nodelet {
         auto timestamp_mode = pnh.param("timestamp_mode", std::string{});
         double ptp_utc_tai_offset = pnh.param("ptp_utc_tai_offset", -37.0);
 
-        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0);
-        if (min_scan_valid_columns_ratio < 0.0 || min_scan_valid_columns_ratio > 1.0) {
+        auto min_scan_valid_columns_ratio = pnh.param("min_scan_valid_columns_ratio", 0.0f);
+        if (min_scan_valid_columns_ratio < 0.0f || min_scan_valid_columns_ratio > 1.0f) {
             NODELET_FATAL("min_scan_valid_columns_ratio needs to be in the range [0, 1]");
             throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
         }


### PR DESCRIPTION
## Related Issues & PRs
- Related #268

## Summary of Changes
* Skip the lidar_scan based on a predefined percentage of the minimum number of valid columns in scan

## Validation
* Launch a node as usual but enable the new `min_scan_valid_columns_ratio` parameter (set a high value)
```bash
roslaunch ouster_ros driver.launch sensor_hostname:=... min_scan_valid_columns_ratio:=0.9
```
* Observe the warning messages whenever the number of valid columns drops below the set amount:
```bash
[ WARN] [1738283732.021510354]: number of valid columns per scan 160 which is below the ratio 90%% SKIPPING SCAN
[ WARN] [1738283732.080962740]: number of valid columns per scan 304 which is below the ratio 90%% SKIPPING SCAN
```