### PR TITLE
Fix .is_dense logic for pointcloud

### DIFF
--- a/src/point_cloud_compose.h
+++ b/src/point_cloud_compose.h
@@ -145,7 +145,8 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
                 timestamp[ts_idx] > scan_ts ? timestamp[ts_idx] - scan_ts : 0UL;
 
             if (organized) {
-                cloud.is_dense &= xyz.isNaN().any();
+                // false if any point in cloud has NaN values
+                cloud.is_dense &= !xyz.isNaN().any();
             } else {
                 if (xyz.isNaN().any())
                     continue;


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes

With the old logic, cloud.is_dense will only be set to true if every single point in the cloud has a NaN coordinate.
Replace
`cloud.is_dense &= xyz.isNaN().any();`
with
`cloud.is_dense &= !xyz.isNaN().any();`

now is_dense is true if no points in cloud are nan, false otherwise

## Validation
Testing by altering the `invalid` arg in ouster::cartesianT

Before:
* `std::numeric_limits<float>::quiet_NaN()` -> `is_dense = False`
* `0.0f` -> `is_dense = False` 

After:
* `std::numeric_limits<float>::quiet_NaN()` -> `is_dense = False`
* `0.0f` -> `is_dense = True` 





