### PR TITLE
feat: simple node diagnostics

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(OpenCV REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
 
 # ==== Options ====
 add_compile_options(-Wall -Wextra)
@@ -77,6 +78,7 @@ set(ouster_ros_library_deps
   pcl_conversions
   tf2
   tf2_eigen
+  diagnostic_msgs
 )
 
 ament_target_dependencies(ouster_ros_library
@@ -114,6 +116,7 @@ function(create_ros2_component
     std_msgs
     sensor_msgs
     geometry_msgs
+    diagnostic_msgs
     ${additonal_dependencies}
   )
 
@@ -127,7 +130,7 @@ endfunction()
 
 # ==== os_sensor_component ====
 create_ros2_component(os_sensor_component
-  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp"
+  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/sensor_diagnostics_tracker.cpp"
   "std_srvs"
 )
 rclcpp_components_register_node(os_sensor_component
@@ -167,7 +170,7 @@ rclcpp_components_register_node(os_image_component
 
 # ==== os_driver_component ====
 create_ros2_component(os_driver_component
-  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/os_driver_node.cpp"
+  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/os_driver_node.cpp;src/sensor_diagnostics_tracker.cpp"
   "std_srvs"
 )
 rclcpp_components_register_node(os_driver_component

--- a/ouster-ros/include/ouster_ros/os_sensor_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_sensor_node_base.h
@@ -8,59 +8,76 @@
  */
 
 #include <chrono>
+#include <map>
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <lifecycle_msgs/srv/change_state.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
 #include "ouster_sensor_msgs/srv/get_metadata.hpp"
+#include "ouster_ros/sensor_diagnostics_tracker.h"
 
 #include <ouster/types.h>
 
-namespace ouster_ros {
+namespace ouster_ros
+{
 
-class OusterSensorNodeBase : public rclcpp_lifecycle::LifecycleNode {
-   protected:
-    explicit OusterSensorNodeBase(const std::string& name,
-                                  const rclcpp::NodeOptions& options);
+class OusterSensorNodeBase : public rclcpp_lifecycle::LifecycleNode
+{
+protected:
+  explicit OusterSensorNodeBase(const std::string & name, const rclcpp::NodeOptions & options);
 
-   protected:
-    bool is_arg_set(const std::string& arg) const {
-        return arg.find_first_not_of(' ') != std::string::npos;
-    }
+protected:
+  bool is_arg_set(const std::string & arg) const
+  {
+    return arg.find_first_not_of(' ') != std::string::npos;
+  }
 
-    void create_get_metadata_service();
+  void create_get_metadata_service();
 
-    void create_metadata_pub();
+  void create_metadata_pub();
 
-    void publish_metadata();
+  void publish_metadata();
 
-    void display_lidar_info(const ouster::sensor::sensor_info& info);
+  void create_diagnostics_pub(
+    double period = 1.0, const std::string & name = "", const std::string & hardware_id = "");
 
-    static std::string read_text_file(const std::string& text_file);
+  void publish_diagnostics();
 
-    static bool write_text_to_file(const std::string& file_path,
-                                   const std::string& text);
+  void update_diagnostics_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {});
 
-    static std::string transition_id_to_string(uint8_t transition_id);
+  void display_lidar_info(const ouster::sensor::sensor_info & info);
 
-    template <typename CallbackT, typename... CallbackT_Args>
-    bool change_state(std::uint8_t transition_id, CallbackT callback,
-                      CallbackT_Args... callback_args,
-                      std::chrono::seconds time_out = std::chrono::seconds{3});
+  static std::string read_text_file(const std::string & text_file);
 
-    void execute_transitions_sequence(std::vector<uint8_t> transitions_sequence,
-                                      size_t at);
+  static bool write_text_to_file(const std::string & file_path, const std::string & text);
 
+  static std::string transition_id_to_string(uint8_t transition_id);
 
-   protected:
-    std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> change_state_client;
+  template <typename CallbackT, typename... CallbackT_Args>
+  bool change_state(
+    std::uint8_t transition_id, CallbackT callback, CallbackT_Args... callback_args,
+    std::chrono::seconds time_out = std::chrono::seconds{3});
 
-    ouster::sensor::sensor_info info;
-    rclcpp::Service<ouster_sensor_msgs::srv::GetMetadata>::SharedPtr get_metadata_srv;
-    std::string cached_metadata;
-    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr metadata_pub;
+  void execute_transitions_sequence(std::vector<uint8_t> transitions_sequence, size_t at);
+
+protected:
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> change_state_client;
+
+  ouster::sensor::sensor_info info;
+  rclcpp::Service<ouster_sensor_msgs::srv::GetMetadata>::SharedPtr get_metadata_srv;
+  std::string cached_metadata;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr metadata_pub;
+
+  double diagnostics_period_{1.0};
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
+  rclcpp::TimerBase::SharedPtr diagnostics_timer_;
+  std::unique_ptr<SensorDiagnosticsTracker> diagnostics_tracker_;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.h
+++ b/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.h
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file sensor_diagnostics_tracker.h
+ * @brief Diagnostic tracking functionality for Ouster sensors
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <cstdint>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <diagnostic_msgs/msg/key_value.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ouster/types.h>
+
+namespace ouster_ros
+{
+
+class SensorDiagnosticsTracker
+{
+public:
+  SensorDiagnosticsTracker(
+    const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id = "");
+  ~SensorDiagnosticsTracker() = default;
+
+  void record_lidar_packet();
+
+  void record_imu_packet();
+
+  void increment_poll_client_errors();
+
+  void increment_lidar_packet_errors();
+
+  void increment_imu_packet_errors();
+
+  void reset_poll_client_errors();
+
+  void reset_lidar_packet_errors();
+
+  void reset_imu_packet_errors();
+
+  std::map<std::string, std::string> get_debug_context(
+    const std::string & sensor_hostname, bool sensor_connection_active, int lidar_port = 0,
+    int imu_port = 0) const;
+
+  diagnostic_msgs::msg::DiagnosticStatus create_diagnostic_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {}) const;
+
+  void update_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {});
+
+  void update_metadata(const ouster::sensor::sensor_info & info);
+
+  diagnostic_msgs::msg::DiagnosticStatus get_current_status() const;
+
+private:
+  std::string name_;
+  std::string hardware_id_;
+
+  rclcpp::Clock::SharedPtr clock_;
+
+  rclcpp::Time sensor_start_time_;
+  rclcpp::Time last_successful_lidar_frame_;
+  rclcpp::Time last_successful_imu_frame_;
+
+  uint32_t total_lidar_packets_received_{0};
+  uint32_t total_imu_packets_received_{0};
+
+  uint32_t poll_client_error_count_{0};
+  uint32_t read_lidar_packet_errors_{0};
+  uint32_t read_imu_packet_errors_{0};
+  std::map<std::string, std::string> sensor_info_;
+
+  mutable std::string current_message_{"Not initialized"};
+  mutable diagnostic_msgs::msg::DiagnosticStatus::_level_type current_level_{
+    diagnostic_msgs::msg::DiagnosticStatus::STALE};
+  mutable std::map<std::string, std::string> current_debug_context_;
+};
+
+}  // namespace ouster_ros

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -60,7 +60,7 @@
 
   <arg name="use_system_default_qos" default="false"
     description="Use the default system QoS settings"/>
-  
+
   <arg name="proc_mask" default="IMG|PCL|IMU|SCAN|TLM" description="
     use any combination of the 4 flags to enable or disable specific processors"/>
 
@@ -97,6 +97,9 @@
 
   <arg name="auto_start" default="true"
     description="automatically configure and activate the node"/>
+
+  <arg name="use_diagnostics" default="false"
+    description="enable publishing diagnostic messages on /diagnostics topic"/>
 
   <arg name="organized" default="true"
     description="generate an organzied point cloud"/>
@@ -149,6 +152,7 @@
       <param name="max_failed_reconnect_attempts"
              value="$(var max_failed_reconnect_attempts)"/>
       <param name="auto_start" value="$(var auto_start)"/>
+      <param name="use_diagnostics" value="$(var use_diagnostics)"/>
       <param name="organized" value="$(var organized)"/>
       <param name="destagger" value="$(var destagger)"/>
       <param name="min_range" value="$(var min_range)"/>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -22,6 +22,7 @@
   <depend>pcl_conversions</depend>
   <depend>std_srvs</depend>
   <depend>cv_bridge</depend>
+  <depend>diagnostic_msgs</depend>
 
   <build_depend>libjsoncpp-dev</build_depend>
   <build_depend>eigen</build_depend>

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -24,7 +24,6 @@
 #include "ouster_ros/visibility_control.h"
 #include "ouster_ros/os_sensor_node_base.h"
 
-
 namespace sensor = ouster::sensor;
 using rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface;
 
@@ -179,6 +178,12 @@ class OusterSensor : public OusterSensorNodeBase {
     double dormant_period_between_reconnects;
     int reconnect_attempts_available;
     rclcpp::TimerBase::SharedPtr reconnect_timer;
+
+    std::string diagnostics_hardware_id_;
+    std::string diagnostics_name_;
+
+    std::string get_diagnostics_hardware_id();
+    std::map<std::string, std::string> get_debug_context() const;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -151,4 +151,46 @@ void OusterSensorNodeBase::execute_transitions_sequence(
     });
 }
 
+void OusterSensorNodeBase::create_diagnostics_pub(
+  double period, const std::string & name, const std::string & hardware_id)
+{
+  auto qos = rclcpp::QoS(1);
+  qos.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+  diagnostics_pub_ = create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", qos);
+
+  diagnostics_period_ = period;
+
+  // Create diagnostics tracker
+  diagnostics_tracker_ = std::make_unique<SensorDiagnosticsTracker>(name, get_clock(), hardware_id);
+
+  // Create timer for diagnostics publishing
+  const auto period_duration = std::chrono::duration<double>(diagnostics_period_);
+  diagnostics_timer_ =
+    create_wall_timer(period_duration, std::bind(&OusterSensorNodeBase::publish_diagnostics, this));
+}
+
+void OusterSensorNodeBase::publish_diagnostics()
+{
+  if (!diagnostics_tracker_ || !diagnostics_pub_) {
+    return;
+  }
+
+  auto msg = diagnostic_msgs::msg::DiagnosticArray();
+  msg.header.stamp = get_clock()->now();
+  msg.status.push_back(diagnostics_tracker_->get_current_status());
+
+  diagnostics_pub_->publish(msg);
+}
+
+void OusterSensorNodeBase::update_diagnostics_status(
+  const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+  const std::map<std::string, std::string> & debug_context)
+{
+  if (!diagnostics_tracker_) {
+    return;
+  }
+
+  diagnostics_tracker_->update_status(message, level, debug_context);
+}
+
 }  // namespace ouster_ros

--- a/ouster-ros/src/sensor_diagnostics_tracker.cpp
+++ b/ouster-ros/src/sensor_diagnostics_tracker.cpp
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file sensor_diagnostics_tracker.cpp
+ * @brief Implementation of diagnostic tracking functionality for Ouster sensors
+ */
+
+#include "ouster_ros/sensor_diagnostics_tracker.h"
+
+namespace ouster_ros
+{
+
+SensorDiagnosticsTracker::SensorDiagnosticsTracker(
+  const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id)
+: name_{name},
+  hardware_id_{hardware_id.empty() ? name : hardware_id},
+  clock_{clock},
+  sensor_start_time_{clock_->now()},
+  last_successful_lidar_frame_{rclcpp::Time(0)},
+  last_successful_imu_frame_{rclcpp::Time(0)},
+  total_lidar_packets_received_{0},
+  total_imu_packets_received_{0},
+  poll_client_error_count_{0},
+  read_lidar_packet_errors_{0},
+  read_imu_packet_errors_{0}
+{
+}
+
+void SensorDiagnosticsTracker::record_lidar_packet()
+{
+  last_successful_lidar_frame_ = clock_->now();
+  total_lidar_packets_received_++;
+}
+
+void SensorDiagnosticsTracker::record_imu_packet()
+{
+  last_successful_imu_frame_ = clock_->now();
+  total_imu_packets_received_++;
+}
+
+void SensorDiagnosticsTracker::increment_poll_client_errors() { poll_client_error_count_++; }
+
+void SensorDiagnosticsTracker::increment_lidar_packet_errors() { read_lidar_packet_errors_++; }
+
+void SensorDiagnosticsTracker::increment_imu_packet_errors() { read_imu_packet_errors_++; }
+
+void SensorDiagnosticsTracker::reset_poll_client_errors() { poll_client_error_count_ = 0; }
+
+void SensorDiagnosticsTracker::reset_lidar_packet_errors() { read_lidar_packet_errors_ = 0; }
+
+void SensorDiagnosticsTracker::reset_imu_packet_errors() { read_imu_packet_errors_ = 0; }
+
+std::map<std::string, std::string> SensorDiagnosticsTracker::get_debug_context(
+  const std::string & sensor_hostname, bool sensor_connection_active, int lidar_port,
+  int imu_port) const
+{
+  std::map<std::string, std::string> context;
+
+  auto now = clock_->now();
+
+  context["Sensor Hostname"] = sensor_hostname;
+
+  if (sensor_start_time_.nanoseconds() > 0) {
+    auto uptime_duration = now - sensor_start_time_;
+    auto uptime_ms = uptime_duration.nanoseconds() / 1000000;  // Convert to milliseconds
+    context["Sensor Uptime (ms)"] = std::to_string(uptime_ms);
+  }
+
+  if (last_successful_lidar_frame_.nanoseconds() > 0) {
+    auto time_since_lidar_duration = now - last_successful_lidar_frame_;
+    auto time_since_lidar_ms = time_since_lidar_duration.nanoseconds() / 1000000;
+    context["Time Since Last LiDAR Frame (ms)"] = std::to_string(time_since_lidar_ms);
+  } else {
+    context["Time Since Last LiDAR Frame (ms)"] = "Never received";
+  }
+
+  if (last_successful_imu_frame_.nanoseconds() > 0) {
+    auto time_since_imu_duration = now - last_successful_imu_frame_;
+    auto time_since_imu_ms = time_since_imu_duration.nanoseconds() / 1000000;
+    context["Time Since Last IMU Frame (ms)"] = std::to_string(time_since_imu_ms);
+  } else {
+    context["Time Since Last IMU Frame (ms)"] = "Never received";
+  }
+
+  context["Sensor Connection Active"] = sensor_connection_active ? "true" : "false";
+
+  if (lidar_port == 0) {
+    context["Potential Issue"] = "LiDAR port set to 0 (auto-assign)";
+  }
+  if (imu_port == 0) {
+    context["Potential Issue"] = "IMU port set to 0 (auto-assign)";
+  }
+
+  return context;
+}
+
+diagnostic_msgs::msg::DiagnosticStatus SensorDiagnosticsTracker::create_diagnostic_status(
+  const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+  const std::map<std::string, std::string> & debug_context) const
+{
+  diagnostic_msgs::msg::DiagnosticStatus status;
+
+  status.hardware_id = hardware_id_;
+  status.message = message;
+  status.level = level;
+  status.name = name_;
+
+  status.values.clear();
+
+  auto now = clock_->now();
+  diagnostic_msgs::msg::KeyValue timestamp_kv;
+
+  timestamp_kv.key = "Last Update";
+  timestamp_kv.value = std::to_string(now.seconds());
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "Sensor Uptime (s)";
+  timestamp_kv.value = std::to_string((now - sensor_start_time_).seconds());
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "Last successful lidar frame";
+  timestamp_kv.value = std::to_string(last_successful_lidar_frame_.seconds());
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "Last successful imu frame";
+  timestamp_kv.value = std::to_string(last_successful_imu_frame_.seconds());
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "Total LIDAR Packets";
+  timestamp_kv.value = std::to_string(total_lidar_packets_received_);
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "Total IMU Packets";
+  timestamp_kv.value = std::to_string(total_imu_packets_received_);
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "Poll Client Error Count";
+  timestamp_kv.value = std::to_string(poll_client_error_count_);
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "LIDAR Packet Error Count";
+  timestamp_kv.value = std::to_string(read_lidar_packet_errors_);
+  status.values.push_back(timestamp_kv);
+
+  timestamp_kv.key = "IMU Packet Error Count";
+  timestamp_kv.value = std::to_string(read_imu_packet_errors_);
+  status.values.push_back(timestamp_kv);
+
+  // Add sensor metadata if available
+  for (const auto & metadata_pair : sensor_info_) {
+    diagnostic_msgs::msg::KeyValue metadata_kv;
+    metadata_kv.key = "Sensor " + metadata_pair.first;
+    metadata_kv.value = metadata_pair.second;
+    status.values.push_back(metadata_kv);
+  }
+
+  for (const auto & context_pair : debug_context) {
+    diagnostic_msgs::msg::KeyValue debug_kv;
+    debug_kv.key = context_pair.first;
+    debug_kv.value = context_pair.second;
+    status.values.push_back(debug_kv);
+  }
+
+  return status;
+}
+
+void SensorDiagnosticsTracker::update_metadata(const ouster::sensor::sensor_info & info)
+{
+  sensor_info_.clear();
+
+  // Basic sensor information
+  sensor_info_["Product Line"] = info.prod_line;
+  sensor_info_["Serial Number"] = info.sn;
+  sensor_info_["Firmware Version"] = info.fw_rev;
+
+  // Lidar configuration
+  sensor_info_["Lidar Mode"] = ouster::sensor::to_string(info.mode);
+  sensor_info_["UDP Profile Lidar"] = ouster::sensor::to_string(info.format.udp_profile_lidar);
+  sensor_info_["UDP Profile IMU"] = ouster::sensor::to_string(info.format.udp_profile_imu);
+
+  // Network configuration (handling optional values)
+  if (info.config.udp_port_lidar.has_value()) {
+    sensor_info_["UDP Port Lidar"] = std::to_string(info.config.udp_port_lidar.value());
+  } else {
+    sensor_info_["UDP Port Lidar"] = "Not set";
+  }
+
+  if (info.config.udp_port_imu.has_value()) {
+    sensor_info_["UDP Port IMU"] = std::to_string(info.config.udp_port_imu.value());
+  } else {
+    sensor_info_["UDP Port IMU"] = "Not set";
+  }
+
+  // Convert UDP destination to string
+  if (info.config.udp_dest.has_value()) {
+    sensor_info_["UDP Dest"] = info.config.udp_dest.value();
+  } else {
+    sensor_info_["UDP Dest"] = "Not set";
+  }
+
+  // Timing and operational settings
+  sensor_info_["Columns Per Packet"] = std::to_string(info.format.columns_per_packet);
+  sensor_info_["Columns Per Frame"] = std::to_string(info.format.columns_per_frame);
+  sensor_info_["Pixels Per Column"] = std::to_string(info.format.pixels_per_column);
+
+  // Column window information
+  if (info.format.column_window.first != info.format.column_window.second) {
+    sensor_info_["Column Window"] = "[" + std::to_string(info.format.column_window.first) + ", " +
+                                    std::to_string(info.format.column_window.second) + "]";
+  }
+
+  // Sensor capabilities and status
+  sensor_info_["Lidar Data Format"] = "Columns: " + std::to_string(info.format.columns_per_frame) +
+                                      ", Pixels: " + std::to_string(info.format.pixels_per_column);
+
+  // Beam configuration (for diagnostic purposes)
+  if (!info.beam_azimuth_angles.empty() && !info.beam_altitude_angles.empty()) {
+    sensor_info_["Beam Count"] = std::to_string(info.beam_azimuth_angles.size());
+
+    auto alt_min =
+      *std::min_element(info.beam_altitude_angles.begin(), info.beam_altitude_angles.end());
+    auto alt_max =
+      *std::max_element(info.beam_altitude_angles.begin(), info.beam_altitude_angles.end());
+    sensor_info_["Altitude Range"] =
+      "[" + std::to_string(alt_min) + ", " + std::to_string(alt_max) + "] degrees";
+  }
+
+  // Additional useful diagnostic information
+  sensor_info_["Sensor Info JSON Length"] = std::to_string(info.original_string().length());
+}
+
+void SensorDiagnosticsTracker::update_status(
+  const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+  const std::map<std::string, std::string> & debug_context)
+{
+  current_message_ = message;
+  current_level_ = level;
+  current_debug_context_ = debug_context;
+}
+
+diagnostic_msgs::msg::DiagnosticStatus SensorDiagnosticsTracker::get_current_status() const
+{
+  return create_diagnostic_status(current_message_, current_level_, current_debug_context_);
+}
+
+}  // namespace ouster_ros


### PR DESCRIPTION
## Related Issues & PRs
This pull request introduces diagnostics functionality to the Ouster ROS sensor node, enabling the publishing of diagnostic messages to the `/diagnostics` topic and tracking the health and status of the sensor. The changes add new dependencies, launch options, configuration parameters, and a new `SensorDiagnosticsTracker` class to support this feature.

**Diagnostics functionality and integration:**

* Added new `SensorDiagnosticsTracker` class (`sensor_diagnostics_tracker.h`) to track sensor status, errors, and publish diagnostic messages. (`[ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.hR1-R85](diffhunk://#diff-031b3dc44ee21f8f7146cf1d4fb718a7d323212b3f3fa496b3d61aedd9639c8cR1-R85)`)
* Integrated diagnostics publishing in the sensor node lifecycle (`os_sensor_node.cpp`, `os_sensor_node_base.h`, `os_sensor_node_base.cpp`), including methods to create publishers, update status, and provide debug context. (`[[1]](diffhunk://#diff-dc133ca34a17dfcc79f2ef415697b31df352c60f63109a5f9853e59429225fa1R45-R67)`, `[[2]](diffhunk://#diff-dc133ca34a17dfcc79f2ef415697b31df352c60f63109a5f9853e59429225fa1R76-R80)`, `[[3]](diffhunk://#diff-2653a4df94e0a153679dfd83af6d5ae0e88b6d8722690fdec2d3b3450ccab4d5R154-R195)`, `[[4]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R129-R158)`, `[[5]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R171-R188)`, `[[6]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R204-R208)`, `[[7]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R224-R227)`, `[[8]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R288-R315)`, `[[9]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76L675-R752)`, `[[10]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R917-R931)`, `[[11]](diffhunk://#diff-5d86898515fd30178f3be61e17c6bf55c387205a961e396451df71fc07a5b853R181-R186)`)

**Configuration and launch support:**

* Added new launch arguments and ROS parameters to enable diagnostics, configure period, hardware ID, and diagnostics name (`sensor.composite.launch.xml`, `os_sensor_node.cpp`). (`[[1]](diffhunk://#diff-706d25354115ff64b52054aa54dee210c3d02d04d63895548ebed0fb22f40538R101-R103)`, `[[2]](diffhunk://#diff-706d25354115ff64b52054aa54dee210c3d02d04d63895548ebed0fb22f40538R155)`, `[[3]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R86-R89)`)

**Build and dependency updates:**

* Added `diagnostic_msgs` as a required package and dependency in CMake and package manifests (`CMakeLists.txt`, `package.xml`). (`[[1]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR25)`, `[[2]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR81)`, `[[3]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR119)`, `[[4]](diffhunk://#diff-4e8b09ed81257de27c2a17fd6b68cbbdb6fa5359600e45d63ee380ebbc902d75R25)`)

**Component registration and source inclusion:**

* Updated component creation to include the diagnostics tracker source file for relevant nodes (`CMakeLists.txt`). (`[[1]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eL130-R133)`, `[[2]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eL170-R173)`)

(References: [[1]](diffhunk://#diff-031b3dc44ee21f8f7146cf1d4fb718a7d323212b3f3fa496b3d61aedd9639c8cR1-R85) [[2]](diffhunk://#diff-dc133ca34a17dfcc79f2ef415697b31df352c60f63109a5f9853e59429225fa1R45-R67) [[3]](diffhunk://#diff-dc133ca34a17dfcc79f2ef415697b31df352c60f63109a5f9853e59429225fa1R76-R80) [[4]](diffhunk://#diff-2653a4df94e0a153679dfd83af6d5ae0e88b6d8722690fdec2d3b3450ccab4d5R154-R195) [[5]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R129-R158) [[6]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R171-R188) [[7]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R204-R208) [[8]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R224-R227) [[9]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R288-R315) [[10]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76L675-R752) [[11]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R917-R931) [[12]](diffhunk://#diff-5d86898515fd30178f3be61e17c6bf55c387205a961e396451df71fc07a5b853R181-R186) [[13]](diffhunk://#diff-706d25354115ff64b52054aa54dee210c3d02d04d63895548ebed0fb22f40538R101-R103) [[14]](diffhunk://#diff-706d25354115ff64b52054aa54dee210c3d02d04d63895548ebed0fb22f40538R155) [[15]](diffhunk://#diff-2aaddd95a83c7cc908de2d901550a86e239868811b36c4938bb9337ce410dc76R86-R89) [[16]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR25) [[17]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR81) [[18]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR119) [[19]](diffhunk://#diff-4e8b09ed81257de27c2a17fd6b68cbbdb6fa5359600e45d63ee380ebbc902d75R25) [[20]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eL130-R133) [[21]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eL170-R173)
## Summary of Changes

## Validation
