### PR TITLE
ROS-317: Fix simulation in replay mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changelog
 * Add ``storage`` launch parameter to ``record.launch.xml``
 * Add a padding-free point type of ``PointXYZI`` under ``ouster_ros`` namespace contrary to the pcl
   version ``pcl::PointXYZI`` for bandwith sensitive applications.
+* [BUGFIX]: Use the node clock to ensure messages report sim time in replay mode.
+
 
 ouster_ros v0.13.2
 ==================

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.7</version>
+  <version>0.13.8</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -109,7 +109,7 @@ class OusterCloud : public OusterProcessingNodeBase {
                         // Need to redefine the Packet object and allow use of array_views
                         sensor::ImuPacket imu_packet(msg->buf.size());
                         memcpy(imu_packet.buf.data(), msg->buf.data(), msg->buf.size());
-                        imu_packet.host_timestamp = static_cast<uint64_t>(rclcpp::Clock(RCL_ROS_TIME).now().nanoseconds());
+                        imu_packet.host_timestamp = static_cast<uint64_t>(now().nanoseconds());
                         auto imu_msg = imu_packet_handler(imu_packet);
                         imu_pub->publish(imu_msg);
                     }
@@ -223,8 +223,7 @@ class OusterCloud : public OusterProcessingNodeBase {
                     // Need to redefine the Packet object and allow use of array_views
                     sensor::LidarPacket lidar_packet(msg->buf.size());
                     memcpy(lidar_packet.buf.data(), msg->buf.data(), msg->buf.size());
-                    lidar_packet.host_timestamp =
-                        static_cast<uint64_t>(rclcpp::Clock(RCL_ROS_TIME).now().nanoseconds());
+                    lidar_packet.host_timestamp = static_cast<uint64_t>(now().nanoseconds());
 
                     if (telemetry_handler) {
                         auto telemetry = telemetry_handler(lidar_packet);

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -123,7 +123,7 @@ class OusterImage : public OusterProcessingNodeBase {
                         // Need to redefine the Packet object and allow use of array_views
                         sensor::LidarPacket lidar_packet(msg->buf.size());
                         memcpy(lidar_packet.buf.data(), msg->buf.data(), msg->buf.size());
-                        lidar_packet.host_timestamp = static_cast<uint64_t>(rclcpp::Clock(RCL_ROS_TIME).now().nanoseconds());
+                        lidar_packet.host_timestamp = static_cast<uint64_t>(now().nanoseconds());
                         lidar_packet_handler(lidar_packet);
                     }
                 });


### PR DESCRIPTION
## Related Issues & PRs
- closes #317 

## Summary of Changes
- Use the node clock to ensure it follows the sim time in replay mode

## Validation
- ROS messages follow the sim time