### PR TITLE
Add support for compressed point clouds 

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(OpenCV REQUIRED)
+find_package(point_cloud_transport REQUIRED)
 
 # ==== Options ====
 add_compile_options(-Wall -Wextra)
@@ -114,6 +115,7 @@ function(create_ros2_component
     std_msgs
     sensor_msgs
     geometry_msgs
+    point_cloud_transport
     ${additonal_dependencies}
   )
 

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -1,11 +1,11 @@
-ouster/os_driver:
+/drivers/ouster_lidar_fl/driver:
   ros__parameters:
     # sensor_hostname[required]: hostname or IP address of the sensor (IP4 or
     # IP6).
-    sensor_hostname: ''
+    sensor_hostname: '10.5.5.50'
     # udp_dest[optional]: hostname or multicast group IP where the sensor will
     # send UDP data packets.
-    udp_dest: ''
+    udp_dest: '10.5.5.10'
     # mtp_dest[optional]: hostname IP address for receiving data packets via
     # multicast, by default it is INADDR_ANY, so packets will be received on
     # first available network interface.
@@ -16,7 +16,7 @@ ouster/os_driver:
     # lidar_mode[optional]: resolution and rate; possible values: { 512x10,
     # 512x20, 1024x10, 1024x20, 2048x10, 4096x5 }. Leave empty to remain on
     # current the lidar mode.
-    lidar_mode: ''
+    lidar_mode: '1024x20'
     # timestamp_mode[optional]: method used to timestamp measurements; possible
     # values:
     # - TIME_FROM_INTERNAL_OSC
@@ -25,10 +25,7 @@ ouster/os_driver:
     # - TIME_FROM_ROS_TIME: This option uses the time of reception of first
     #                       packet of a LidarScan as the timestamp of the IMU,
     #                       PointCloud2 and LaserScan messages.
-    timestamp_mode: ''
-    # ptp_utc_tai_offset[optional]: UTC/TAI offset in seconds to apply when
-    # TIME_FROM_PTP_1588 timestamp mode is used.
-    ptp_utc_tai_offset: -37.0
+    timestamp_mode: 'TIME_FROM_ROS_TIME'
     # udp_profile_lidar[optional]: lidar packet profile; possible values:
     # - LEGACY: not recommended
     # - RNG19_RFL8_SIG16_NIR16
@@ -42,28 +39,28 @@ ouster/os_driver:
     # lidar_port[optional]: port value should be in the range [0, 65535]. If you
     # use 0 as the port value then the first avaliable port number will be
     # assigned.
-    lidar_port: 0
+    lidar_port: 7502
     # imu_port[optional]: port value should be in the range [0, 65535]. If you
     # use 0 as the port value then the first avaliable port number will be
     # assigned.
-    imu_port: 0
+    imu_port: 7503
     # sensor_frame[optional]: name to use when referring to the sensor frame.
-    sensor_frame: os_sensor
+    sensor_frame: drivers/ouster_lidar_fl/sensor
     # lidar_frame[optional]: name to use when referring to the lidar frame.
-    lidar_frame: os_lidar
+    lidar_frame: drivers/ouster_lidar_fl/lidar
     # imu_frame[optional]: name to use when referring to the imu frame.
-    imu_frame: os_imu
+    imu_frame: drivers/ouster_lidar_fl/imu
     # point_cloud_frame[optional]: which frame of reference to use when
     # generating PointCloud2 or LaserScan messages, select between the values of
     # lidar_frame and sensor_frame.
-    point_cloud_frame: os_lidar
+    point_cloud_frame: drivers/ouster_lidar_fl/lidar
     # pub_static_tf[optional]: when this flag is set to True, the driver will
     # broadcast the TF transforms for the imu/sensor/lidar frames. Prevent the
     # driver from broadcasting TF transforms by setting this parameter to False.
     pub_static_tf: true
     # proc_mask[optional]: use any combination of the 6 flags IMG, PCL, IMU, SCAN
     # RAW and TLM to enable or disable their respective messages.
-    proc_mask: IMU|PCL|SCAN|IMG|RAW|TLM
+    proc_mask: IMG|PCL|IMU|SCAN
     # scan_ring[optional]: use this parameter in conjunction with the SCAN flag
     # to select which beam of the LidarScan to use when producing the LaserScan
     # message. Choose a value the range [0, sensor_beams_count).
@@ -71,7 +68,7 @@ ouster/os_driver:
     # use_system_default_qos[optional]: if false, data are published with sensor
     # data QoS. This is preferrable for production but default QoS is needed for
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
-    use_system_default_qos: false
+    use_system_default_qos: true
     # point_type[optional]: choose from: {original, native, xyz, xyzi, o_xyzi, 
     #                                     yzir}
     # Here is a breif description of each option:

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -22,6 +22,7 @@
   <depend>pcl_conversions</depend>
   <depend>std_srvs</depend>
   <depend>cv_bridge</depend>
+  <depend>point_cloud_transport</depend>
 
   <build_depend>libjsoncpp-dev</build_depend>
   <build_depend>eigen</build_depend>
@@ -38,6 +39,9 @@
   <exec_depend>curl</exec_depend>
   <exec_depend>spdlog</exec_depend>
   <exec_depend>libtins-dev</exec_depend>
+  <exec_depend>zstd_point_cloud_transport</exec_depend>
+  <exec_depend>zlib_point_cloud_transport</exec_depend>
+  <exec_depend>draco_point_cloud_transport</exec_depend>
 
   <test_depend>gtest</test_depend>
 

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -23,6 +23,8 @@
 #include "ouster_sensor_msgs/srv/set_config.hpp"
 #include "ouster_ros/visibility_control.h"
 #include "ouster_ros/os_sensor_node_base.h"
+#include <point_cloud_transport/point_cloud_transport.hpp>
+
 
 
 namespace sensor = ouster::sensor;


### PR DESCRIPTION
# MR OVERVIEW
This MR adds support for the transport of compressed point clouds using the [point_cloud_transport package](https://github.com/ros-perception/point_cloud_transport.git). Available compression types are: **zstd**, **zlib**, and **draco**.

# Changes
- Added `point_cloud_transport` as a dependency in `CMakeLists.txt`, `package.xml`, and code.
- Updated `driver_params.yaml` to match our lidar sensors.
- Modified publisher logic in `os_driver_node.cpp` to use `point_cloud_transport` for point cloud topics. This publisher requires a regular `rclcpp::Node` instance to construct the `PointCloudTransport`, which is why a separate helper node was created instead of using the main `LifecycleNode`.
- Updated publisher types and cleanup logic to support the new transport.
- Added new dependencies for point cloud transport plugins in `package.xml`.

# Note
Run the following commands to install the missing dependencies:
```bash
sudo apt update
sudo apt install ros-jazzy-point-cloud-transport
sudo apt install ros-jazzy-point-cloud-transport-plugins
sudo apt install ros-jazzy-zstd-point-cloud-transport
sudo apt install ros-jazzy-zlib-point-cloud-transport
sudo apt install ros-jazzy-draco-point-cloud-transport
```
# Usage
Make sure that the praram file is correctly set up and start the lidar with following command:
```bash
ros2 launch ouster_ros driver.launch.py ouster_ns:=/drivers/ouster_lidar_fl os_driver_name:=driver viz:=false
```
Ur point cloud will be displayed on the topic `/drivers/ouster_lidar_fl/points`. To view the compressed topicsa add your compression type at the end e.g. `/drivers/ouster_lidar_fl/points/zstd`.
The bandwiths are as following:
zstd -> 15,5 MB/s
zlib -> 5,5 MB/s
draco-> 5,3 MB/s
| Compression type | Bandwith [MB/s] |
| --- | --- |
| `None` | 120 |
| `zstd` | 15.5 |
| `zlib` | 5.5 |
| `draco` | 5.3 |

Note: The compressed point cloud topics seem to have a lower quality, especially 'zlib'.