### PR TITLE
ROS-436[ROS2]: define padding-free PointXYZI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
 * Update where ouster-ros and ouster_client include directories get installed so that those headers
   can be included externally.
 * Add ``storage`` launch parameter to ``record.launch.xml``
+* Add a padding-free point type of ``PointXYZI`` under ``ouster_ros`` namespace contrary to the pcl
+  version ``pcl::PointXYZI`` for bandwith sensitive applications.
 
 ouster_ros v0.13.2
 ==================

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -72,7 +72,8 @@ ouster/os_driver:
     # data QoS. This is preferrable for production but default QoS is needed for
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
     use_system_default_qos: false
-    # point_type[optional]: choose from: {original, native, xyz, xyzi, xyzir}
+    # point_type[optional]: choose from: {original, native, xyz, xyzi, o_xyzi, 
+    #                                     yzir}
     # Here is a breif description of each option:
     #  - original: This uses the original point representation ouster_ros::Point
     #          of the ouster-ros driver.
@@ -82,6 +83,7 @@ ouster/os_driver:
     #  - xyz: the simplest point type, only has {x, y, z}
     #  - xyzi: same as xyz point type but adds intensity (signal) field. this
     #          type is not compatible with the low data profile.
+    #  - o_xyzi: same as xyzi point type but doesn't add the extra 4 padding bytes.
     #  - xyzir: same as xyzi type but adds ring (channel) field.
     #          this type is same as Velodyne point cloud type
     #          this type is not compatible with the low data profile.

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -34,6 +34,6 @@ ouster/os_cloud:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
     scan_ring: 0  # Use this parameter in conjunction with the SCAN flag and choose a
                   # value the range [0, sensor_beams_count)
-    point_type: original # choose from: {original, native, xyz, xyzi, xyzir}
+    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir}
 ouster/os_image:
     use_system_default_qos: false # needs to match the value defined for os_sensor node

--- a/ouster-ros/include/ouster_ros/common_point_types.h
+++ b/ouster-ros/include/ouster_ros/common_point_types.h
@@ -17,6 +17,52 @@ namespace ouster_ros {
  */
 
 /*
+ * Same as Apollo point cloud type
+ * @remark XYZIT point type is not compatible with RNG15_RFL8_NIR8/LOW_DATA
+ * udp lidar profile.
+ */
+struct EIGEN_ALIGN16 _Ouster_PointXYZI {
+    union EIGEN_ALIGN16 {
+        float data[4];
+        struct {
+          float x;
+          float y;
+          float z;
+          float intensity;
+        };
+   };
+   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct PointXYZI : public _Ouster_PointXYZI {
+
+    inline PointXYZI(const _Ouster_PointXYZI& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z;
+      intensity = pt.intensity;
+    }
+
+    inline PointXYZI()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      intensity = 0.0f;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, intensity);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+/*
  * Same as Velodyne point cloud type
  * @remark XYZIR point type is not compatible with RNG15_RFL8_NIR8/LOW_DATA
  * udp lidar profile.
@@ -59,6 +105,13 @@ struct PointXYZIR : public _PointXYZIR {
 }   // namespace ouster_ros
 
 // clang-format off
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZI,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, intensity, intensity)
+)
 
 /* common point types */
 POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIR,

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -78,6 +78,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -63,6 +63,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -59,6 +59,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -74,6 +74,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -82,6 +82,7 @@
     native,
     xyz,
     xyzi,
+    o_xyzi,
     xyzir
     }"/>
 

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.6</version>
+  <version>0.13.7</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -130,7 +130,7 @@ class PointCloudProcessorFactory {
    public:
     static bool point_type_requires_intensity(const std::string& point_type) {
         return point_type == "xyzi" || point_type == "xyzir" ||
-               point_type == "original";
+               point_type == "original" || point_type == "o_xyzi";
     }
 
     static bool profile_has_intensity(UDPProfileLidar profile) {
@@ -186,6 +186,11 @@ class PointCloudProcessorFactory {
                 post_processing_fn);
         } else if (point_type == "xyzi") {
             return make_point_cloud_processor<pcl::PointXYZI>(
+                info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
+                post_processing_fn);
+        } else if (point_type == "o_xyzi") {
+            return make_point_cloud_processor<ouster_ros::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
                 post_processing_fn);


### PR DESCRIPTION
## Related Issues & PRs
- Related: #436 
- Related[ROS1]: #438 

## Summary of Changes
- Implemented a padding-free version of the `pcl::PointXYZI` dupped `ouster_ros::PointXYZI`

## Validation
1) **pcl::PointXYZI**
  * Set `point_type` param to with `xyzi` in `driver_params.yaml` and run the driver
  ```
  ros2 launch ouster_ros driver.launch.py params_file:=<...>
  ```
  * Echo `/ouster/points` topic and observe that: 
  ```
  fields: '<sequence type: sensor_msgs/msg/PointField, length: 4>'
  point_step: 32
  ```

2) **ouster_ros::PointXYZI**
  * Set `point_type` param to with `o_xyzi` in `driver_params.yaml` and run the driver
  ```
  ros2 launch ouster_ros driver.launch.py params_file:=<...>
  ```
  * Echo `/ouster/points` topic and observe that: 
  ```
  fields: '<sequence type: sensor_msgs/msg/PointField, length: 4>'
  point_step: 16
  ```