### PR TITLE
Add preprocessing function to PointCloudProcessor

### DIFF
--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -220,6 +220,7 @@ class OusterCloud : public nodelet::Nodelet {
                     point_type, info, tf_bcast.point_cloud_frame_id(),
                     tf_bcast.apply_lidar_to_sensor_transform(), organized,
                     destagger, min_range, max_range, v_reduction, mask_path,
+                    PointCloudProcessor_PreProcessingFn(),
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i) {
                             if (msgs[i]->header.stamp > last_msg_ts)

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -166,6 +166,7 @@ class OusterDriver : public OusterSensor {
                     point_type, info, tf_bcast.point_cloud_frame_id(),
                     tf_bcast.apply_lidar_to_sensor_transform(), organized,
                     destagger, min_range, max_range, v_reduction, mask_path,
+                    PointCloudProcessor_PreProcessingFn(),
                     [this](PointCloudProcessor_OutputType msgs) {
                         for (size_t i = 0; i < msgs.size(); ++i)
                             lidar_pubs[i].publish(*msgs[i]);

--- a/src/point_cloud_processor.h
+++ b/src/point_cloud_processor.h
@@ -23,6 +23,7 @@
 namespace ouster_ros {
 
 // Moved out of PointCloudProcessor to avoid type templatization
+using PointCloudProcessor_PreProcessingFn = std::function<const ouster::LidarScan(const ouster::LidarScan&)>;
 using PointCloudProcessor_OutputType =
     std::vector<std::shared_ptr<sensor_msgs::PointCloud2>>;
 using PointCloudProcessor_PostProcessingFn = std::function<void(PointCloudProcessor_OutputType)>;
@@ -44,6 +45,7 @@ class PointCloudProcessor {
                         uint32_t min_range, uint32_t max_range, int rows_step,
                         const std::string& mask_path,
                         ScanToCloudFn scan_to_cloud_fn_,
+                        PointCloudProcessor_PreProcessingFn pre_processing_fn_,
                         PointCloudProcessor_PostProcessingFn post_processing_fn_)
         : frame(frame_id),
           pixel_shift_by_row(info.format.pixel_shift_by_row),
@@ -52,6 +54,7 @@ class PointCloudProcessor {
           min_range_(min_range), max_range_(max_range),
           pc_msgs(get_n_returns(info)),
           scan_to_cloud_fn(scan_to_cloud_fn_),
+          pre_processing_fn(pre_processing_fn_),
           post_processing_fn(post_processing_fn_) {
         for (size_t i = 0; i < pc_msgs.size(); ++i)
             pc_msgs[i] = std::make_shared<sensor_msgs::PointCloud2>();
@@ -87,15 +90,18 @@ class PointCloudProcessor {
 
     void process(const ouster::LidarScan& lidar_scan, uint64_t scan_ts,
                  const ros::Time& msg_ts) {
+        
+        auto &scan = pre_processing_fn ? pre_processing_fn(lidar_scan) : lidar_scan;
+                
         for (int i = 0; i < static_cast<int>(pc_msgs.size()); ++i) {
             auto range_ch = static_cast<sensor::ChanField>(sensor::ChanField::RANGE + i);
-            auto range = lidar_scan.field<uint32_t>(range_ch);
+            auto range = scan.field<uint32_t>(range_ch);
             auto range_masked = mask.size() != 0 ? range * mask : range;
             ouster::cartesianT(points, range_masked, lut_direction, lut_offset,
                                min_range_, max_range_,
                                std::numeric_limits<float>::quiet_NaN());
 
-            scan_to_cloud_fn(cloud, points, scan_ts, lidar_scan, pixel_shift_by_row, i);
+            scan_to_cloud_fn(cloud, points, scan_ts, scan, pixel_shift_by_row, i);
 
             pcl_toROSMsg(cloud, *pc_msgs[i]);
             pc_msgs[i]->header.stamp = msg_ts;
@@ -112,11 +118,12 @@ class PointCloudProcessor {
                                      uint32_t min_range, uint32_t max_range,
                                      int rows_step, const std::string& mask_path,
                                      ScanToCloudFn scan_to_cloud_fn_,
+                                     PointCloudProcessor_PreProcessingFn pre_processing_fn,
                                      PointCloudProcessor_PostProcessingFn post_processing_fn) {
         auto handler = std::make_shared<PointCloudProcessor>(
             info, frame, apply_lidar_to_sensor_transform,
             min_range, max_range, rows_step, mask_path,
-            scan_to_cloud_fn_, post_processing_fn);
+            scan_to_cloud_fn_, pre_processing_fn, post_processing_fn);
 
         return [handler](const ouster::LidarScan& lidar_scan, uint64_t scan_ts,
                          const ros::Time& msg_ts) {
@@ -140,6 +147,7 @@ class PointCloudProcessor {
     uint32_t max_range_;
     PointCloudProcessor_OutputType pc_msgs;
     ScanToCloudFn scan_to_cloud_fn;
+    PointCloudProcessor_PreProcessingFn pre_processing_fn;
     PointCloudProcessor_PostProcessingFn post_processing_fn;
 
     ouster::img_t<uint32_t> mask;

--- a/src/point_cloud_processor_factory.h
+++ b/src/point_cloud_processor_factory.h
@@ -119,13 +119,14 @@ class PointCloudProcessorFactory {
         bool organized, bool destagger,
         uint32_t min_range, uint32_t max_range, int rows_step,
         const std::string& mask_path,
+        PointCloudProcessor_PreProcessingFn pre_processing_fn,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
         auto scan_to_cloud_fn = make_scan_to_cloud_fn<PointT>(
             info, organized, destagger, rows_step);
         return PointCloudProcessor<PointT>::create(
             info, frame, apply_lidar_to_sensor_transform,
             min_range, max_range, rows_step, mask_path,
-            scan_to_cloud_fn, post_processing_fn);
+            scan_to_cloud_fn, pre_processing_fn, post_processing_fn);
     }
 
    public:
@@ -146,6 +147,7 @@ class PointCloudProcessorFactory {
         bool organized, bool destagger,
         uint32_t min_range, uint32_t max_range, int rows_step,
         const std::string& mask_path,
+        PointCloudProcessor_PreProcessingFn pre_processing_fn,
         PointCloudProcessor_PostProcessingFn post_processing_fn) {
         if (point_type == "native") {
             switch (info.format.udp_profile_lidar) {
@@ -153,30 +155,30 @@ class PointCloudProcessorFactory {
                     return make_point_cloud_processor<Point_LEGACY>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        mask_path, post_processing_fn);
+                        mask_path, pre_processing_fn, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16_DUAL:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        mask_path, post_processing_fn);
+                        mask_path, pre_processing_fn, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG19_RFL8_SIG16_NIR16:
                     return make_point_cloud_processor<
                         Point_RNG19_RFL8_SIG16_NIR16>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        mask_path, post_processing_fn);
+                        mask_path, pre_processing_fn, post_processing_fn);
                 case UDPProfileLidar::PROFILE_RNG15_RFL8_NIR8:
                     return make_point_cloud_processor<Point_RNG15_RFL8_NIR8>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        mask_path, post_processing_fn);
+                        mask_path, pre_processing_fn, post_processing_fn);
                 case UDPProfileLidar::PROFILE_FUSA_RNG15_RFL8_NIR8_DUAL:
                     return make_point_cloud_processor<
                         Point_FUSA_RNG15_RFL8_NIR8_DUAL>(
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
-                        mask_path, post_processing_fn);
+                        mask_path, pre_processing_fn, post_processing_fn);
                 default:
                     // TODO: implement fallback?
                     throw std::runtime_error("unsupported udp_profile_lidar");
@@ -185,27 +187,27 @@ class PointCloudProcessorFactory {
             return make_point_cloud_processor<pcl::PointXYZ>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                mask_path, post_processing_fn);
+                mask_path, pre_processing_fn, post_processing_fn);
         } else if (point_type == "xyzi") {
             return make_point_cloud_processor<pcl::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                mask_path, post_processing_fn);
+                mask_path, pre_processing_fn, post_processing_fn);
         } else if (point_type == "o_xyzi") {
             return make_point_cloud_processor<ouster_ros::PointXYZI>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                mask_path, post_processing_fn);
+                mask_path, pre_processing_fn, post_processing_fn);
         } else if (point_type == "xyzir") {
             return make_point_cloud_processor<PointXYZIR>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                mask_path, post_processing_fn);
+                mask_path, pre_processing_fn, post_processing_fn);
         } else if (point_type == "original") {
             return make_point_cloud_processor<ouster_ros::Point>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
-                mask_path, post_processing_fn);
+                mask_path, pre_processing_fn, post_processing_fn);
         }
 
         throw std::runtime_error(


### PR DESCRIPTION
## Summary of Changes
Add a preprocessing function similar to the postprocessing function which allows for modification of the LidarScan before cloud generation.

This enables advanced filtering operations to be performed fairly efficiently. For example, this could be used to implement the masking functionality although I think that the current implementation is likely more efficient. 


## Validation
With an empty preprocessing function (as default in this pr), the cloud generated as normal.
The following contrived example will set the intensity for points whose range is between 2m and 4m to zero:
```cpp
[](const ouster::LidarScan& lidar_scan)-> const ouster::LidarScan {
    auto scan = lidar_scan;
    auto range = lidar_scan.field<uint32_t>(sensor::ChanField::RANGE);
    auto intensity = scan.field<uint16_t>(sensor::ChanField::SIGNAL);
    intensity = (range.array() > 2000 && range.array() < 4000).select(0, intensity);
    return scan;
},
```