### PR TITLE
Add missing nodelet include in lidar_packet_handler.h

### DIFF
--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -15,6 +15,7 @@
 // clang-format on
 
 #include <pcl_conversions/pcl_conversions.h>
+#include <nodelet/nodelet.h>
 
 #include "lock_free_ring_buffer.h"
 #include <optional>


### PR DESCRIPTION
The file uses NODELET_WARN/DEBUG multiple places.
This led to some build error in certain cases for me.

## Related Issues & PRs

## Summary of Changes

## Validation
