### PR TITLE
[ros2] Fix ouster_ros install directories for easy include by dependent nodes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
   the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
 * Add a new launch file parameter ``min_scan_valid_columns_ratio`` to allow users to set the minimum
   ratio of valid columns in a scan for it to be processed. Default value is ``0.0``.
+* Update where ouster-ros and ouster_client include directories get installed so that those headers can be included externally.
 
 ouster_ros v0.13.2
 ==================

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -231,9 +231,16 @@ install(
 
 install(
   DIRECTORY
-    ${_ouster_ros_INCLUDE_DIRS}
+    include/${PROJECT_NAME}/
   DESTINATION
-    include/${PROJECT_NAME}
+    include/${PROJECT_NAME}/
+)
+
+install(
+  DIRECTORY
+    ouster-sdk/ouster_client/include/ouster
+    ouster-sdk/ouster_client/include/optional-lite/nonstd
+  DESTINATION include
 )
 
 install(

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.5</version>
+  <version>0.13.6</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
This PR is similar in nature to https://github.com/ouster-lidar/ouster-ros/pull/258 except targeting the ros2 branch. I've found that before these changes, I am not able to include the header files in ouster_ros when using the install space.

Before, the file tree under `install/ouster_ros/include` looked like this:

![image](https://github.com/user-attachments/assets/75a97513-5253-46c3-834f-cbff19cc9f34)

After the changes the file tree under `install/ouster_ros/include` is the following which makes more sense.

![image](https://github.com/user-attachments/assets/7dcaeb86-6e05-4f00-8d21-ab1eae4deda4)

## Summary of Changes
Updates install path in Cmakelists.txt
## Validation
Was able to include ouster_ros headers (like `#include <ouster_ros/os_ros.h>`) in my project and it can now compile!