### PR TITLE
Fix timestamp in scan_to_cloud_f in case of packet loss

### DIFF
--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -121,6 +121,7 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
                      const ouster::PointsF& points, uint64_t scan_ts,
                      const ouster::LidarScan& ls,
                      const std::vector<int>& pixel_shift_by_row,
+                     double scan_col_ts_spacing_ns,
                      bool organized = false, bool destagger = true,
                      int rows_step = 1) {
     auto ls_tuple = make_lidar_scan_tuple<0, N, PROFILE>(ls);
@@ -143,7 +144,7 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
             auto ts_idx =
                 destagger ? v : (v + ls.w + pixel_shift_by_row[u]) % ls.w;
             auto ts =
-                timestamp[ts_idx] > scan_ts ? timestamp[ts_idx] - scan_ts : 0UL;
+                timestamp[ts_idx] > scan_ts ? timestamp[ts_idx] - scan_ts : scan_col_ts_spacing_ns*v;
 
             if (organized) {
                 // set is_dense to false if any of the xyz coordinates is NaN

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -33,6 +33,7 @@ class PointCloudProcessor {
                                         const ouster::PointsF& points,
                                         uint64_t scan_ts, const ouster::LidarScan& ls,
                                         const std::vector<int>& pixel_shift_by_row,
+                                        double scan_col_ts_spacing_ns,
                                         int return_index)>;
 
    public:
@@ -67,6 +68,8 @@ class PointCloudProcessor {
         lut_direction = xyz_lut.direction.cast<float>();
         lut_offset = xyz_lut.offset.cast<float>();
         points = ouster::PointsF(lut_direction.rows(), lut_offset.cols());
+        
+        scan_col_ts_spacing_ns = LidarPacketHandler::compute_scan_col_ts_spacing_ns(info.mode);
 
         mask = impl::load_mask<uint32_t>(
                     mask_path,
@@ -94,7 +97,7 @@ class PointCloudProcessor {
                                std::numeric_limits<float>::quiet_NaN());
 
             scan_to_cloud_fn(cloud, points, scan_ts, lidar_scan,
-                                        pixel_shift_by_row, i);
+                                        pixel_shift_by_row, scan_col_ts_spacing_ns, i);
 
             pcl_toROSMsg(cloud, *pc_msgs[i]);
             pc_msgs[i]->header.stamp = msg_ts;
@@ -140,6 +143,7 @@ class PointCloudProcessor {
     PointCloudProcessor_OutputType pc_msgs;
     ScanToCloudFn scan_to_cloud_fn;
     PointCloudProcessor_PostProcessingFn post_processing_fn;
+    double scan_col_ts_spacing_ns;
 
     ouster::img_t<uint32_t> mask;
 };

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -19,12 +19,14 @@ class PointCloudProcessorFactory {
                     const ouster::PointsF& points, uint64_t scan_ts,
                     const ouster::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
+                    double scan_col_ts_spacing_ns,
                     int /*return_index*/) {
 
                     Point_LEGACY staging_pt;
                     scan_to_cloud_f<Profile_LEGACY.size(), Profile_LEGACY>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row, organized, destagger, rows_step);
+                        pixel_shift_by_row, scan_col_ts_spacing_ns,
+                        organized, destagger, rows_step);
                 };
 
             case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
@@ -33,6 +35,7 @@ class PointCloudProcessorFactory {
                     const ouster::PointsF& points, uint64_t scan_ts,
                     const ouster::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
+                    double scan_col_ts_spacing_ns,
                     int return_index) {
 
                     Point_RNG19_RFL8_SIG16_NIR16_DUAL staging_pt;
@@ -41,13 +44,15 @@ class PointCloudProcessorFactory {
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL.size(),
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, scan_col_ts_spacing_ns,
+                            organized, destagger, rows_step);
                     } else {
                         scan_to_cloud_f<
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN.size(),
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, scan_col_ts_spacing_ns,
+                            organized, destagger, rows_step);
                     }
                 };
 
@@ -57,6 +62,7 @@ class PointCloudProcessorFactory {
                     const ouster::PointsF& points, uint64_t scan_ts,
                     const ouster::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
+                    double scan_col_ts_spacing_ns,
                     int /*return_index*/) {
 
                     Point_RNG19_RFL8_SIG16_NIR16 staging_pt;
@@ -64,7 +70,8 @@ class PointCloudProcessorFactory {
                         Profile_RNG19_RFL8_SIG16_NIR16.size(),
                         Profile_RNG19_RFL8_SIG16_NIR16>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, scan_col_ts_spacing_ns,
+                            organized, destagger, rows_step);
                 };
 
             case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
@@ -73,6 +80,7 @@ class PointCloudProcessorFactory {
                     const ouster::PointsF& points, uint64_t scan_ts,
                     const ouster::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
+                    double scan_col_ts_spacing_ns,
                     int /*return_index*/) {
 
                     Point_RNG15_RFL8_NIR8 staging_pt;
@@ -80,7 +88,8 @@ class PointCloudProcessorFactory {
                         Profile_RNG15_RFL8_NIR8.size(),
                         Profile_RNG15_RFL8_NIR8>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row, organized, destagger, rows_step);
+                        pixel_shift_by_row, scan_col_ts_spacing_ns,
+                        organized, destagger, rows_step);
                 };
 
             case UDPProfileLidar::PROFILE_FUSA_RNG15_RFL8_NIR8_DUAL:
@@ -89,6 +98,7 @@ class PointCloudProcessorFactory {
                     const ouster::PointsF& points, uint64_t scan_ts,
                     const ouster::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
+                    double scan_col_ts_spacing_ns,
                     int return_index) {
 
                     Point_FUSA_RNG15_RFL8_NIR8_DUAL staging_pt;
@@ -97,13 +107,15 @@ class PointCloudProcessorFactory {
                             Profile_FUSA_RNG15_RFL8_NIR8_DUAL.size(),
                             Profile_FUSA_RNG15_RFL8_NIR8_DUAL>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, scan_col_ts_spacing_ns,
+                            organized, destagger, rows_step);
                     } else {
                         scan_to_cloud_f<
                             Profile_FUSA_RNG15_RFL8_NIR8_DUAL_2ND_RETURN.size(),
                             Profile_FUSA_RNG15_RFL8_NIR8_DUAL_2ND_RETURN>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, scan_col_ts_spacing_ns,
+                            organized, destagger, rows_step);
                     }
                 };
 


### PR DESCRIPTION
When converting the lidar scan to a cloud in the _scan_to_cloud_f_ function of "point_cloud_compose.h" the timestamp of every point is taken from its neighbors based on the pixel shift.
In case of packet loss it can occur that the corresponding shifted point is not available. 
In this case the  timestamp is set to zero.

This leads to the points having a wrong timestamp and the assumption of increasing timestamps along the rotation direction being broken, which can have effects on downstream usage of this cloud (see attached before image).

<img width="1749" height="896" alt="ts_before" src="https://github.com/user-attachments/assets/8a308d85-272c-41f2-b1d9-1619833f7daf" />

Since the timestamps are calculated beforehand in the package handler we decided to repeat this same calculation in the scan to cloud function in case the timestamp is not correct.
Which leads to the cloud having correct timestamps for all points, even if some points are missing (see below).

<img width="1425" height="889" alt="ts_after" src="https://github.com/user-attachments/assets/ffe456c7-0186-458d-89a3-2fb57375f8a5" />
