### PR TITLE
fix-rolling build

### DIFF
--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -12,7 +12,12 @@
 #include "ouster_ros/os_ros.h"
 // clang-format on
 
+#if __has_include(<tf2/LinearMath/Transform.hpp>)
+#include <tf2/LinearMath/Transform.hpp>
+#else
 #include <tf2/LinearMath/Transform.h>
+#endif
+
 
 #include <tf2_eigen/tf2_eigen.hpp>
 


### PR DESCRIPTION
CI Build for rolling fails with error: 
```
#14 47.15 /var/lib/build/src/ouster-ros/ouster-ros/src/os_ros.cpp:15:10: fatal error: tf2/LinearMath/Transform.h: No such file or directory
#14 47.15    15 | #include <tf2/LinearMath/Transform.h>
#14 47.15       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 47.15 compilation terminated.
```

## Summary of Changes

This simple change allows compilation for all ros2 distros.

## Validation

Compilation passes.

