### PR TITLE
fix-MapLidarScanFieldsTest

### DIFF
--- a/ouster-ros/test/point_cloud_compose_test.cpp
+++ b/ouster-ros/test/point_cloud_compose_test.cpp
@@ -65,10 +65,19 @@ TEST_F(PointCloudComposeTest, MapLidarScanFields) {
     ouster_ros::Point_RNG19_RFL8_SIG16_NIR16_DUAL pt;
 
     for (auto src_idx = 0U; src_idx < SAMPLES; ++src_idx) {
+        // Convert linear index to 2D coordinates
+        auto row = src_idx / WIDTH;
+        auto col = src_idx % WIDTH;
+
         copy_lidar_scan_fields_to_point<0>(pt, ls_tuple, src_idx);
-        EXPECT_EQ(point::get<5>(pt), range(0, src_idx));
-        EXPECT_EQ(point::get<6>(pt), signal(0, src_idx));
-        EXPECT_EQ(point::get<7>(pt), reflect(0, src_idx));
-        EXPECT_EQ(point::get<8>(pt), near_ir(0, src_idx));
+
+        EXPECT_EQ(point::get<5>(pt), range(row, col))
+            << "Range mismatch at index " << src_idx << " (row=" << row << ", col=" << col << ")";
+        EXPECT_EQ(point::get<6>(pt), signal(row, col))
+            << "Signal mismatch at index " << src_idx << " (row=" << row << ", col=" << col << ")";
+        EXPECT_EQ(point::get<7>(pt), reflect(row, col))
+            << "Reflectivity mismatch at index " << src_idx << " (row=" << row << ", col=" << col << ")";
+        EXPECT_EQ(point::get<8>(pt), near_ir(row, col))
+            << "Near IR mismatch at index " << src_idx << " (row=" << row << ", col=" << col << ")";
     }
 }


### PR DESCRIPTION
## Related Issues & PRs
Compilation with Debug symbols:
```
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug  --packages-select ouster_ros
```
Causes assertion in Eigen:
```
[----------] 1 test from PointCloudComposeTest
[ RUN      ] PointCloudComposeTest.MapLidarScanFields
ouster_ros_test: /usr/include/eigen3/Eigen/src/Core/DenseCoeffsBase.h:366: Eigen::DenseCoeffsBase<Derived, 1>::Scalar& Eigen::DenseCoeffsBase<Derived, 1>::operator()(Eigen::Index, Eigen::Index) [with Derived = Eigen::Ref<Eigen::Array<unsigned int, -1, -1, 1, -1, -1> >; Eigen::DenseCoeffsBase<Derived, 1>::Scalar = unsigned int; Eigen::Index = long int]: Assertion `row >= 0 && row < rows() && col >= 0 && col < cols()' failed.
^C
```

## Summary of Changes

This change fixes iteration over rows and columns in Eigen lib.

## Validation

run test. 
