### PR TITLE
Cherry-pick node auto-start to ros2-foxy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ Changelog
   to the default
 * Added a new launch ``persist_config`` option to request the sensor persist the current config
 * Added a new ``loop`` option to the ``replay.launch.xml`` file.
+* Added an automatic start mode to make it easier to start the node without using time actions.
+  - To disable set ``auto_start`` to ``false`` during launch
+* Added a new parameter ``organized`` to request publishing unorganized point cloud
+* Added a new parameter ``destagger`` to request publishing staggered point cloud
+* Added two parameters ``min_range``, ``max_range`` to limit the lidar effective range
 
 ouster_ros v0.12.0
 ==================

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -93,3 +93,12 @@ ouster/os_driver:
     azimuth_window_end: 360000
     # persist_config[optional]: request the sensor to persist settings
     persist_config: false
+    # organized[optional]: whether to generate an organized point cloud. default
+    # is organized.
+    organized: true
+    # destagger[optional]: enable or disable point cloud destaggering, default enabled.
+    destagger: true
+    # min_range[optional]: minimum lidar range to consider (meters).
+    min_range: 0.0
+    # max_range[optional]: maximum lidar range to consider (meters).
+    max_range: 1000.0

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -158,6 +158,14 @@ inline bool check_token(const std::set<std::string>& tokens,
 
 ouster::util::version parse_version(const std::string& fw_rev);
 
+template <typename T>
+uint64_t ulround(T value) {
+    T rounded_value = std::round(value);
+    if (rounded_value < 0) return 0ULL;
+    if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
+    return static_cast<uint64_t>(rounded_value);
+}
+
 } // namespace impl
 
 }  // namespace ouster_ros

--- a/ouster-ros/launch/replay.independent.launch.xml
+++ b/ouster-ros/launch/replay.independent.launch.xml
@@ -61,6 +61,16 @@
     xyzir
     }"/>
 
+  <arg name="organized" default="true"
+    description="generate an organzied point cloud"/>
+  <arg name="destagger" default="true"
+    description="enable or disable point cloud destaggering"/>
+
+  <arg name="min_range" default="0.0"
+    description="minimum lidar range to consider (meters)"/>
+  <arg name="max_range" default="100000.0"
+    description="minimum lidar range to consider (meters)"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
@@ -79,6 +89,10 @@
       <param name="proc_mask" value="$(var proc_mask)"/>
       <param name="scan_ring" value="$(var scan_ring)"/>
       <param name="point_type" value="$(var point_type)"/>
+      <param name="organized" value="$(var organized)"/>
+      <param name="destagger" value="$(var destagger)"/>
+      <param name="min_range" value="$(var min_range)"/>
+      <param name="max_range" value="$(var max_range)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen">
       <remap from="/os_node/lidar_packets" to="/ouster/lidar_packets"/>

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -55,6 +55,16 @@
     xyzir
     }"/>
 
+  <arg name="organized" default="true"
+    description="generate an organzied point cloud"/>
+  <arg name="destagger" default="true"
+    description="enable or disable point cloud destaggering"/>
+
+  <arg name="min_range" default="0.0"
+    description="minimum lidar range to consider (meters)"/>
+  <arg name="max_range" default="10000.0"
+    description="minimum lidar range to consider (meters)"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_pcap" name="os_pcap" output="screen">
@@ -73,6 +83,10 @@
       <param name="proc_mask" value="$(var proc_mask)"/>
       <param name="scan_ring" value="$(var scan_ring)"/>
       <param name="point_type" value="$(var point_type)"/>
+      <param name="organized" value="$(var organized)"/>
+      <param name="destagger" value="$(var destagger)"/>
+      <param name="min_range" value="$(var min_range)"/>
+      <param name="max_range" value="$(var max_range)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen">
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/launch/sensor.composite.launch.py
+++ b/ouster-ros/launch/sensor.composite.launch.py
@@ -36,12 +36,15 @@ def generate_launch_description():
     rviz_enable = LaunchConfiguration('viz')
     rviz_enable_arg = DeclareLaunchArgument('viz', default_value='True')
 
+    auto_start = LaunchConfiguration('auto_start')
+    auto_start_arg = DeclareLaunchArgument('auto_start', default_value='True')
+
     os_sensor = ComposableNode(
         package='ouster_ros',
         plugin='ouster_ros::OusterSensor',
         name='os_sensor',
         namespace=ouster_ns,
-        parameters=[params_file]
+        parameters=[params_file, {'auto_start': auto_start}]
     )
 
     os_cloud = ComposableNode(
@@ -80,25 +83,11 @@ def generate_launch_description():
         condition=IfCondition(rviz_enable)
     )
 
-    # HACK: to configure and activate the the sensor since state transition
-    # API doesn't seem to support composable nodes yet.
-
-    def invoke_lifecycle_cmd(node_name, verb):
-        ros2_exec = FindExecutable(name='ros2')
-        return ExecuteProcess(
-            cmd=[[ros2_exec, ' lifecycle set ',
-                  ouster_ns, '/', node_name, ' ', verb]],
-            shell=True)
-
-    sensor_configure_cmd = invoke_lifecycle_cmd('os_sensor', 'configure')
-    sensor_activate_cmd = invoke_lifecycle_cmd('os_sensor', 'activate')
-
     return launch.LaunchDescription([
         params_file_arg,
         ouster_ns_arg,
         rviz_enable_arg,
+        auto_start_arg,
         rviz_launch,
-        os_container,
-        sensor_configure_cmd,
-        TimerAction(period=1.0, actions=[sensor_activate_cmd])
+        os_container
     ])

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -84,6 +84,16 @@
   <arg name="auto_start" default="true"
     description="automatically configure and activate the node"/>
 
+  <arg name="organized" default="true"
+    description="generate an organzied point cloud"/>
+  <arg name="destagger" default="true"
+    description="enable or disable point cloud destaggering"/>
+
+  <arg name="min_range" default="0.0"
+    description="minimum lidar range to consider (meters)"/>
+  <arg name="max_range" default="10000.0"
+    description="minimum lidar range to consider (meters)"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -110,6 +120,10 @@
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
       <param name="auto_start" value="$(var auto_start)"/>
+      <param name="organized" value="$(var organized)"/>
+      <param name="destagger" value="$(var destagger)"/>
+      <param name="min_range" value="$(var min_range)"/>
+      <param name="max_range" value="$(var max_range)"/>
     </node>
   </group>
 

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -81,6 +81,9 @@
   <arg name="persist_config" default="false"
     description="request the sensor to persist settings"/>
 
+  <arg name="auto_start" default="true"
+    description="automatically configure and activate the node"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -106,15 +109,9 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
+      <param name="auto_start" value="$(var auto_start)"/>
     </node>
   </group>
-
-  <!-- HACK: configure and activate the sensor node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -83,6 +83,9 @@
   <arg name="persist_config" default="false"
     description="request the sensor to persist settings"/>
 
+  <arg name="auto_start" default="true"
+    description="automatically configure and activate the node"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_sensor" name="os_sensor" output="screen">
@@ -100,6 +103,7 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
+      <param name="auto_start" value="$(var auto_start)"/>
     </node>
     <node pkg="ouster_ros" exec="os_cloud" name="os_cloud" output="screen">
       <param name="sensor_frame" value="$(var sensor_frame)"/>
@@ -117,13 +121,6 @@
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
     </node>
   </group>
-
-  <!-- HACK: configure and activate the sensor node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_sensor activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>

--- a/ouster-ros/launch/sensor.independent.launch.xml
+++ b/ouster-ros/launch/sensor.independent.launch.xml
@@ -86,6 +86,16 @@
   <arg name="auto_start" default="true"
     description="automatically configure and activate the node"/>
 
+  <arg name="organized" default="true"
+    description="generate an organzied point cloud"/>
+  <arg name="destagger" default="true"
+    description="enable or disable point cloud destaggering"/>
+
+  <arg name="min_range" default="0.0"
+    description="minimum lidar range to consider (meters)"/>
+  <arg name="max_range" default="10000.0"
+    description="minimum lidar range to consider (meters)"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_sensor" name="os_sensor" output="screen">
@@ -116,6 +126,10 @@
       <param name="proc_mask" value="$(var proc_mask)"/>
       <param name="scan_ring" value="$(var scan_ring)"/>
       <param name="point_type" value="$(var point_type)"/>
+      <param name="organized" value="$(var organized)"/>
+      <param name="destagger" value="$(var destagger)"/>
+      <param name="min_range" value="$(var min_range)"/>
+      <param name="max_range" value="$(var max_range)"/>
     </node>
     <node pkg="ouster_ros" exec="os_image" name="os_image" output="screen">
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -89,6 +89,9 @@
   <arg name="persist_config" default="false"
     description="request the sensor to persist settings"/>
 
+  <arg name="auto_start" default="true"
+    description="automatically configure and activate the node"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -114,15 +117,9 @@
       <param name="azimuth_window_start" value="$(var azimuth_window_start)"/>
       <param name="azimuth_window_end" value="$(var azimuth_window_end)"/>
       <param name="persist_config" value="$(var persist_config)"/>
+      <param name="auto_start" value="$(var auto_start)"/>
     </node>
   </group>
-
-  <!-- HACK: configure and activate the sensor node via a process execute since state
-    transition is currently not availabe through launch.xml format -->
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver configure"
-    launch-prefix="bash -c 'sleep 0; $0 $@'" output="screen"/>
-  <executable cmd="$(find-exec ros2) lifecycle set /$(var ouster_ns)/os_driver activate"
-    launch-prefix="bash -c 'sleep 1; $0 $@'" output="screen"/>
 
   <include if="$(var viz)" file="$(find-pkg-share ouster_ros)/launch/rviz.launch.xml">
     <arg name="ouster_ns" value="$(var ouster_ns)"/>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.12.6</version>
+  <version>0.12.7</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/impl/cartesian.h
+++ b/ouster-ros/src/impl/cartesian.h
@@ -16,7 +16,10 @@ namespace ouster {
  * LidarScan.
  * @param[in] direction the direction of an xyz lut.
  * @param[in] offset the offset of an xyz lut.
- * @param[in] invalid the value to assign of an xyz lut.
+ * @param[in] min_range minimum lidar range to consider (millimeters).
+ * @param[in] max_range maximum lidar range to consider (millimeters).
+ * @param[in] invalid the value to assign of an xyz lut when range values are
+ * equal to or exceed the min_range and max_range values.
  *
  * @return Cartesian points where ith row is a 3D point which corresponds
  *         to ith pixel in LidarScan where i = row * w + col.
@@ -25,7 +28,7 @@ template <typename T>
 void cartesianT(PointsT<T>& points,
                 const Eigen::Ref<const img_t<uint32_t>>& range,
                 const PointsT<T>& direction, const PointsT<T>& offset,
-                T invalid) {
+                uint32_t min_r, uint32_t max_r, T invalid) {
     assert(points.rows() == direction.rows() &&
            "points & direction row count mismatch");
     assert(points.rows() == offset.rows() &&
@@ -51,7 +54,7 @@ void cartesianT(PointsT<T>& points,
         const auto idx_x = col_x + i;
         const auto idx_y = col_y + i;
         const auto idx_z = col_z + i;
-        if (r == 0) {
+        if (r <= min_r || r >= max_r) {
             pts[idx_x] = pts[idx_y] = pts[idx_z] = invalid;
         } else {
             pts[idx_x] = r * dir[idx_x] + ofs[idx_x];

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -46,14 +46,6 @@ uint64_t linear_interpolate(int x0, uint64_t y0, int x1, uint64_t y1, int x) {
     return y0 + (x - x0) * sign * (max_v - min_v) / (x1 - x0);
 }
 
-template <typename T>
-uint64_t ulround(T value) {
-    T rounded_value = std::round(value);
-    if (rounded_value < 0) return 0ULL;
-    if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
-    return static_cast<uint64_t>(rounded_value);
-}
-
 }  // namespace
 
 namespace ouster_ros {
@@ -189,7 +181,7 @@ class LidarPacketHandler {
             last_scan_last_nonzero_idx, last_scan_last_nonzero_value,
             scan_width + curr_scan_first_nonzero_idx,
             curr_scan_first_nonzero_value, scan_width);
-        return ulround(interpolated_value);
+        return impl::ulround(interpolated_value);
     }
 
     uint64_t extrapolate_value(int curr_scan_first_nonzero_idx,
@@ -197,7 +189,7 @@ class LidarPacketHandler {
         double extrapolated_value =
             curr_scan_first_nonzero_value -
             scan_col_ts_spacing_ns * curr_scan_first_nonzero_idx;
-        return ulround(extrapolated_value);
+        return impl::ulround(extrapolated_value);
     }
 
     // compute_scan_ts_0 for first scan

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -66,6 +66,11 @@ class OusterCloud : public OusterProcessingNodeBase {
         declare_parameter("use_system_default_qos", false);
         declare_parameter("scan_ring", 0);
         declare_parameter("point_type", "original");
+        declare_parameter("organized", true);
+        declare_parameter("destagger", true);
+        declare_parameter("min_range", 0.0);
+        declare_parameter("max_range", 1000.0);
+        declare_parameter("rows_step", 1);
     }
 
     void metadata_handler(
@@ -117,9 +122,26 @@ class OusterCloud : public OusterProcessingNodeBase {
             }
 
             auto point_type = get_parameter("point_type").as_string();
+            auto organized = get_parameter("organized").as_bool();
+            auto destagger = get_parameter("destagger").as_bool();
+            auto min_range_m = get_parameter("min_range").as_double();
+            auto max_range_m = get_parameter("max_range").as_double();
+            if (min_range_m < 0.0 || max_range_m < 0.0) {
+                RCLCPP_FATAL(get_logger(), "min_range and max_range need to be positive");
+                throw std::runtime_error("negative range limits!");
+            }
+            if (min_range_m >= max_range_m) {
+                RCLCPP_FATAL(get_logger(), "min_range can't be equal or exceed max_range");
+                throw std::runtime_error("min_range equal to or exceeds max_range!");
+            }
+            // convert to millimeters
+            uint32_t min_range = impl::ulround(min_range_m * 1000);
+            uint32_t max_range = impl::ulround(max_range_m * 1000);
+            auto rows_step = get_parameter("rows_step").as_int();
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(point_type, info,
                     tf_bcast.point_cloud_frame_id(), tf_bcast.apply_lidar_to_sensor_transform(),
+                    organized, destagger, min_range, max_range, rows_step,
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i) lidar_pubs[i]->publish(*msgs[i]);
                     }

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -97,9 +97,26 @@ class OusterDriver : public OusterSensor {
             }
 
             auto point_type = get_parameter("point_type").as_string();
+            auto organized = get_parameter("organized").as_bool();
+            auto destagger = get_parameter("destagger").as_bool();
+            auto min_range_m = get_parameter("min_range").as_double();
+            auto max_range_m = get_parameter("max_range").as_double();
+            if (min_range_m < 0.0 || max_range_m < 0.0) {
+                RCLCPP_FATAL(get_logger(), "min_range and max_range need to be positive");
+                throw std::runtime_error("negative range limits!");
+            }
+            if (min_range_m >= max_range_m) {
+                RCLCPP_FATAL(get_logger(), "min_range can't be equal or exceed max_range");
+                throw std::runtime_error("min_range equal to or exceeds max_range!");
+            }
+            // convert to millimeters
+            uint32_t min_range = impl::ulround(min_range_m * 1000);
+            uint32_t max_range = impl::ulround(max_range_m * 1000);
+            auto rows_step = get_parameter("rows_step").as_int();
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(point_type, info,
                     tf_bcast.point_cloud_frame_id(), tf_bcast.apply_lidar_to_sensor_transform(),
+                    organized, destagger, min_range, max_range, rows_step,
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i) lidar_pubs[i]->publish(*msgs[i]);
                     }

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -38,6 +38,11 @@ class OusterDriver : public OusterSensor {
         declare_parameter("scan_ring", 0);
         declare_parameter("ptp_utc_tai_offset", -37.0);
         declare_parameter("point_type", "original");
+        declare_parameter("organized", true);
+        declare_parameter("destagger", true);
+        declare_parameter("min_range", 0.0);
+        declare_parameter("max_range", 1000.0);
+        declare_parameter("rows_step", 1);
     }
 
     ~OusterDriver() override {

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -190,6 +190,8 @@ class OusterSensor : public OusterSensorNodeBase {
 
     const int MIN_AZW = 0;
     const int MAX_AZW = 360000;
+
+    rclcpp::TimerBase::SharedPtr reconnect_timer;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -114,24 +114,47 @@ void copy_lidar_scan_fields_to_point(PointT& pt, const Tuple& tp, int idx) {
 template <class T>
 using Cloud = pcl::PointCloud<T>;
 
+// TODO[UN]: make this a functor
 template <std::size_t N, const ChanFieldTable<N>& PROFILE, typename PointT,
           typename PointS>
-void scan_to_cloud_f_destaggered(ouster_ros::Cloud<PointT>& cloud,
-                                 PointS& staging_point,
-                                 const ouster::PointsF& points,
-                                 uint64_t scan_ts, const ouster::LidarScan& ls,
-                                 const std::vector<int>& pixel_shift_by_row) {
+void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
+                     const ouster::PointsF& points, uint64_t scan_ts,
+                     const ouster::LidarScan& ls,
+                     const std::vector<int>& pixel_shift_by_row,
+                     bool organized = false, bool destagger = true,
+                     int rows_step = 1) {
     auto ls_tuple = make_lidar_scan_tuple<0, N, PROFILE>(ls);
     auto timestamp = ls.timestamp();
 
-    for (auto u = 0; u < ls.h; u++) {
-        for (auto v = 0; v < ls.w; v++) {
-            const auto v_shift = (v + ls.w - pixel_shift_by_row[u]) % ls.w;
-            auto ts = timestamp[v_shift];
-            ts = ts > scan_ts ? ts - scan_ts : 0UL;
+    if (!organized) cloud.clear();
+    cloud.is_dense = true;
+
+    for (auto u = 0; u < ls.h; u += rows_step) {
+        for (auto v = 0; v < ls.w; ++v) {   // TODO[UN]: consider cols_step in future
+            const auto v_shift =
+                destagger ? (v + ls.w - pixel_shift_by_row[u]) % ls.w : v;
             const auto src_idx = u * ls.w + v_shift;
-            const auto tgt_idx = u * ls.w + v;
             const auto xyz = points.row(src_idx);
+            const auto tgt_idx =
+                organized ? (u / rows_step) * ls.w + v : cloud.size();
+
+            // as opposed to the point cloud destaggering if it is disabled
+            // then timestamps needs to be staggered.
+            auto ts_idx =
+                destagger ? v : (v + ls.w + pixel_shift_by_row[u]) % ls.w;
+            auto ts =
+                timestamp[ts_idx] > scan_ts ? timestamp[ts_idx] - scan_ts : 0UL;
+
+            if (organized) {
+                cloud.is_dense &= xyz.isNaN().any();
+            } else {
+                if (xyz.isNaN().any())
+                    continue;
+                else
+                    cloud.points.emplace_back();
+            }
+
+
             // if target point and staging point has matching type bind the
             // target directly and avoid performing transform_point at the end
             auto& pt = CondBinaryBind<std::is_same_v<PointT, PointS>>::run(
@@ -141,7 +164,7 @@ void scan_to_cloud_f_destaggered(ouster_ros::Cloud<PointT>& cloud,
             pt.y = static_cast<decltype(pt.y)>(xyz(1));
             pt.z = static_cast<decltype(pt.z)>(xyz(2));
             // TODO: in the future we could probably skip copying t and ring
-            // values if knowing before hand that the target point cloud does
+            // values if known before hand that the target point cloud does
             // not have a field to hold the timestamp or a ring for example the
             // case of pcl::PointXYZ or pcl::PointXYZI.
             pt.t = static_cast<uint32_t>(ts);

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -80,6 +80,7 @@ class PointCloudProcessor {
             auto range_channel = static_cast<sensor::ChanField>(sensor::ChanField::RANGE + i);
             auto range = lidar_scan.field<uint32_t>(range_channel);
             ouster::cartesianT(points, range, lut_direction, lut_offset,
+                               min_range_, max_range_
                                std::numeric_limits<float>::quiet_NaN());
 
             scan_to_cloud_fn(cloud, points, scan_ts, lidar_scan,
@@ -97,10 +98,13 @@ class PointCloudProcessor {
     static LidarScanProcessor create(const ouster::sensor::sensor_info& info,
                                      const std::string& frame,
                                      bool apply_lidar_to_sensor_transform,
+                                     uint32_t min_range, uint32_t max_range,
                                      ScanToCloudFn scan_to_cloud_fn_,
                                      PointCloudProcessor_PostProcessingFn post_processing_fn) {
         auto handler = std::make_shared<PointCloudProcessor>(
-            info, frame, apply_lidar_to_sensor_transform, scan_to_cloud_fn_, post_processing_fn);
+            info, frame, apply_lidar_to_sensor_transform,
+            min_range, max_range, rows_step,
+            scan_to_cloud_fn_, post_processing_fn);
 
         return [handler](const ouster::LidarScan& lidar_scan, uint64_t scan_ts,
                          const rclcpp::Time& msg_ts) {
@@ -120,6 +124,8 @@ class PointCloudProcessor {
     ouster::PointsF points;
     std::vector<int> pixel_shift_by_row;
     ouster_ros::Cloud<PointT> cloud;
+    uint32_t min_range_;
+    uint32_t max_range_;
     PointCloudProcessor_OutputType pc_msgs;
     ScanToCloudFn scan_to_cloud_fn;
     PointCloudProcessor_PostProcessingFn post_processing_fn;

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -102,7 +102,7 @@ class PointCloudProcessor {
                                      const std::string& frame,
                                      bool apply_lidar_to_sensor_transform,
                                      uint32_t min_range, uint32_t max_range,
-                                     ScanToCloudFn scan_to_cloud_fn_,
+                                     int rows_step, ScanToCloudFn scan_to_cloud_fn_,
                                      PointCloudProcessor_PostProcessingFn post_processing_fn) {
         auto handler = std::make_shared<PointCloudProcessor>(
             info, frame, apply_lidar_to_sensor_transform,

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -83,7 +83,7 @@ class PointCloudProcessor {
             auto range_channel = static_cast<sensor::ChanField>(sensor::ChanField::RANGE + i);
             auto range = lidar_scan.field<uint32_t>(range_channel);
             ouster::cartesianT(points, range, lut_direction, lut_offset,
-                               min_range_, max_range_
+                               min_range_, max_range_,
                                std::numeric_limits<float>::quiet_NaN());
 
             scan_to_cloud_fn(cloud, points, scan_ts, lidar_scan,

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -39,11 +39,14 @@ class PointCloudProcessor {
     PointCloudProcessor(const ouster::sensor::sensor_info& info,
                         const std::string& frame_id,
                         bool apply_lidar_to_sensor_transform,
+                        uint32_t min_range, uint32_t max_range, int rows_step,
                         ScanToCloudFn scan_to_cloud_fn_,
                         PointCloudProcessor_PostProcessingFn post_processing_fn_)
         : frame(frame_id),
           pixel_shift_by_row(info.format.pixel_shift_by_row),
-          cloud{info.format.columns_per_frame, info.format.pixels_per_column},
+          cloud{info.format.columns_per_frame,
+            info.format.pixels_per_column / rows_step},
+          min_range_(min_range), max_range_(max_range),
           pc_msgs(get_n_returns(info)),
           scan_to_cloud_fn(scan_to_cloud_fn_),
           post_processing_fn(post_processing_fn_) {

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -10,94 +10,100 @@ using sensor::UDPProfileLidar;
 class PointCloudProcessorFactory {
     template <typename PointT>
     static typename PointCloudProcessor<PointT>::ScanToCloudFn
-    make_scan_to_cloud_fn(const sensor::sensor_info& info) {
+    make_scan_to_cloud_fn(const sensor::sensor_info& info,
+                          bool organized, bool destagger, int rows_step) {
         switch (info.format.udp_profile_lidar) {
             case UDPProfileLidar::PROFILE_LIDAR_LEGACY:
-                return [](ouster_ros::Cloud<PointT>& cloud,
-                          const ouster::PointsF& points, uint64_t scan_ts,
-                          const ouster::LidarScan& ls,
-                          const std::vector<int>& pixel_shift_by_row,
-                          int return_index) {
-                    unused_variable(return_index);
+                return [organized, destagger, rows_step](
+                    ouster_ros::Cloud<PointT>& cloud,
+                    const ouster::PointsF& points, uint64_t scan_ts,
+                    const ouster::LidarScan& ls,
+                    const std::vector<int>& pixel_shift_by_row,
+                    int /*return_index*/) {
+
                     Point_LEGACY staging_pt;
-                    scan_to_cloud_f_destaggered<Profile_LEGACY.size(),
-                                                Profile_LEGACY>(
+                    scan_to_cloud_f<Profile_LEGACY.size(), Profile_LEGACY>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row);
+                        pixel_shift_by_row, organized, destagger, rows_step);
                 };
 
             case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
-                return [](ouster_ros::Cloud<PointT>& cloud,
-                          const ouster::PointsF& points, uint64_t scan_ts,
-                          const ouster::LidarScan& ls,
-                          const std::vector<int>& pixel_shift_by_row,
-                          int return_index) {
+                return [organized, destagger, rows_step](
+                    ouster_ros::Cloud<PointT>& cloud,
+                    const ouster::PointsF& points, uint64_t scan_ts,
+                    const ouster::LidarScan& ls,
+                    const std::vector<int>& pixel_shift_by_row,
+                    int return_index) {
+
                     Point_RNG19_RFL8_SIG16_NIR16_DUAL staging_pt;
                     if (return_index == 0) {
-                        scan_to_cloud_f_destaggered<
+                        scan_to_cloud_f<
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL.size(),
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row);
+                            pixel_shift_by_row, organized, destagger, rows_step);
                     } else {
-                        scan_to_cloud_f_destaggered<
-                            Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN
-                                .size(),
+                        scan_to_cloud_f<
+                            Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN.size(),
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row);
+                            pixel_shift_by_row, organized, destagger, rows_step);
                     }
                 };
 
             case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16:
-                return [](ouster_ros::Cloud<PointT>& cloud,
-                          const ouster::PointsF& points, uint64_t scan_ts,
-                          const ouster::LidarScan& ls,
-                          const std::vector<int>& pixel_shift_by_row,
-                          int return_index) {
-                    unused_variable(return_index);
+                return [organized, destagger, rows_step](
+                    ouster_ros::Cloud<PointT>& cloud,
+                    const ouster::PointsF& points, uint64_t scan_ts,
+                    const ouster::LidarScan& ls,
+                    const std::vector<int>& pixel_shift_by_row,
+                    int /*return_index*/) {
+
                     Point_RNG19_RFL8_SIG16_NIR16 staging_pt;
-                    scan_to_cloud_f_destaggered<
+                    scan_to_cloud_f<
                         Profile_RNG19_RFL8_SIG16_NIR16.size(),
-                        Profile_RNG19_RFL8_SIG16_NIR16>(cloud, staging_pt,
-                                                        points, scan_ts, ls,
-                                                        pixel_shift_by_row);
+                        Profile_RNG19_RFL8_SIG16_NIR16>(
+                            cloud, staging_pt, points, scan_ts, ls,
+                            pixel_shift_by_row, organized, destagger, rows_step);
                 };
 
             case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
-                return [](ouster_ros::Cloud<PointT>& cloud,
-                          const ouster::PointsF& points, uint64_t scan_ts,
-                          const ouster::LidarScan& ls,
-                          const std::vector<int>& pixel_shift_by_row,
-                          int return_index) {
-                    unused_variable(return_index);
+                return [organized, destagger, rows_step](
+                    ouster_ros::Cloud<PointT>& cloud,
+                    const ouster::PointsF& points, uint64_t scan_ts,
+                    const ouster::LidarScan& ls,
+                    const std::vector<int>& pixel_shift_by_row,
+                    int /*return_index*/) {
+
                     Point_RNG15_RFL8_NIR8 staging_pt;
-                    scan_to_cloud_f_destaggered<Profile_RNG15_RFL8_NIR8.size(),
-                                                Profile_RNG15_RFL8_NIR8>(
+                    scan_to_cloud_f<
+                        Profile_RNG15_RFL8_NIR8.size(),
+                        Profile_RNG15_RFL8_NIR8>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row);
+                        pixel_shift_by_row, organized, destagger, rows_step);
                 };
 
             case UDPProfileLidar::PROFILE_FUSA_RNG15_RFL8_NIR8_DUAL:
-                return [](ouster_ros::Cloud<PointT>& cloud,
-                          const ouster::PointsF& points, uint64_t scan_ts,
-                          const ouster::LidarScan& ls,
-                          const std::vector<int>& pixel_shift_by_row,
-                          int return_index) {
+                return [organized, destagger, rows_step](
+                    ouster_ros::Cloud<PointT>& cloud,
+                    const ouster::PointsF& points, uint64_t scan_ts,
+                    const ouster::LidarScan& ls,
+                    const std::vector<int>& pixel_shift_by_row,
+                    int return_index) {
+
                     Point_FUSA_RNG15_RFL8_NIR8_DUAL staging_pt;
                     if (return_index == 0) {
-                        scan_to_cloud_f_destaggered<
+                        scan_to_cloud_f<
                             Profile_FUSA_RNG15_RFL8_NIR8_DUAL.size(),
                             Profile_FUSA_RNG15_RFL8_NIR8_DUAL>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row);
+                            pixel_shift_by_row, organized, destagger, rows_step);
                     } else {
-                        scan_to_cloud_f_destaggered<
-                            Profile_FUSA_RNG15_RFL8_NIR8_DUAL_2ND_RETURN
-                                .size(),
+                        scan_to_cloud_f<
+                            Profile_FUSA_RNG15_RFL8_NIR8_DUAL_2ND_RETURN.size(),
                             Profile_FUSA_RNG15_RFL8_NIR8_DUAL_2ND_RETURN>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row);
+                            pixel_shift_by_row, organized, destagger, rows_step);
                     }
                 };
 
@@ -110,11 +116,15 @@ class PointCloudProcessorFactory {
     static LidarScanProcessor make_point_cloud_processor(
         const sensor::sensor_info& info, const std::string& frame,
         bool apply_lidar_to_sensor_transform,
+        bool organized, bool destagger,
+        uint32_t min_range, uint32_t max_range, int rows_step,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
-        auto scan_to_cloud_fn = make_scan_to_cloud_fn<PointT>(info);
+        auto scan_to_cloud_fn = make_scan_to_cloud_fn<PointT>(
+            info, organized, destagger, rows_step);
         return PointCloudProcessor<PointT>::create(
-            info, frame, apply_lidar_to_sensor_transform, scan_to_cloud_fn,
-            post_processing_fn);
+            info, frame, apply_lidar_to_sensor_transform,
+            min_range, max_range, rows_step,
+            scan_to_cloud_fn, post_processing_fn);
     }
 
    public:
@@ -132,31 +142,38 @@ class PointCloudProcessorFactory {
     static LidarScanProcessor create_point_cloud_processor(
         const std::string& point_type, const sensor::sensor_info& info,
         const std::string& frame, bool apply_lidar_to_sensor_transform,
+        bool organized, bool destagger,
+        uint32_t min_range, uint32_t max_range, int rows_step,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
         if (point_type == "native") {
             switch (info.format.udp_profile_lidar) {
                 case UDPProfileLidar::PROFILE_LIDAR_LEGACY:
                     return make_point_cloud_processor<Point_LEGACY>(
                         info, frame, apply_lidar_to_sensor_transform,
+                        organized, destagger, min_range, max_range, rows_step,
                         post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
+                        organized, destagger, min_range, max_range, rows_step,
                         post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16>(
                         info, frame, apply_lidar_to_sensor_transform,
+                        organized, destagger, min_range, max_range, rows_step,
                         post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
                     return make_point_cloud_processor<Point_RNG15_RFL8_NIR8>(
                         info, frame, apply_lidar_to_sensor_transform,
+                        organized, destagger, min_range, max_range, rows_step,
                         post_processing_fn);
                 case UDPProfileLidar::PROFILE_FUSA_RNG15_RFL8_NIR8_DUAL:
                     return make_point_cloud_processor<
                         Point_FUSA_RNG15_RFL8_NIR8_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
+                        organized, destagger, min_range, max_range, rows_step,
                         post_processing_fn);
                 default:
                     // TODO: implement fallback?
@@ -165,18 +182,22 @@ class PointCloudProcessorFactory {
         } else if (point_type == "xyz") {
             return make_point_cloud_processor<pcl::PointXYZ>(
                 info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
                 post_processing_fn);
         } else if (point_type == "xyzi") {
             return make_point_cloud_processor<pcl::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
                 post_processing_fn);
         } else if (point_type == "xyzir") {
             return make_point_cloud_processor<PointXYZIR>(
                 info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
                 post_processing_fn);
         } else if (point_type == "original") {
             return make_point_cloud_processor<ouster_ros::Point>(
                 info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
                 post_processing_fn);
         }
 


### PR DESCRIPTION
## Related Issues & PRs
- Related: #362
- Related: #369

## Summary of Changes
- Add `auto_start` flag to support start without using events or execute cmd
- Add a flag to control the publish of organized point cloud vs non-organized
- Add a flag to control the publish of destaggerd point cloud vs staggered
- Add parameter to set the min/max lidar range on generated point clouds

## Validation
- Verify that all sensor launch files work as expected after the execute commands have been removed
- Verify that the newly added features:
  - When `destagger` is set to false verify the driver doesn't destagger the published point cloud
  - When `organized` is set to false verify that the published point cloud isn't 2D
  - Adjust `min_range` and `max_range` and observe the point cloud shrink accordingly.