### PR TITLE
Port the changes to ROS2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,12 +5,14 @@ Changelog
 [unreleased]
 ============
 * [BUGFIX]: correctly align timestamps to the generated point cloud.
-* Added support to enable **loop** for pcap replay + other replay config.
-* Added a new launch file parameter ``pub_static_tf`` that allows users to turn off the braodcast
+* [BUGFIX]: NEAR_IR data is not populated with data for organized point clouds that have no range.
+* Add support to enable **loop** for pcap replay + other replay config.
+* Add a new launch file parameter ``pub_static_tf`` that allows users to turn off the braodcast
   of sensor TF transforms.
-* Introduced a new topic ``/ouster/telemetry`` that publishes ``ouster_ros::Telemetry`` messages,
+* Introduce a new topic ``/ouster/telemetry`` that publishes ``ouster_ros::Telemetry`` messages,
   the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
-[BUGFIX]: NEAR_IR data is not populated with data for organized point clouds that have no range.
+* Add a new launch file parameter ``min_scan_valid_columns_ratio`` to allow users to set the minimum
+  ratio of valid columns in a scan for it to be processed. Default value is ``0.0``.
 
 ouster_ros v0.13.2
 ==================

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -115,3 +115,6 @@ ouster/os_driver:
     min_range: 0.0
     # max_range[optional]: maximum lidar range to consider (meters).
     max_range: 1000.0
+    # min_scan_valid_columns_ratio[optional]: The minimum ratio of valid columns for
+    # processing the LidarScan [0, 1]. default is 0%
+    min_scan_valid_columns_ratio: 0.0

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -79,6 +79,16 @@
     xyzir
     }"/>
 
+  <arg name="organized" default="true"
+    description="generate an organzied point cloud"/>
+  <arg name="destagger" default="true"
+    description="enable or disable point cloud destaggering"/>
+
+  <arg name="min_range" default="0.0"
+    description="minimum lidar range to consider (meters)"/>
+  <arg name="max_range" default="100000.0"
+    description="minimum lidar range to consider (meters)"/>
+
   <arg name="azimuth_window_start" default="0" description="azimuth window start;
     values range [0, 360000] millidegrees"/>
   <arg name="azimuth_window_end" default="360000" description="azimuth window end;
@@ -98,6 +108,9 @@
 
   <arg name="auto_start" default="true"
     description="automatically configure and activate the node"/>
+
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    description="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
@@ -136,6 +149,11 @@
         <param name="proc_mask" value="$(var proc_mask)"/>
         <param name="scan_ring" value="$(var scan_ring)"/>
         <param name="point_type" value="$(var point_type)"/>
+        <param name="organized" value="$(var organized)"/>
+        <param name="destagger" value="$(var destagger)"/>
+        <param name="min_range" value="$(var min_range)"/>
+        <param name="max_range" value="$(var max_range)"/>
+        <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -76,6 +76,9 @@
   <arg name="max_range" default="100000.0"
     description="minimum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    description="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
@@ -102,6 +105,7 @@
         <param name="destagger" value="$(var destagger)"/>
         <param name="min_range" value="$(var min_range)"/>
         <param name="max_range" value="$(var max_range)"/>
+        <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <remap from="/os_node/metadata" to="/ouster/metadata"/>

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -72,6 +72,9 @@
   <arg name="max_range" default="10000.0"
     description="minimum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    description="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_pcap" name="os_pcap"
@@ -99,6 +102,7 @@
         <param name="destagger" value="$(var destagger)"/>
         <param name="min_range" value="$(var min_range)"/>
         <param name="max_range" value="$(var max_range)"/>
+        <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -107,6 +107,9 @@
   <arg name="max_range" default="10000.0"
     description="minimum lidar range to consider (meters)"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    description="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -143,6 +146,8 @@
       <param name="destagger" value="$(var destagger)"/>
       <param name="min_range" value="$(var min_range)"/>
       <param name="max_range" value="$(var max_range)"/>
+      <param name="min_scan_valid_columns_ratio"
+             value="$(var min_scan_valid_columns_ratio)"/>
     </node>
   </group>
 

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -97,6 +97,9 @@
   <arg name="auto_start" default="true"
     description="automatically configure and activate the node"/>
 
+  <arg name="min_scan_valid_columns_ratio" default="0.0"
+    description="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_sensor" name="os_sensor" output="screen">
@@ -133,6 +136,8 @@
       <param name="proc_mask" value="$(var proc_mask)"/>
       <param name="scan_ring" value="$(var scan_ring)"/>
       <param name="point_type" value="$(var point_type)"/>
+      <param name="min_scan_valid_columns_ratio"
+             value="$(var min_scan_valid_columns_ratio)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen">
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -42,6 +42,7 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("timestamp_mode", "");
         declare_parameter("ptp_utc_tai_offset", -37.0);
         declare_parameter("use_system_default_qos", false);
+        declare_parameter("min_scan_valid_columns_ratio", 0.0);
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
@@ -94,6 +95,12 @@ class OusterImage : public OusterProcessingNodeBase {
                                                             selected_qos);
         }
 
+        auto min_scan_valid_columns_ratio = get_parameter("min_scan_valid_columns_ratio").as_double();
+        if (min_scan_valid_columns_ratio < 0.0f || min_scan_valid_columns_ratio > 1.0f) {
+            RCLCPP_FATAL(get_logger(), "min_scan_valid_columns_ratio needs to be in the range [0, 1]");
+            throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
+        }
+
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
                 info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
@@ -106,7 +113,8 @@ class OusterImage : public OusterProcessingNodeBase {
 
         lidar_packet_handler = LidarPacketHandler::create(
             info, processors, timestamp_mode,
-            static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+            static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
+            min_scan_valid_columns_ratio);
         lidar_packet_sub = create_subscription<PacketMsg>(
                 "lidar_packets", selected_qos,
                 [this](const PacketMsg::ConstSharedPtr msg) {


### PR DESCRIPTION
## Related Issues & PRs
- Related #268

## Summary of Changes
* Skip the lidar_scan based on a predefined percentage of the minimum number of valid columns in scan

## Validation
* Edit `driver_params.yaml` to set the sensor name and set `min_scan_valid_columns_ratio` value to a high value `0.9`
* Launch a node as usual `ros2 ouster_ros driver.launch.py`
* Observe the warning messages whenever the number of valid columns drops below the set amount:
```bash
[ WARN] [1738283732.021510354]: number of valid columns per scan 160 which is below the ratio 90% SKIPPING SCAN
[ WARN] [1738283732.080962740]: number of valid columns per scan 304 which is below the ratio 90% SKIPPING SCAN
```