### PR TITLE
[ROS1] Expose the vertical beam reduction param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
   ratio of valid columns in a scan for it to be processed. Default value is ``0.0``.
 * Add a padding-free point type of ``PointXYZI`` under ``ouster_ros`` namespace contrary to the pcl
   version ``pcl::PointXYZI`` for bandwith sensitive applications.
+* Introduce a new param ``v_reduction`` that allows reducing the number of beams count of the published
+  point cloud.
 
 
 ouster_ros v0.13.0

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -55,6 +55,8 @@
   <arg name="min_scan_valid_columns_ratio"
     doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
+  <arg name="v_reduction" doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
       output="screen" required="true"
@@ -78,6 +80,7 @@
       <param name="~/destagger" value="$(arg destagger)"/>
       <param name="~/min_range" value="$(arg min_range)"/>
       <param name="~/max_range" value="$(arg max_range)"/>
+      <param name="~/v_reduction" value="$(arg v_reduction)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
     </node>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -103,6 +103,9 @@
   <arg name="min_scan_valid_columns_ratio" default="0.0"
     doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
+  <arg name="v_reduction" default="1"
+    doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -143,6 +146,7 @@
       <param name="~/destagger" value="$(arg destagger)"/>
       <param name="~/min_range" value="$(arg min_range)"/>
       <param name="~/max_range" value="$(arg max_range)"/>
+      <param name="~/v_reduction" value="$(arg v_reduction)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
     </node>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -103,6 +103,9 @@
   <arg name="min_scan_valid_columns_ratio" default="0.0"
     doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
+  <arg name="v_reduction" default="1"
+    doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -158,6 +161,7 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="v_reduction" value="$(arg v_reduction)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -81,6 +81,9 @@
   <arg name="min_scan_valid_columns_ratio" default="0.0"
     doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
+  <arg name="v_reduction" default="1"
+    doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -120,6 +123,7 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <are name="v_reduction" value="$(arg v_reduction)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -75,6 +75,9 @@
   <arg name="min_scan_valid_columns_ratio" default="0.0"
     doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
+  <arg name="v_reduction" default="1"
+    doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -115,6 +118,7 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="v_reduction" value="$(arg v_reduction)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -111,6 +111,9 @@
   <arg name="min_scan_valid_columns_ratio" default="0.0"
     doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
+  <arg name="v_reduction" default="1"
+    doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -166,6 +169,7 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="v_reduction" value="$(arg v_reduction)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -115,6 +115,9 @@
   <arg name="min_scan_valid_columns_ratio" default="0.0"
     doc="The minimum ratio of valid columns for processing the LidarScan [0, 1]"/>
 
+  <arg name="v_reduction" default="1"
+    doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -172,6 +175,7 @@
     <arg name="destagger" value="$(arg destagger)"/>
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
+    <arg name="v_reduction" value="$(arg v_reduction)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.5</version>
+  <version>0.13.6</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -206,13 +206,18 @@ class OusterCloud : public nodelet::Nodelet {
             // convert to millimeters
             uint32_t min_range = impl::ulround(min_range_m * 1000);
             uint32_t max_range = impl::ulround(max_range_m * 1000);
-            auto rows_step = pnh.param("rows_step", 1);
+            auto v_reduction = pnh.param("v_reduction", 1);
+            auto valid_values = std::vector<int>{1, 2, 4, 8, 16};
+            if (std::find(valid_values.begin(), valid_values.end(), v_reduction) == valid_values.end()) {
+                NODELET_FATAL("v_reduction needs to be one of the values: {1, 2, 4, 8, 16}");
+                throw std::runtime_error("invalid v_reduction value!");
+            }
 
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(
                     point_type, info, tf_bcast.point_cloud_frame_id(),
                     tf_bcast.apply_lidar_to_sensor_transform(), organized,
-                    destagger, min_range, max_range, rows_step,
+                    destagger, min_range, max_range, v_reduction,
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i) {
                             if (msgs[i]->header.stamp > last_msg_ts)

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -151,13 +151,19 @@ class OusterDriver : public OusterSensor {
             // convert to millimeters
             uint32_t min_range = impl::ulround(min_range_m * 1000);
             uint32_t max_range = impl::ulround(max_range_m * 1000);
-            auto rows_step = pnh.param("rows_step", 1);
+            auto v_reduction = pnh.param("v_reduction", 1);
+            auto valid_values = std::vector<int>{1, 2, 4, 8, 16};
+            if (std::find(valid_values.begin(), valid_values.end(),
+                          v_reduction) == valid_values.end()) {
+                NODELET_FATAL("v_reduction needs to be one of the values: {1, 2, 4, 8, 16}");
+                throw std::runtime_error("invalid v_reduction value!");
+            }
 
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(
                     point_type, info, tf_bcast.point_cloud_frame_id(),
                     tf_bcast.apply_lidar_to_sensor_transform(), organized,
-                    destagger, min_range, max_range, rows_step,
+                    destagger, min_range, max_range, v_reduction,
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i)
                             lidar_pubs[i].publish(*msgs[i]);


### PR DESCRIPTION
## Related Issues & PRs
- Closes #175
- Include #191 
- ROS2: #444 

## Summary of Changes
* Expose the vertical beam reduction value

## Validation
```bash
roslaunch ... driver.launch sensor_hostname:=<source_url> v_reduction:=2
```
or
```bash
roslaunch ... replay.launch bag_file:=<source_url> v_reduction:=2
```
and observe the number of beams are reduced by the specified factor with respect to the original beam count of the sensor.