### PR TITLE
ROS-436: define padding-free PointXYZI point type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changelog
   the topic can be turned on/off by including the token ``TLM`` in the flag ``proc_mask`` launch arg.
 * Add a new launch file parameter ``min_scan_valid_columns_ratio`` to allow users to set the minimum
   ratio of valid columns in a scan for it to be processed. Default value is ``0.0``.
+* Add a padding-free point type of ``PointXYZI`` under ``ouster_ros`` namespace contrary to the pcl
+  version ``pcl::PointXYZI`` for bandwith sensitive applications.
 
 
 ouster_ros v0.13.0

--- a/include/ouster_ros/common_point_types.h
+++ b/include/ouster_ros/common_point_types.h
@@ -17,6 +17,52 @@ namespace ouster_ros {
  */
 
 /*
+ * Same as Apollo point cloud type
+ * @remark XYZIT point type is not compatible with RNG15_RFL8_NIR8/LOW_DATA
+ * udp lidar profile.
+ */
+struct EIGEN_ALIGN16 _Ouster_PointXYZI {
+    union EIGEN_ALIGN16 {
+        float data[4];
+        struct {
+          float x;
+          float y;
+          float z;
+          float intensity;
+        };
+   };
+   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct PointXYZI : public _Ouster_PointXYZI {
+
+    inline PointXYZI(const _Ouster_PointXYZI& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z;
+      intensity = pt.intensity;
+    }
+
+    inline PointXYZI()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      intensity = 0.0f;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, intensity);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+/*
  * Same as Velodyne point cloud type
  * @remark XYZIR point type is not compatible with RNG15_RFL8_NIR8/LOW_DATA
  * udp lidar profile.
@@ -59,6 +105,13 @@ struct PointXYZIR : public _PointXYZIR {
 }   // namespace ouster_ros
 
 // clang-format off
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZI,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, intensity, intensity)
+)
 
 /* common point types */
 POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIR,

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -42,7 +42,8 @@
     native,
     xyz,
     xyzi,
-    xyzir
+    o_xyzi,
+    xyzir,
     }"/>
 
   <arg name="organized" doc="generate an organzied point cloud"/>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -69,6 +69,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -69,6 +69,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -64,6 +64,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -77,6 +77,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -81,6 +81,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.4</version>
+  <version>0.13.5</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/point_cloud_processor_factory.h
+++ b/src/point_cloud_processor_factory.h
@@ -130,7 +130,7 @@ class PointCloudProcessorFactory {
    public:
     static bool point_type_requires_intensity(const std::string& point_type) {
         return point_type == "xyzi" || point_type == "xyzir" ||
-               point_type == "original";
+               point_type == "original" || point_type == "o_xyzi";
     }
 
     static bool profile_has_intensity(UDPProfileLidar profile) {
@@ -186,6 +186,11 @@ class PointCloudProcessorFactory {
                 post_processing_fn);
         } else if (point_type == "xyzi") {
             return make_point_cloud_processor<pcl::PointXYZI>(
+                info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
+                post_processing_fn);
+        } else if (point_type == "o_xyzi") {
+            return make_point_cloud_processor<ouster_ros::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
                 post_processing_fn);


### PR DESCRIPTION
## Related Issues & PRs
- Related: #436 

## Summary of Changes
- Implemented a padding-free version of the `pcl::PointXYZI` dupped `ouster_ros::PointXYZI`

## Validation
* Run **ouster_ros** with `xyzi` point type
```
roslaunch ouster_ros driver.launch sensor_hostname:=<...> point_type:="xyzi"
```
* Echo `/ouster/points` topic and observe that: 
```
fields: "<array type: sensor_msgs/PointField, length: 4>"
point_step: 32
```

* Re-run **ouster_ros** with `o_xyzi` point type
```
roslaunch ouster_ros driver.launch sensor_hostname:=<...> point_type:="xyzi"
```
* Echo `/ouster/points` topic and observe that: 
```
fields: "<array type: sensor_msgs/PointField, length: 4>"
point_step: 16
```