### PR TITLE
Restore whole-archive and use modern add compile definitions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+[unreleased]
+============
+* Restore ``whole-archive`` only on ouster_ros library to avoid double free corruption issue.
+  - The ``ouster_client`` library is now linked normally without whole-archive.
+* Use ``add_compile_definitions`` to set ``EIGEN_MPL2_ONLY`` instead of legacy ``add_definitions``.
 
 ouster_ros v0.14.0
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,11 @@
 Changelog
 =========
 
-[unreleased]
+[UNRELEASED]
 ============
 * Restore ``whole-archive`` only on ouster_ros library to avoid double free corruption issue.
   - The ``ouster_client`` library is now linked normally without whole-archive.
-* Use ``add_compile_definitions`` to set ``EIGEN_MPL2_ONLY`` instead of legacy ``add_definitions``.
+* Use ``add_compile_definitions`` instead of ``add_definitions`` to set the ``EIGEN_MPL2_ONLY`` flag.
 
 ouster_ros v0.14.0
 ==================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ include_directories(
   ${OpenCV_INCLUDE_DIRS})
 
 # use only MPL-licensed parts of eigen
-add_definitions(-DEIGEN_MPL2_ONLY)
+add_compile_definitions(EIGEN_MPL2_ONLY)
 
 set(NODELET_SRC
   src/os_sensor_nodelet_base.cpp
@@ -102,7 +102,7 @@ endif()
 add_library(ouster_ros src/os_ros.cpp)
 target_link_libraries(ouster_ros
   PUBLIC ${catkin_LIBRARIES} ouster_build OusterSDK::ouster_sensor pcl_common
-  PRIVATE ${OUSTER_TARGET_LINKS}
+  PRIVATE -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive # in future replace with $<LINK_LIBRARY:WHOLE_ARCHIVE:ouster_client> (min cmake 3.24)
 )
 
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
@@ -112,7 +112,6 @@ add_library(${PROJECT_NAME}_nodelets ${NODELET_SRC})
 target_link_libraries(
   ${PROJECT_NAME}_nodelets
   ouster_ros
-  ${OUSTER_TARGET_LINKS}  # Add this to ensure ouster_client is linked
   ${catkin_LIBRARIES}
   ${OpenCV_LIBRARIES}
 )
@@ -128,8 +127,11 @@ if(CATKIN_ENABLE_TESTING)
     tests/point_transform_test.cpp
     tests/point_cloud_compose_test.cpp
   )
-  target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES}
-    ouster_build pcl_common ${OUSTER_TARGET_LINKS})
+  target_link_libraries(${PROJECT_NAME}_test
+    ouster_ros
+    ${catkin_LIBRARIES}
+    ouster_build
+    pcl_common)
 endif()
 
 # ==== Install ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,9 @@ add_library(ouster_ros src/os_ros.cpp)
 
 # in future replace with $<LINK_LIBRARY:WHOLE_ARCHIVE,${OUSTER_TARGET_LINKS}> (min cmake 3.24) 
 if (APPLE)
-  set(WHOLE_ARCHIVE_LINK -Wl,-force-load,$<TARGET_FILE:ouster_client>)
+  set(WHOLE_ARCHIVE_LINK -Wl,-force_load,$<TARGET_FILE:ouster_client>)
   if (BUILD_PCAP)
-    list(APPEND WHOLE_ARCHIVE_LINK -Wl,-force-load,$<TARGET_FILE:ouster_pcap>)
+    list(APPEND WHOLE_ARCHIVE_LINK -Wl,-force_load,$<TARGET_FILE:ouster_pcap>)
   endif()
 else()
   set(WHOLE_ARCHIVE_LINK -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive)
@@ -134,6 +134,7 @@ add_library(${PROJECT_NAME}_nodelets ${NODELET_SRC})
 target_link_libraries(
   ${PROJECT_NAME}_nodelets
   ouster_ros
+  ${OpenCV_LIBS}
 )
 add_dependencies(${PROJECT_NAME}_nodelets ${PROJECT_NAME}_gencpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ find_package(tf2_eigen REQUIRED)
 find_package(CURL REQUIRED)
 find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
+# Use OpenCV libs varaible
+if (NOT OpenCV_LIBS)
+  set(OpenCV_LIBS ${OpenCV_LIBRARIES})
+endif()
 
 find_package(
   catkin REQUIRED
@@ -37,11 +41,12 @@ add_service_files(FILES GetConfig.srv SetConfig.srv GetMetadata.srv)
 generate_messages(DEPENDENCIES std_msgs sensor_msgs geometry_msgs)
 
 set(_ouster_ros_INCLUDE_DIRS
-  "include;"
-  "ouster-sdk/ouster_sensor/include;"
-  "ouster-sdk/ouster_client/include;"
-  "ouster-sdk/ouster_client/include/optional-lite;"
-  "ouster-sdk/ouster_pcap/include")
+  include
+  ouster-sdk/ouster_sensor/include
+  ouster-sdk/ouster_client/include
+  ouster-sdk/ouster_pcap/include
+  ouster-sdk/ouster_client/include/optional-lite
+)
 
 catkin_package(
   INCLUDE_DIRS
@@ -101,8 +106,14 @@ endif()
 
 add_library(ouster_ros src/os_ros.cpp)
 target_link_libraries(ouster_ros
-  PUBLIC ${catkin_LIBRARIES} ouster_build OusterSDK::ouster_sensor pcl_common
-  PRIVATE -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive # in future replace with $<LINK_LIBRARY:WHOLE_ARCHIVE:ouster_client> (min cmake 3.24)
+  PUBLIC
+    pcl_common
+    ouster_build
+    OusterSDK::ouster_sensor
+    ${catkin_LIBRARIES}
+  PRIVATE
+    -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive # in future replace with $<LINK_LIBRARY:WHOLE_ARCHIVE:ouster_client> (min cmake 3.24)
+    ${OpenCV_LIBS}
 )
 
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
@@ -112,8 +123,6 @@ add_library(${PROJECT_NAME}_nodelets ${NODELET_SRC})
 target_link_libraries(
   ${PROJECT_NAME}_nodelets
   ouster_ros
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBRARIES}
 )
 add_dependencies(${PROJECT_NAME}_nodelets ${PROJECT_NAME}_gencpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ target_link_libraries(
   ${PROJECT_NAME}_nodelets
   ouster_ros
   ${OpenCV_LIBS}
+  ${catkin_LIBRARIES}
 )
 add_dependencies(${PROJECT_NAME}_nodelets ${PROJECT_NAME}_gencpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,17 @@ if (BUILD_PCAP)
 endif()
 
 add_library(ouster_ros src/os_ros.cpp)
+
+# in future replace with $<LINK_LIBRARY:WHOLE_ARCHIVE,${OUSTER_TARGET_LINKS}> (min cmake 3.24) 
+if (APPLE)
+  set(WHOLE_ARCHIVE_LINK -Wl,-force-load,$<TARGET_FILE:ouster_client>)
+  if (BUILD_PCAP)
+    list(APPEND WHOLE_ARCHIVE_LINK -Wl,-force-load,$<TARGET_FILE:ouster_pcap>)
+  endif()
+else()
+  set(WHOLE_ARCHIVE_LINK -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive)
+endif()
+
 target_link_libraries(ouster_ros
   PUBLIC
     pcl_common
@@ -112,7 +123,7 @@ target_link_libraries(ouster_ros
     OusterSDK::ouster_sensor
     ${catkin_LIBRARIES}
   PRIVATE
-    -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive # in future replace with $<LINK_LIBRARY:WHOLE_ARCHIVE:ouster_client> (min cmake 3.24)
+    ${WHOLE_ARCHIVE_LINK}
     ${OpenCV_LIBS}
 )
 

--- a/src/lidar_packet_handler.h
+++ b/src/lidar_packet_handler.h
@@ -19,8 +19,12 @@
 
 #include "lock_free_ring_buffer.h"
 #include <optional>
-#include <thread>
 #include <chrono>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <vector>
+#include <string>
 
 namespace {
 

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -14,11 +14,12 @@
 #include "ouster_ros/os_ros.h"
 // clang-format on
 
-#include <ouster/client.h>
 #include <string>
 #include <thread>
 #include <atomic>
 #include <optional>
+
+#include <ouster/client.h>
 
 #include "ouster_ros/GetConfig.h"
 #include "ouster_ros/SetConfig.h"


### PR DESCRIPTION
## Related Issues & PRs
Includes #518
Related #520

## Summary of Changes
* Restore whole-archive but only for one node
* Use modern add compile definitions

## Validation
Build passes