### PR TITLE
Add a new storage param to record.launch.xml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,9 @@ Changelog
   the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
 * Add a new launch file parameter ``min_scan_valid_columns_ratio`` to allow users to set the minimum
   ratio of valid columns in a scan for it to be processed. Default value is ``0.0``.
-* Update where ouster-ros and ouster_client include directories get installed so that those headers can be included externally.
+* Update where ouster-ros and ouster_client include directories get installed so that those headers
+  can be included externally.
+* Add ``storage`` launch parameter to ``record.launch.xml``
 
 ouster_ros v0.13.2
 ==================

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -1,5 +1,7 @@
 <launch>
 
+  <arg name="storage" default="sqlite3" description="specify the storage {sqlite3, mcap}"/>
+
   <arg name="ouster_ns" default="ouster"
     description="Override the default namespace of all ouster nodes"/>
   <arg name="sensor_hostname"
@@ -172,13 +174,16 @@
   <!-- <let name="_topics_to_record" value="/imu_packets /lidar_packets"/> -->
 
   <executable if="$(var _use_bag_file_name)" output="screen"
-    cmd="ros2 bag record --output $(var bag_file)
+    cmd="ros2 bag record
+      --output $(var bag_file)
+      --storage $(var storage)
       /$(var ouster_ns)/imu_packets
       /$(var ouster_ns)/lidar_packets
       /$(var ouster_ns)/metadata"/>
 
   <executable unless="$(var _use_bag_file_name)" output="screen"
     cmd="ros2 bag record
+      --storage $(var storage)
       /$(var ouster_ns)/imu_packets
       /$(var ouster_ns)/lidar_packets
       /$(var ouster_ns)/metadata"/>

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="storage" default="sqlite3" description="specify the storage {sqlite3, mcap}"/>
+  <arg name="storage" default="sqlite3" description="specify bag file storage {sqlite3, mcap}"/>
 
   <arg name="ouster_ns" default="ouster"
     description="Override the default namespace of all ouster nodes"/>


### PR DESCRIPTION
## Related Issues & PRs
- Related #306 

## Summary of Changes
* Add ``storage`` launch parameter to ``record.launch.xml``

## Validation
```
ros2 launch ouster_ros record.launch.xml \
    sensor_hostname:=<sensor-url> \
    bag_file:=<destination> \
    storage:=sqlite3
```
or
```
ros2 launch ouster_ros record.launch.xml \
    sensor_hostname:=<sensor-url> \
    bag_file:=<destination> \
    storage:=mcap
```