### PR TITLE
Port the pointcloud mask feature to ROS2

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         exclude:
           - ros_distro: iron
-            rmw_imp: rmw_zenoh_cpp
         ros_distro:
           - rolling
           - humble

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,9 @@ Changelog
 * [BUGFIX]: Use the node clock to ensure messages report sim time in replay mode.
 * Introduce a new param ``v_reduction`` that allows reducing the number of beams count of the published
   point cloud
-* Allow users to use ``Zenoh`` with the supplied Dockerfile and add it to the CI pipeline. 
+* Allow users to use ``Zenoh`` with the supplied Dockerfile and add it to the CI pipeline.
+* Introduce a new capability to suppress certain range measurements of the point cloud by providing
+  a mask image to the driver through the ``mask_path`` launch file argument.
 
 
 ouster_ros v0.13.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     BUILD_HOME=/var/lib/build \
     OUSTER_ROS_PATH=/opt/ros2_ws/src/ouster-ros
 
-RUN apt-get update || true && \
-    apt-get install -y curl gnupg
-
 RUN set -xue && \
-    # Turn off installing extra packages globally to slim down rosdep install
-    echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommend && \
-    rm -f /etc/apt/sources.list.d/ros2-snapshots.list || true && \
-    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list && \
     apt-get update && \
     apt-get install -y \
         build-essential \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Official ROS driver for Ouster sensors
 
 [ROS1 (melodic/noetic)](https://github.com/ouster-lidar/ouster-ros/tree/master) |
-[ROS2 (rolling/humble/iron/jazzy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2) |
+[ROS2 (rolling/humble/iron/jazzy/kilted)](https://github.com/ouster-lidar/ouster-ros/tree/ros2) |
 [ROS2 (galactic/foxy)](https://github.com/ouster-lidar/ouster-ros/tree/ros2-foxy)
 
 <p style="float: right;"><img width="20%" src="docs/images/logo.png" /></p>
@@ -9,7 +9,7 @@
 | ROS Version | Build Status (Linux) |
 |:-----------:|:------:|
 | ROS1 (melodic/noetic) | [![melodic/noetic](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=master)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
-| ROS2 (rolling/humble/iron/jazzy) | [![rolling/humble/iron/jazzy](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
+| ROS2 (rolling/humble/iron/jazzy/kilted) | [![rolling/humble/iron/jazzy/kilted](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 | ROS2 (galactic/foxy) | [![galactic/foxy](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml/badge.svg?branch=ros2-foxy)](https://github.com/ouster-lidar/ouster-ros/actions/workflows/docker-image.yml)
 
 - [Official ROS driver for Ouster sensors](#official-ros-driver-for-ouster-sensors)
@@ -57,9 +57,9 @@ You can obtain detailed specs sheet about the sensors and obtain updated FW thro
 [downloads](https://ouster.com/downloads) section.
 
 ## Requirements
-This branch is only intended for use with **Rolling**, **Humble**, **Iron** and **Jazzy** ROS 2 distros.
-Please refer to ROS 2 online documentation on how to setup ROS on your machine before proceeding with
-the remainder of this guide.
+This branch is only intended for use with **Rolling**, **Humble**, **Iron**,  **Jazzy** and **Kilted**
+ROS 2 distros. Please refer to ROS 2 online documentation on how to setup ROS on your machine before
+proceeding with the remainder of this guide.
 
 > **Note**  
 > If you have _rosdep_ tool installed on your system you can then use the following command to get all
@@ -77,7 +77,7 @@ sudo apt install -y             \
     ros-$ROS_DISTRO-tf2-eigen   \
     ros-$ROS_DISTRO-rviz2
 ```
-where `$ROS_DISTRO` can be either ``rolling``, ``humble``, ``iron`` or ``jazzy``.
+where `$ROS_DISTRO` can be either ``rolling``, ``humble``, ``iron``, ``jazzy`` or ``kilted``.
 
 > **Note**  
 > Installing `ros-$ROS_DISTRO-rviz` package is optional in case you didn't need to visualize the
@@ -120,7 +120,7 @@ git clone -b ros2 --recurse-submodules https://github.com/ouster-lidar/ouster-ro
 
 Next to compile the driver you need to source the ROS environemt into the active termainl:
 ```bash
-source /opt/ros/<ros-distro>/setup.bash # replace ros-distro with 'rolling', 'humble', 'iron' or 'jazzy'
+source /opt/ros/<ros-distro>/setup.bash # replace ros-distro with 'rolling', 'humble', 'iron', 'jazzy' or `kilted`
 ```
 
 Finally, invoke `colcon build` command from within the catkin workspace as shown below:

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
 find_package(tf2_eigen REQUIRED)
+find_package(OpenCV REQUIRED)
 
 # ==== Options ====
 add_compile_options(-Wall -Wextra)
@@ -52,7 +53,9 @@ find_package(OusterSDK REQUIRED)
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
 
 # catkin adds all include dirs to a single variable, don't try to use targets
-include_directories(${_ouster_ros_INCLUDE_DIRS})
+include_directories(
+  ${_ouster_ros_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS})
 
 # use only MPL-licensed parts of eigen
 add_definitions(-DEIGEN_MPL2_ONLY)
@@ -86,6 +89,7 @@ target_link_libraries(ouster_ros_library
     pcl_common
   # PRIVATE (unsupported)
   -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive
+  ${OpenCV_LIBRARIES}
 )
 
 # helper method to construct ouster-ros components

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -122,3 +122,6 @@ ouster/os_driver:
     # min_scan_valid_columns_ratio[optional]: The minimum ratio of valid columns for
     # processing the LidarScan [0, 1]. default is 0%
     min_scan_valid_columns_ratio: 0.0
+    # mask_path[optional]: path to an image file that will be used to mask parts of the
+    # pointcloud.
+    mask_path: ''

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -17,7 +17,8 @@
 #include <ouster/types.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-
+#include <opencv2/opencv.hpp>
+#include <opencv2/core/eigen.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 
@@ -135,7 +136,7 @@ ouster_sensor_msgs::msg::Telemetry lidar_packet_to_telemetry_msg(
 
 namespace impl {
 
-sensor::ChanField suitable_return(sensor::ChanField input_field, bool second);
+sensor::ChanField scan_return(sensor::ChanField input_field, bool second);
 
 struct read_and_cast {
     template <typename T, typename U>
@@ -178,6 +179,32 @@ uint64_t ulround(T value) {
     if (rounded_value < 0) return 0ULL;
     if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
     return static_cast<uint64_t>(rounded_value);
+}
+
+void warn_mask_resized(int image_cols, int image_rows,
+                       int scan_height, int scan_width);
+
+template <typename pixel_type>
+ouster::img_t<pixel_type> load_mask(const std::string& mask_path,
+                                    size_t height, size_t width) {
+    if (mask_path.empty()) return ouster::img_t<pixel_type>();
+
+    cv::Mat image = cv::imread(mask_path, cv::IMREAD_GRAYSCALE);
+    if (image.empty()) {
+        throw std::runtime_error("Failed to load mask image from path: " + mask_path);
+    }
+
+    if (image.rows != static_cast<int>(height) || image.cols != static_cast<int>(width)) {
+        warn_mask_resized(image.cols, image.rows, static_cast<int>(height), static_cast<int>(width));
+        cv::Mat resized;
+        cv::resize(image, resized, cv::Size(width, height), 0, 0, cv::INTER_NEAREST);
+        image = resized;
+    }
+    Eigen::MatrixXi eigen_img(image.rows, image.cols);
+    cv::cv2eigen(image, eigen_img);
+    Eigen::MatrixXi zero_image = Eigen::MatrixXi::Zero(eigen_img.rows(), eigen_img.cols());
+    Eigen::MatrixXi ones_image = Eigen::MatrixXi::Ones(eigen_img.rows(), eigen_img.cols());
+    return (eigen_img.array() == 0.0).select(zero_image, ones_image).cast<pixel_type>();
 }
 
 } // namespace impl

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -118,6 +118,9 @@
   <arg name="v_reduction" default="1" description="vertical beam reduction;
    available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default="" description="path to an image file that will be used to
+   mask parts of the pointcloud}"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="os_container" output="screen" namespace="">
@@ -160,11 +163,13 @@
         <param name="min_range" value="$(var min_range)"/>
         <param name="max_range" value="$(var max_range)"/>
         <param name="v_reduction" value="$(var v_reduction)"/>
+        <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
         <param name="proc_mask" value="$(var proc_mask)"/>
+        <param name="mask_path" value="$(var mask_path)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -83,6 +83,9 @@
   <arg name="v_reduction" default="1" description="vertical beam reduction;
    available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default="" description="path to an image file that will be used to
+   mask parts of the pointcloud}"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
@@ -107,11 +110,13 @@
         <param name="min_range" value="$(var min_range)"/>
         <param name="max_range" value="$(var max_range)"/>
         <param name="v_reduction" value="$(var v_reduction)"/>
+        <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
         <param name="proc_mask" value="$(var proc_mask)"/>
+        <param name="mask_path" value="$(var mask_path)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -79,6 +79,9 @@
   <arg name="v_reduction" default="1" description="vertical beam reduction;
    available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default="" description="path to an image file that will be used to
+   mask parts of the pointcloud}"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_pcap" name="os_pcap"
@@ -107,11 +110,13 @@
         <param name="min_range" value="$(var min_range)"/>
         <param name="max_range" value="$(var max_range)"/>
         <param name="v_reduction" value="$(var v_reduction)"/>
+        <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
         <param name="proc_mask" value="$(var proc_mask)"/>
+        <param name="mask_path" value="$(var mask_path)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -114,6 +114,9 @@
   <arg name="v_reduction" default="1" description="vertical beam reduction;
    available options: {1, 2, 4, 8, 16}"/>
 
+  <arg name="mask_path" default="" description="path to an image file that will be used to
+   mask parts of the pointcloud}"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node pkg="ouster_ros" exec="os_driver" name="os_driver" output="screen">
@@ -151,6 +154,7 @@
       <param name="min_range" value="$(var min_range)"/>
       <param name="max_range" value="$(var max_range)"/>
       <param name="v_reduction" value="$(var v_reduction)"/>
+      <param name="mask_path" value="$(var mask_path)"/>
       <param name="min_scan_valid_columns_ratio"
              value="$(var min_scan_valid_columns_ratio)"/>
     </node>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.9</version>
+  <version>0.13.10</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>
@@ -21,6 +21,7 @@
   <depend>pcl_ros</depend>
   <depend>pcl_conversions</depend>
   <depend>std_srvs</depend>
+  <depend>cv_bridge</depend>
 
   <build_depend>libjsoncpp-dev</build_depend>
   <build_depend>eigen</build_depend>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -67,6 +67,7 @@ class OusterCloud : public OusterProcessingNodeBase {
         declare_parameter("max_range", 1000.0);
         declare_parameter("v_reduction", 1);
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
+        declare_parameter("mask_path", "");
     }
 
     void metadata_handler(
@@ -158,11 +159,13 @@ class OusterCloud : public OusterProcessingNodeBase {
                 throw std::runtime_error("invalid v_reduction value!");
             }
 
+            auto mask_path = get_parameter("mask_path").as_string();
+
             processors.push_back(
                 PointCloudProcessorFactory::create_point_cloud_processor(point_type,
                     info, tf_bcast.point_cloud_frame_id(),
                     tf_bcast.apply_lidar_to_sensor_transform(),
-                    organized, destagger, min_range, max_range, v_reduction,
+                    organized, destagger, min_range, max_range, v_reduction, mask_path,
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i)
                             lidar_pubs[i]->publish(*msgs[i]);

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -43,6 +43,7 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("ptp_utc_tai_offset", -37.0);
         declare_parameter("use_system_default_qos", false);
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
+        declare_parameter("mask_path", "");
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
@@ -101,9 +102,12 @@ class OusterImage : public OusterProcessingNodeBase {
             throw std::runtime_error("min_scan_valid_columns_ratio out of bounds!");
         }
 
+        auto mask_path = get_parameter("mask_path").as_string();
+
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
                 info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
+                mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
                         image_pubs[it->first]->publish(*it->second);

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -98,7 +98,7 @@ sensor_msgs::msg::Imu packet_to_imu_msg(const PacketMsg& pm,
 }
 
 namespace impl {
-sensor::ChanField suitable_return(sensor::ChanField input_field, bool second) {
+sensor::ChanField scan_return(sensor::ChanField input_field, bool second) {
     switch (input_field) {
         case sensor::ChanField::RANGE:
         case sensor::ChanField::RANGE2:
@@ -151,6 +151,14 @@ version parse_version(const std::string& fw_rev) {
     } catch (const std::exception&) {
         return invalid_version;
     }
+}
+
+void warn_mask_resized(int image_cols, int image_rows,
+                       int scan_height, int scan_width) {
+    auto logger = rclcpp::get_logger("ouster_ros");
+    RCLCPP_WARN_STREAM(logger, "Mask image has size (" << image_cols << "x" << image_rows << ")"
+                       << " but incoming scans has size (" << scan_height << "x" << scan_width << ")."
+                       << " Resizing mask to match the scans size.");    
 }
 
 }  // namespace impl

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -118,12 +118,13 @@ class PointCloudProcessorFactory {
         bool apply_lidar_to_sensor_transform,
         bool organized, bool destagger,
         uint32_t min_range, uint32_t max_range, int rows_step,
+        const std::string& mask_path,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
         auto scan_to_cloud_fn = make_scan_to_cloud_fn<PointT>(
             info, organized, destagger, rows_step);
         return PointCloudProcessor<PointT>::create(
             info, frame, apply_lidar_to_sensor_transform,
-            min_range, max_range, rows_step,
+            min_range, max_range, rows_step, mask_path,
             scan_to_cloud_fn, post_processing_fn);
     }
 
@@ -144,6 +145,7 @@ class PointCloudProcessorFactory {
         const std::string& frame, bool apply_lidar_to_sensor_transform,
         bool organized, bool destagger,
         uint32_t min_range, uint32_t max_range, int rows_step,
+        const std::string& mask_path,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
         if (point_type == "native") {
             switch (info.format.udp_profile_lidar) {
@@ -151,30 +153,30 @@ class PointCloudProcessorFactory {
                     return make_point_cloud_processor<Point_LEGACY>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
                     return make_point_cloud_processor<Point_RNG15_RFL8_NIR8>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 case UDPProfileLidar::PROFILE_FUSA_RNG15_RFL8_NIR8_DUAL:
                     return make_point_cloud_processor<
                         Point_FUSA_RNG15_RFL8_NIR8_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        post_processing_fn);
+                        mask_path, post_processing_fn);
                 default:
                     // TODO: implement fallback?
                     throw std::runtime_error("unsupported udp_profile_lidar");
@@ -183,27 +185,27 @@ class PointCloudProcessorFactory {
             return make_point_cloud_processor<pcl::PointXYZ>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "xyzi") {
             return make_point_cloud_processor<pcl::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "o_xyzi") {
             return make_point_cloud_processor<ouster_ros::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "xyzir") {
             return make_point_cloud_processor<PointXYZIR>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         } else if (point_type == "original") {
             return make_point_cloud_processor<ouster_ros::Point>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                post_processing_fn);
+                mask_path, post_processing_fn);
         }
 
         throw std::runtime_error(


### PR DESCRIPTION
## Related Issues & PRs
- ROS1: #460

## Summary of Changes
- Implemented a mask filter on the received LidarScan.
- The mask is applied to the cloud + the image messages
- If the supplied mask size is different from the received LidarScan, the driver will resize the mask to match incoming scans size.

## Validation
* Test out a sequence without applying a mask:
![image](https://github.com/user-attachments/assets/7cccbb39-0dd2-40fc-95d4-c46175123a03)
* Generate any mask composed of Black/White pixels, such as:
![image](https://github.com/user-attachments/assets/c7735141-0acb-4430-9453-ec0676f30e58)
* Apply the mask as follows:
```bash
roslaunch ouster_ros driver.launch sensor_hostname:=<source_url> mask_path:=<path/to/mask.png>
```
* Observe the masked image in RVIZ/image_view:
![image](https://github.com/user-attachments/assets/99073135-b08c-4922-b7d9-15874d52f5e0)
* Observe the mask cloud in RVIZ/cloud_view
![image](https://github.com/user-attachments/assets/de18b1ff-c77a-4c04-8ea1-7702c4b13d9d)
