### PR TITLE
Drop whole archive linkage of ouster-client in ouster-ros

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changelog
 * Introduce a new capability to suppress certain range measurements of the point cloud by providing
   a mask image to the driver through the ``mask_path`` launch file argument.
 * [BUGFIX]: Correct the computation of ``pointcloud.is_dense`` flag.
+* [BUGFIX]: Drop while archive linkage which is causing double free corruption.
 
 
 ouster_ros v0.13.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Changelog
 * Introduce a new capability to suppress certain range measurements of the point cloud by providing
   a mask image to the driver through the ``mask_path`` launch file argument.
 * [BUGFIX]: Correct the computation of ``pointcloud.is_dense`` flag.
-* [BUGFIX]: Drop while archive linkage which is causing double free corruption.
+* [BUGFIX]: Drop whole archive linkage which is causing double free corruption.
 
 
 ouster_ros v0.13.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,35 +98,22 @@ if (BUILD_PCAP)
 endif()
 
 add_library(ouster_ros src/os_ros.cpp)
-if(APPLE)
-  target_link_libraries(ouster_ros
-    PUBLIC ${catkin_LIBRARIES} ouster_build pcl_common
-    PRIVATE ${OUSTER_TARGET_LINKS})
-else()
-  target_link_libraries(ouster_ros
-    PUBLIC ${catkin_LIBRARIES} ouster_build pcl_common
-    PRIVATE -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive)
-endif()
+target_link_libraries(ouster_ros
+  PUBLIC ${catkin_LIBRARIES} ouster_build pcl_common
+  PRIVATE ${OUSTER_TARGET_LINKS}
+)
 
-  add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
+add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
 
 # ==== Executables ====
 add_library(${PROJECT_NAME}_nodelets ${NODELET_SRC})
-if(APPLE)
-  target_link_libraries(
-    ${PROJECT_NAME}_nodelets
-    ouster_ros
-    ${OUSTER_TARGET_LINKS}  # Add this to ensure ouster_client is linked
-    ${catkin_LIBRARIES}
-    ${OpenCV_LIBRARIES})
-else()
-  target_link_libraries(
-    ${PROJECT_NAME}_nodelets
-    ouster_ros
-    -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive
-    ${catkin_LIBRARIES}
-    ${OpenCV_LIBRARIES})
-endif()
+target_link_libraries(
+  ${PROJECT_NAME}_nodelets
+  ouster_ros
+  ${OUSTER_TARGET_LINKS}  # Add this to ensure ouster_client is linked
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+)
 add_dependencies(${PROJECT_NAME}_nodelets ${PROJECT_NAME}_gencpp)
 
 # ==== Test ====
@@ -139,13 +126,8 @@ if(CATKIN_ENABLE_TESTING)
     tests/point_transform_test.cpp
     tests/point_cloud_compose_test.cpp
   )
-  if(APPLE)
   target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES}
     ouster_build pcl_common ${OUSTER_TARGET_LINKS})
-  else()
-  target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES}
-    ouster_build pcl_common -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive)
-  endif()
 endif()
 
 # ==== Install ====

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.8</version>
+  <version>0.13.9</version>
   <description>Ouster ROS driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
- Resolves #485
- Related #481 

## Summary of Changes
- Drop whole archive linkage of ouster-client in ouster-ros

## Validation
Builds on all supported platforms, execution maintained, double free error on shutdown is gone.