### PR TITLE
[ROS2] Drop whole archive linkage of ouster-client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changelog
 * Introduce a new capability to suppress certain range measurements of the point cloud by providing
   a mask image to the driver through the ``mask_path`` launch file argument.
 * [BUGFIX]: Correct the computation of ``pointcloud.is_dense`` flag.
+* [BUGFIX]: Drop whole archive linkage which is causing double free corruption.
 
 
 ouster_ros v0.13.2

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -39,9 +39,6 @@ set(_ouster_ros_INCLUDE_DIRS
 )
 
 # ==== Libraries ====
-# Build static libraries and bundle them into ouster_ros using the `--whole-archive` flag. This is
-# necessary because catkin doesn't interoperate easily with target-based cmake builds. Object
-# libraries are the recommended way to do this, but require >=3.13 to propagate usage requirements.
 set(_SAVE_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 
@@ -88,7 +85,7 @@ target_link_libraries(ouster_ros_library
     ouster_build
     pcl_common
   # PRIVATE (unsupported)
-  -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive
+  ${OUSTER_TARGET_LINKS}
   ${OpenCV_LIBRARIES}
 )
 

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.13.11</version>
+  <version>0.13.12</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
- Resolves #485 
- ROS1 #486 

## Summary of Changes
* Drop whole archive linkage of ouster-client

## Validation
Builds on all supported platforms, execution maintained, double free error on shutdown is gone