### PR TITLE
PointCloud mask

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Changelog
   version ``pcl::PointXYZI`` for bandwith sensitive applications.
 * Introduce a new param ``v_reduction`` that allows reducing the number of beams count of the published
   point cloud.
+* Introduce a new capability to suppress certain range measurements of the point cloud by providing
+  a mask image to the driver through the ``mask_path`` launch file argument.
 
 
 ouster_ros v0.13.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PCL REQUIRED COMPONENTS common)
 find_package(tf2_eigen REQUIRED)
 find_package(CURL REQUIRED)
 find_package(Boost REQUIRED)
+find_package(OpenCV REQUIRED)
 
 find_package(
   catkin REQUIRED
@@ -54,6 +55,7 @@ catkin_package(
     geometry_msgs
   DEPENDS
     EIGEN3
+    OpenCV
 )
 
 # ==== Libraries ====
@@ -71,7 +73,10 @@ find_package(OusterSDK REQUIRED)
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
 
 # catkin adds all include dirs to a single variable, don't try to use targets
-include_directories(${_ouster_ros_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(
+  ${_ouster_ros_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS})
 
 # use only MPL-licensed parts of eigen
 add_definitions(-DEIGEN_MPL2_ONLY)
@@ -100,7 +105,10 @@ add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
 
 # ==== Executables ====
 add_library(${PROJECT_NAME}_nodelets ${NODELET_SRC})
-target_link_libraries(${PROJECT_NAME}_nodelets ouster_ros ${catkin_LIBRARIES})
+target_link_libraries(
+  ${PROJECT_NAME}_nodelets ouster_ros
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES})
 add_dependencies(${PROJECT_NAME}_nodelets ${PROJECT_NAME}_gencpp)
 
 # ==== Test ====

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -185,6 +185,9 @@ uint64_t ulround(T value) {
     return static_cast<uint64_t>(rounded_value);
 }
 
+void warn_mask_resized(int image_cols, int image_rows,
+                       int scan_height, int scan_width);
+
 template <typename pixel_type>
 ouster::img_t<pixel_type> load_mask(const std::string& mask_path,
                                     size_t height, size_t width) {
@@ -196,6 +199,7 @@ ouster::img_t<pixel_type> load_mask(const std::string& mask_path,
     }
 
     if (image.rows != static_cast<int>(height) || image.cols != static_cast<int>(width)) {
+        warn_mask_resized(image.cols, image.rows, static_cast<int>(height), static_cast<int>(width));
         cv::Mat resized;
         cv::resize(image, resized, cv::Size(width, height), 0, 0, cv::INTER_NEAREST);
         image = resized;

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -206,7 +206,9 @@ ouster::img_t<pixel_type> load_mask(const std::string& mask_path,
     }
     Eigen::MatrixXi eigen_img(image.rows, image.cols);
     cv::cv2eigen(image, eigen_img);
-    return eigen_img.cast<pixel_type>() / 255;
+    Eigen::MatrixXi zero_image = Eigen::MatrixXi::Zero(eigen_img.rows(), eigen_img.cols());
+    Eigen::MatrixXi ones_image = Eigen::MatrixXi::Ones(eigen_img.rows(), eigen_img.cols());
+    return (eigen_img.array() == 0.0).select(zero_image, ones_image).cast<pixel_type>();
 }
 
 } // namespace impl

--- a/include/ouster_ros/os_ros.h
+++ b/include/ouster_ros/os_ros.h
@@ -132,7 +132,7 @@ Telemetry lidar_packet_to_telemetry_msg(
 
 
 namespace impl {
-sensor::ChanField suitable_return(sensor::ChanField input_field, bool second);
+sensor::ChanField scan_return(sensor::ChanField input_field, bool second);
 
 struct read_and_cast {
     template <typename T, typename U>

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -57,6 +57,8 @@
 
   <arg name="v_reduction" doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" doc="path to an image file that will be used to mask parts of the pointcloud"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
       output="screen" required="true"
@@ -81,6 +83,7 @@
       <param name="~/min_range" value="$(arg min_range)"/>
       <param name="~/max_range" value="$(arg max_range)"/>
       <param name="~/v_reduction" value="$(arg v_reduction)"/>
+      <param name="~/mask_path" value="$(arg mask_path)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
     </node>

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -94,6 +94,7 @@
       output="screen" required="true"
       args="load ouster_ros/OusterImage os_nodelet_mgr $(arg _no_bond)">
       <param name="~/proc_mask" value="$(arg proc_mask)"/>
+      <param name="~/mask_path" value="$(arg mask_path)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -106,6 +106,9 @@
   <arg name="v_reduction" default="1"
     doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default=""
+    doc="path to an image file that will be used to mask parts of the pointcloud"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -147,6 +150,7 @@
       <param name="~/min_range" value="$(arg min_range)"/>
       <param name="~/max_range" value="$(arg max_range)"/>
       <param name="~/v_reduction" value="$(arg v_reduction)"/>
+      <param name="~/mask_path" value="$(arg mask_path)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
     </node>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -106,6 +106,9 @@
   <arg name="v_reduction" default="1"
     doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default=""
+    doc="path to an image file that will be used to mask parts of the pointcloud"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -162,6 +165,7 @@
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="v_reduction" value="$(arg v_reduction)"/>
+    <arg name="~/mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -84,6 +84,9 @@
   <arg name="v_reduction" default="1"
     doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default=""
+    doc="path to an image file that will be used to mask parts of the pointcloud"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -124,6 +127,7 @@
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="v_reduction" value="$(arg v_reduction)"/>
+    <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -78,6 +78,9 @@
   <arg name="v_reduction" default="1"
     doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default=""
+    doc="path to an image file that will be used to mask parts of the pointcloud"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -119,6 +122,7 @@
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="v_reduction" value="$(arg v_reduction)"/>
+    <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -114,6 +114,9 @@
   <arg name="v_reduction" default="1"
     doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default=""
+    doc="path to an image file that will be used to mask parts of the pointcloud"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -170,6 +173,7 @@
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="v_reduction" value="$(arg v_reduction)"/>
+    <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -118,6 +118,9 @@
   <arg name="v_reduction" default="1"
     doc="vertical beam reduction; available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default=""
+    doc="path to an image file that will be used to mask parts of the pointcloud"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -176,6 +179,7 @@
     <arg name="min_range" value="$(arg min_range)"/>
     <arg name="max_range" value="$(arg max_range)"/>
     <arg name="v_reduction" value="$(arg v_reduction)"/>
+    <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
   </include>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.6</version>
+  <version>0.13.7</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>
@@ -14,6 +14,7 @@
   <depend>tf2_ros</depend>
   <depend>pcl_ros</depend>
   <depend>pcl_conversions</depend>
+  <depend>cv_bridge</depend>
 
   <build_depend>boost</build_depend>
   <build_depend>nodelet</build_depend>
@@ -24,7 +25,6 @@
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>curl</build_depend>
   <build_depend>spdlog</build_depend>
-  <build_depend>opencv2</build_depend>
 
   <exec_depend>nodelet</exec_depend>
   <exec_depend>libjsoncpp</exec_depend>
@@ -32,7 +32,6 @@
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>curl</exec_depend>
   <exec_depend>spdlog</exec_depend>
-  <exec_depend>opencv2</exec_depend>
 
   <test_depend>gtest</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>curl</build_depend>
   <build_depend>spdlog</build_depend>
+  <build_depend>opencv2</build_depend>
 
   <exec_depend>nodelet</exec_depend>
   <exec_depend>libjsoncpp</exec_depend>
@@ -31,6 +32,7 @@
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>curl</exec_depend>
   <exec_depend>spdlog</exec_depend>
+  <exec_depend>opencv2</exec_depend>
 
   <test_depend>gtest</test_depend>
 

--- a/src/image_processor.h
+++ b/src/image_processor.h
@@ -15,6 +15,8 @@
 // clang-format on
 
 #include <sensor_msgs/image_encodings.h>
+#include <opencv2/opencv.hpp>
+#include <opencv2/core/eigen.hpp>
 
 #include "ouster/image_processing.h"
 
@@ -22,40 +24,41 @@ namespace ouster_ros {
 
 namespace sensor = ouster::sensor;
 namespace viz = ouster::viz;
+using sensor::ChanField;
 
 class ImageProcessor {
    public:
     using OutputType =
-        std::map<sensor::ChanField, std::shared_ptr<sensor_msgs::Image>>;
+        std::map<ChanField, std::shared_ptr<sensor_msgs::Image>>;
     using PostProcessingFn = std::function<void(OutputType)>;
 
    public:
     ImageProcessor(const ouster::sensor::sensor_info& info,
-                   const std::string& frame_id, PostProcessingFn func)
+                   const std::string& frame_id,
+                   const std::string& mask_path,
+                   PostProcessingFn func)
         : frame(frame_id), post_processing_fn(func), info_(info) {
         uint32_t H = info.format.pixels_per_column;
         uint32_t W = info.format.columns_per_frame;
 
-        image_msgs[sensor::ChanField::RANGE] =
-            std::make_shared<sensor_msgs::Image>();
-        image_msgs[sensor::ChanField::SIGNAL] =
-            std::make_shared<sensor_msgs::Image>();
-        image_msgs[sensor::ChanField::REFLECTIVITY] =
-            std::make_shared<sensor_msgs::Image>();
-        image_msgs[sensor::ChanField::NEAR_IR] =
-            std::make_shared<sensor_msgs::Image>();
+        image_msgs[ChanField::RANGE] = std::make_shared<sensor_msgs::Image>();
+        image_msgs[ChanField::SIGNAL] = std::make_shared<sensor_msgs::Image>();
+        image_msgs[ChanField::REFLECTIVITY] = std::make_shared<sensor_msgs::Image>();
+        image_msgs[ChanField::NEAR_IR] = std::make_shared<sensor_msgs::Image>();
         if (get_n_returns(info) == 2) {
-            image_msgs[sensor::ChanField::RANGE2] =
+            image_msgs[ChanField::RANGE2] =
                 std::make_shared<sensor_msgs::Image>();
-            image_msgs[sensor::ChanField::SIGNAL2] =
+            image_msgs[ChanField::SIGNAL2] =
                 std::make_shared<sensor_msgs::Image>();
-            image_msgs[sensor::ChanField::REFLECTIVITY2] =
+            image_msgs[ChanField::REFLECTIVITY2] =
                 std::make_shared<sensor_msgs::Image>();
         }
 
         for (auto it = image_msgs.begin(); it != image_msgs.end(); ++it) {
             init_image_msg(*it->second, H, W, frame);
         }
+
+        load_mask(mask_path, H, W);
     }
 
    private:
@@ -84,60 +87,49 @@ class ImageProcessor {
         if (post_processing_fn) post_processing_fn(image_msgs);
     }
 
+    // TODO: this functin could be benefit of some refactor
     void process_return(const ouster::LidarScan& lidar_scan, int return_index) {
         const bool first = return_index == 0;
 
         // across supported lidar profiles range is always 32-bit
-        auto range_channel =
-            first ? sensor::ChanField::RANGE : sensor::ChanField::RANGE2;
+        auto range_channel = first ? ChanField::RANGE : ChanField::RANGE2;
         ouster::img_t<uint32_t> range =
             lidar_scan.field<uint32_t>(range_channel);
 
         ouster::img_t<uint16_t> reflectivity = impl::get_or_fill_zero<uint16_t>(
-            impl::suitable_return(sensor::ChanField::REFLECTIVITY, !first),
-            lidar_scan);
+            impl::scan_return(ChanField::REFLECTIVITY, !first), lidar_scan);
 
         ouster::img_t<uint32_t> signal = impl::get_or_fill_zero<uint32_t>(
-            impl::suitable_return(sensor::ChanField::SIGNAL, !first),
-            lidar_scan);
+            impl::scan_return(ChanField::SIGNAL, !first), lidar_scan);
 
         // TODO: note that near_ir will be processed twice for DUAL return
         // sensor
         ouster::img_t<uint16_t> near_ir = impl::get_or_fill_zero<uint16_t>(
-            impl::suitable_return(sensor::ChanField::NEAR_IR, !first),
-            lidar_scan);
+            impl::scan_return(ChanField::NEAR_IR, !first), lidar_scan);
 
         uint32_t H = info_.format.pixels_per_column;
         uint32_t W = info_.format.columns_per_frame;
 
-        // views into message data
+        // create views into message data
+        auto range_msg = image_msgs[impl::scan_return(ChanField::RANGE, !first)];
         auto range_image_map = Eigen::Map<ouster::img_t<pixel_type>>(
-            (pixel_type*)image_msgs[impl::suitable_return(
-                                        sensor::ChanField::RANGE, !first)]
-                ->data.data(),
-            H, W);
+            (pixel_type*)range_msg->data.data(), H, W);
+        auto signal_msg = image_msgs[impl::scan_return(ChanField::SIGNAL, !first)];
         auto signal_image_map = Eigen::Map<ouster::img_t<pixel_type>>(
-            (pixel_type*)image_msgs[impl::suitable_return(
-                                        sensor::ChanField::SIGNAL, !first)]
-                ->data.data(),
-            H, W);
+            (pixel_type*)signal_msg->data.data(), H, W);
+        auto reflectivity_msg = image_msgs[impl::scan_return(ChanField::REFLECTIVITY, !first)];
         auto reflec_image_map = Eigen::Map<ouster::img_t<pixel_type>>(
-            (pixel_type*)
-                image_msgs[impl::suitable_return(
-                               sensor::ChanField::REFLECTIVITY, !first)]
-                    ->data.data(),
-            H, W);
-        auto nearir_image_map = Eigen::Map<ouster::img_t<pixel_type>>(
-            (pixel_type*)image_msgs[impl::suitable_return(
-                                        sensor::ChanField::NEAR_IR, !first)]
-                ->data.data(),
-            H, W);
+            (pixel_type*)reflectivity_msg->data.data(), H, W);
+        auto near_ir_msg = image_msgs[impl::scan_return(ChanField::NEAR_IR, !first)];
+            auto nearir_image_map = Eigen::Map<ouster::img_t<pixel_type>>(
+            (pixel_type*)near_ir_msg->data.data(), H, W);
 
         const auto& px_offset = info_.format.pixel_shift_by_row;
 
         ouster::img_t<float> signal_image_eigen(H, W);
         ouster::img_t<float> reflec_image_eigen(H, W);
         ouster::img_t<float> nearir_image_eigen(H, W);
+
 
         const auto rg = range.data();
         const auto sg = signal.data();
@@ -173,17 +165,46 @@ class ImageProcessor {
             (reflec_image_eigen * pixel_value_max).cast<pixel_type>();
         nearir_image_map =
             (nearir_image_eigen * pixel_value_max).cast<pixel_type>();
+
+        if (mask.size() != 0) {
+            range_image_map = range_image_map * mask;
+            signal_image_map = signal_image_map * mask;
+            reflec_image_map = reflec_image_map * mask;
+            nearir_image_map = nearir_image_map * mask;
+        }
     }
 
    public:
     static LidarScanProcessor create(const ouster::sensor::sensor_info& info,
                                      const std::string& frame,
+                                     const std::string& mask_path,
                                      PostProcessingFn func) {
-        auto handler = std::make_shared<ImageProcessor>(info, frame, func);
+        auto handler = std::make_shared<ImageProcessor>(info, frame, mask_path, func);
         return [handler](const ouster::LidarScan& lidar_scan, uint64_t scan_ts,
                          const ros::Time& msg_ts) {
             handler->process(lidar_scan, scan_ts, msg_ts);
         };
+    }
+
+   private:
+    void load_mask(const std::string& mask_path, size_t height, size_t width) {
+        if (mask_path.empty()) return;
+
+        cv::Mat image = cv::imread(mask_path, cv::IMREAD_GRAYSCALE);
+        if (image.empty()) {
+            throw std::runtime_error("Failed to load mask image from path: " + mask_path);
+        }
+        if (image.rows != static_cast<int>(height) ||
+            image.cols != static_cast<int>(width)) {
+            std::stringstream ss;
+            ss << "Mask image size (" << image.rows << "x" << image.cols
+               << ") does not match the expected dimensions ("
+               << height << "x" << width << ").";
+            throw std::runtime_error(ss.str());
+        }
+        Eigen::MatrixXi eigen_img(image.rows, image.cols);
+        cv::cv2eigen(image, eigen_img);
+        mask = eigen_img.cast<pixel_type>() / 255;
     }
 
    private:
@@ -194,6 +215,8 @@ class ImageProcessor {
 
     viz::AutoExposure nearir_ae, signal_ae, reflec_ae;
     viz::BeamUniformityCorrector nearir_buc;
+
+    ouster::img_t<pixel_type> mask;
 };
 
 }  // namespace ouster_ros

--- a/src/image_processor.h
+++ b/src/image_processor.h
@@ -58,7 +58,7 @@ class ImageProcessor {
             init_image_msg(*it->second, H, W, frame);
         }
 
-        load_mask(mask_path, H, W);
+        mask = impl::load_mask<pixel_type>(mask_path, H, W);
     }
 
    private:
@@ -184,27 +184,6 @@ class ImageProcessor {
                          const ros::Time& msg_ts) {
             handler->process(lidar_scan, scan_ts, msg_ts);
         };
-    }
-
-   private:
-    void load_mask(const std::string& mask_path, size_t height, size_t width) {
-        if (mask_path.empty()) return;
-
-        cv::Mat image = cv::imread(mask_path, cv::IMREAD_GRAYSCALE);
-        if (image.empty()) {
-            throw std::runtime_error("Failed to load mask image from path: " + mask_path);
-        }
-        if (image.rows != static_cast<int>(height) ||
-            image.cols != static_cast<int>(width)) {
-            std::stringstream ss;
-            ss << "Mask image size (" << image.rows << "x" << image.cols
-               << ") does not match the expected dimensions ("
-               << height << "x" << width << ").";
-            throw std::runtime_error(ss.str());
-        }
-        Eigen::MatrixXi eigen_img(image.rows, image.cols);
-        cv::cv2eigen(image, eigen_img);
-        mask = eigen_img.cast<pixel_type>() / 255;
     }
 
    private:

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -213,11 +213,13 @@ class OusterCloud : public nodelet::Nodelet {
                 throw std::runtime_error("invalid v_reduction value!");
             }
 
+            auto mask_path = pnh.param("mask_path", std::string{});
+
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(
                     point_type, info, tf_bcast.point_cloud_frame_id(),
                     tf_bcast.apply_lidar_to_sensor_transform(), organized,
-                    destagger, min_range, max_range, v_reduction,
+                    destagger, min_range, max_range, v_reduction, mask_path,
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i) {
                             if (msgs[i]->header.stamp > last_msg_ts)

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -131,6 +131,8 @@ class OusterDriver : public OusterSensor {
             throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
         }
 
+        auto mask_path = pnh.param("mask_path", std::string{});
+
         std::vector<LidarScanProcessor> processors;
         if (impl::check_token(tokens, "PCL")) {
             auto point_type = pnh.param("point_type", std::string{"original"});
@@ -158,8 +160,6 @@ class OusterDriver : public OusterSensor {
                 NODELET_FATAL("v_reduction needs to be one of the values: {1, 2, 4, 8, 16}");
                 throw std::runtime_error("invalid v_reduction value!");
             }
-
-            auto mask_path = pnh.param("mask_path", std::string{});
 
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(
@@ -207,7 +207,7 @@ class OusterDriver : public OusterSensor {
 
         if (impl::check_token(tokens, "IMG")) {
             processors.push_back(ImageProcessor::create(
-                info, tf_bcast.point_cloud_frame_id(),
+                info, tf_bcast.point_cloud_frame_id(), mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
                         image_pubs[it->first].publish(*it->second);

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -159,11 +159,13 @@ class OusterDriver : public OusterSensor {
                 throw std::runtime_error("invalid v_reduction value!");
             }
 
+            auto mask_path = pnh.param("mask_path", std::string{});
+
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(
                     point_type, info, tf_bcast.point_cloud_frame_id(),
                     tf_bcast.apply_lidar_to_sensor_transform(), organized,
-                    destagger, min_range, max_range, v_reduction,
+                    destagger, min_range, max_range, v_reduction, mask_path,
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i)
                             lidar_pubs[i].publish(*msgs[i]);

--- a/src/os_image_nodelet.cpp
+++ b/src/os_image_nodelet.cpp
@@ -105,9 +105,12 @@ class OusterImage : public nodelet::Nodelet {
             throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
         }
 
+        auto mask_path = pnh.param("mask_path", std::string{});
+
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
                 info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
+                mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
                         image_pubs[it->first].publish(*it->second);

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -12,6 +12,7 @@
 #include "ouster_ros/os_ros.h"
 // clang-format on
 
+#include <ros/console.h>
 #include <tf2/LinearMath/Transform.h>
 
 #include <tf2_eigen/tf2_eigen.h>
@@ -148,6 +149,13 @@ version parse_version(const std::string& fw_rev) {
     } catch (const std::exception&) {
         return invalid_version;
     }
+}
+
+void warn_mask_resized(int image_cols, int image_rows,
+                       int scan_height, int scan_width) {
+    ROS_WARN_STREAM("Mask image has size (" << image_cols << "x" << image_rows << ")"
+                        << " but incoming scans has size (" << scan_height << "x" << scan_width << ")."
+                        << " Resizing mask to match the scans size.");    
 }
 
 }  // namespace impl

--- a/src/os_ros.cpp
+++ b/src/os_ros.cpp
@@ -95,7 +95,7 @@ sensor_msgs::Imu packet_to_imu_msg(const PacketMsg& pm,
 }
 
 namespace impl {
-sensor::ChanField suitable_return(sensor::ChanField input_field, bool second) {
+sensor::ChanField scan_return(sensor::ChanField input_field, bool second) {
     switch (input_field) {
         case sensor::ChanField::RANGE:
         case sensor::ChanField::RANGE2:

--- a/src/point_cloud_processor.h
+++ b/src/point_cloud_processor.h
@@ -75,6 +75,9 @@ class PointCloudProcessor {
         if (!mask_path.empty()) {
             cv::Mat image = cv::imread(mask_path,
                                     cv::IMREAD_GRAYSCALE);
+            if (image.empty()) {
+                throw std::runtime_error("Failed to load mask image from path: " + mask_path);
+            }
             Eigen::MatrixXi eigen_img(image.rows, image.cols);
             cv::cv2eigen(image, eigen_img);
             mask = eigen_img.cast<uint32_t>() / 255;

--- a/src/point_cloud_processor.h
+++ b/src/point_cloud_processor.h
@@ -78,6 +78,15 @@ class PointCloudProcessor {
             if (image.empty()) {
                 throw std::runtime_error("Failed to load mask image from path: " + mask_path);
             }
+            if (image.rows != static_cast<int>(info.format.pixels_per_column) ||
+                image.cols != static_cast<int>(info.format.columns_per_frame)) {
+                std::stringstream ss;
+                ss << "Mask image size (" << image.rows << "x" << image.cols
+                   << ") does not match the expected dimensions ("
+                   << info.format.pixels_per_column << "x" << info.format.columns_per_frame
+                   << ").";
+                throw std::runtime_error(ss.str());
+            }
             Eigen::MatrixXi eigen_img(image.rows, image.cols);
             cv::cv2eigen(image, eigen_img);
             mask = eigen_img.cast<uint32_t>() / 255;

--- a/src/point_cloud_processor.h
+++ b/src/point_cloud_processor.h
@@ -18,6 +18,10 @@
 #include "lidar_packet_handler.h"
 #include "impl/cartesian.h"
 
+#include <opencv2/opencv.hpp>
+#include <opencv2/core/eigen.hpp>
+
+
 namespace ouster_ros {
 
 // Moved out of PointCloudProcessor to avoid type templatization
@@ -40,6 +44,7 @@ class PointCloudProcessor {
                         const std::string& frame_id,
                         bool apply_lidar_to_sensor_transform,
                         uint32_t min_range, uint32_t max_range, int rows_step,
+                        const std::string& mask_path,
                         ScanToCloudFn scan_to_cloud_fn_,
                         PointCloudProcessor_PostProcessingFn post_processing_fn_)
         : frame(frame_id),
@@ -66,6 +71,14 @@ class PointCloudProcessor {
         lut_direction = xyz_lut.direction.cast<float>();
         lut_offset = xyz_lut.offset.cast<float>();
         points = ouster::PointsF(lut_direction.rows(), lut_offset.cols());
+
+        if (!mask_path.empty()) {
+            cv::Mat image = cv::imread(mask_path,
+                                    cv::IMREAD_GRAYSCALE);
+            Eigen::MatrixXi eigen_img(image.rows, image.cols);
+            cv::cv2eigen(image, eigen_img);
+            mask = eigen_img.cast<uint32_t>() / 255;
+        }
     }
 
    private:
@@ -82,7 +95,8 @@ class PointCloudProcessor {
         for (int i = 0; i < static_cast<int>(pc_msgs.size()); ++i) {
             auto range_ch = static_cast<sensor::ChanField>(sensor::ChanField::RANGE + i);
             auto range = lidar_scan.field<uint32_t>(range_ch);
-            ouster::cartesianT(points, range, lut_direction, lut_offset,
+            auto range_masked = mask.rows() == range.rows() && mask.cols() == range.cols() ? range * mask : range;
+            ouster::cartesianT(points, range_masked, lut_direction, lut_offset,
                                min_range_, max_range_,
                                std::numeric_limits<float>::quiet_NaN());
 
@@ -102,11 +116,12 @@ class PointCloudProcessor {
                                      const std::string& frame,
                                      bool apply_lidar_to_sensor_transform,
                                      uint32_t min_range, uint32_t max_range,
-                                     int rows_step, ScanToCloudFn scan_to_cloud_fn_,
+                                     int rows_step, const std::string& mask_path,
+                                     ScanToCloudFn scan_to_cloud_fn_,
                                      PointCloudProcessor_PostProcessingFn post_processing_fn) {
         auto handler = std::make_shared<PointCloudProcessor>(
             info, frame, apply_lidar_to_sensor_transform,
-            min_range, max_range, rows_step,
+            min_range, max_range, rows_step, mask_path,
             scan_to_cloud_fn_, post_processing_fn);
 
         return [handler](const ouster::LidarScan& lidar_scan, uint64_t scan_ts,
@@ -132,6 +147,8 @@ class PointCloudProcessor {
     PointCloudProcessor_OutputType pc_msgs;
     ScanToCloudFn scan_to_cloud_fn;
     PointCloudProcessor_PostProcessingFn post_processing_fn;
+
+    ouster::img_t<uint32_t> mask;
 };
 
 }  // namespace ouster_ros

--- a/src/point_cloud_processor.h
+++ b/src/point_cloud_processor.h
@@ -18,8 +18,6 @@
 #include "lidar_packet_handler.h"
 #include "impl/cartesian.h"
 
-#include <opencv2/opencv.hpp>
-#include <opencv2/core/eigen.hpp>
 
 
 namespace ouster_ros {
@@ -72,30 +70,10 @@ class PointCloudProcessor {
         lut_offset = xyz_lut.offset.cast<float>();
         points = ouster::PointsF(lut_direction.rows(), lut_offset.cols());
 
-        load_mask(mask_path,
-                  info.format.pixels_per_column / rows_step,
-                  info.format.columns_per_frame);
-    }
-
-   private:
-    void load_mask(const std::string& mask_path, size_t height, size_t width) {
-        if (mask_path.empty()) return;
-
-        cv::Mat image = cv::imread(mask_path, cv::IMREAD_GRAYSCALE);
-        if (image.empty()) {
-            throw std::runtime_error("Failed to load mask image from path: " + mask_path);
-        }
-        if (image.rows != static_cast<int>(height) ||
-            image.cols != static_cast<int>(width)) {
-            std::stringstream ss;
-            ss << "Mask image size (" << image.rows << "x" << image.cols
-               << ") does not match the expected dimensions ("
-               << height << "x" << width << ").";
-            throw std::runtime_error(ss.str());
-        }
-        Eigen::MatrixXi eigen_img(image.rows, image.cols);
-        cv::cv2eigen(image, eigen_img);
-        mask = eigen_img.cast<uint32_t>() / 255;
+        mask = impl::load_mask<uint32_t>(
+            mask_path,
+            info.format.pixels_per_column / rows_step,
+            info.format.columns_per_frame);
     }
 
    private:

--- a/src/point_cloud_processor_factory.h
+++ b/src/point_cloud_processor_factory.h
@@ -118,12 +118,13 @@ class PointCloudProcessorFactory {
         bool apply_lidar_to_sensor_transform,
         bool organized, bool destagger,
         uint32_t min_range, uint32_t max_range, int rows_step,
+        const std::string& mask_path,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
         auto scan_to_cloud_fn = make_scan_to_cloud_fn<PointT>(
             info, organized, destagger, rows_step);
         return PointCloudProcessor<PointT>::create(
             info, frame, apply_lidar_to_sensor_transform,
-            min_range, max_range, rows_step,
+            min_range, max_range, rows_step, mask_path,
             scan_to_cloud_fn, post_processing_fn);
     }
 
@@ -144,6 +145,7 @@ class PointCloudProcessorFactory {
         const std::string& frame, bool apply_lidar_to_sensor_transform,
         bool organized, bool destagger,
         uint32_t min_range, uint32_t max_range, int rows_step,
+        const std::string& mask_path,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
         if (point_type == "native") {
             switch (info.format.udp_profile_lidar) {
@@ -151,30 +153,30 @@ class PointCloudProcessorFactory {
                     return make_point_cloud_processor<Point_LEGACY>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
                     return make_point_cloud_processor<Point_RNG15_RFL8_NIR8>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_FUSA_RNG15_RFL8_NIR8_DUAL:
                     return make_point_cloud_processor<
                         Point_FUSA_RNG15_RFL8_NIR8_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 default:
                     // TODO: implement fallback?
                     throw std::runtime_error("unsupported udp_profile_lidar");
@@ -183,27 +185,27 @@ class PointCloudProcessorFactory {
             return make_point_cloud_processor<pcl::PointXYZ>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "xyzi") {
             return make_point_cloud_processor<pcl::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "o_xyzi") {
             return make_point_cloud_processor<ouster_ros::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "xyzir") {
             return make_point_cloud_processor<PointXYZIR>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "original") {
             return make_point_cloud_processor<ouster_ros::Point>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         }
 
         throw std::runtime_error(


### PR DESCRIPTION
## Related Issues & PRs
- None

## Summary of Changes
- Implemented a mask filter on the received LidarScan.
- The mask is applied to the cloud + the image messages
- If the supplied mask size is different from the received LidarScan, the driver will resize the mask to match incoming scans size.

## Validation
* Test out a sequence without applying a mask:
![image](https://github.com/user-attachments/assets/7cccbb39-0dd2-40fc-95d4-c46175123a03)
* Generate any mask composed of Black/White pixels, such as:
![image](https://github.com/user-attachments/assets/c7735141-0acb-4430-9453-ec0676f30e58)
* Apply the mask as follows:
```bash
roslaunch ouster_ros driver.launch sensor_hostname:=<source_url> mask_path:=<path/to/mask.png>
```
* Observe the masked image in RVIZ/image_view:
![image](https://github.com/user-attachments/assets/99073135-b08c-4922-b7d9-15874d52f5e0)
* Observe the mask cloud in RVIZ/cloud_view
![image](https://github.com/user-attachments/assets/de18b1ff-c77a-4c04-8ea1-7702c4b13d9d)
