### PR TITLE
cmake: Use --whole-archive to export ouster_client symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 add_library(ouster_ros src/os_ros.cpp)
 target_link_libraries(ouster_ros
   PUBLIC ${catkin_LIBRARIES} ouster_build OusterSDK::ouster_sensor pcl_common
-  PRIVATE ${OUSTER_TARGET_LINKS}
+    -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive
 )
 
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)


### PR DESCRIPTION
671fc0a fixes the double-free by removing --whole-archive and linking ${OUSTER_TARGET_LINKS} directly to each internal target (nodelets, tests). This works within the ouster_ros package, but breaks external downstream catkin packages.

Since ouster_client remains PRIVATE to ouster_ros, only symbols referenced by os_ros.cpp end up in libouster_ros.so — everything else is stripped by the linker. Downstream packages that <depend> on ouster_ros get libouster_ros.so via catkin but have no  way to access unreferenced ouster_client symbols (e.g. make_xyz_lut, sensor config APIs). The internal workaround of linking ${OUSTER_TARGET_LINKS} directly isn't available to external packages since ouster_client is a static library that isn't installed or exported.

this commit solves this by using --whole-archive as PUBLIC on ouster_ros only, so all ouster_client symbols are bundled into libouster_ros.so and visible to downstream consumers. The original double-free was caused by --whole-archive being applied to both ouster_ros and the nodelets, linking ouster_client twice into the same process. Applying it only to ouster_ros avoids this.

## Related Issues & PRs

## Summary of Changes

## Validation
External packages using ouster_client libs now builds