### PR TITLE
fix: include <optional> in headers to resolve std::optional build errors

### DIFF
--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -17,6 +17,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 #include "lock_free_ring_buffer.h"
+#include <optional>
 #include <thread>
 #include <chrono>
 

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <thread>
+#include <optional>
 
 #include "ouster_ros/GetConfig.h"
 #include "ouster_ros/SetConfig.h"


### PR DESCRIPTION
## Related Issues & PRs
fix: include <optional> in headers to resolve std::optional build errors
<img width="2448" height="2050" alt="image" src="https://github.com/user-attachments/assets/2bd22ab5-457b-44ba-a68a-1370424ce186" />



## Summary of Changes
Add #include <optional> to os_sensor_nodelet.h and lidar_packet_handler.h to fix std::optional' not found and related compile errors.

