### PR TITLE
Fix macOS linker flag and link OpenCV in CMakeLists,txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,9 @@ add_library(ouster_ros src/os_ros.cpp)
 
 # in future replace with $<LINK_LIBRARY:WHOLE_ARCHIVE,${OUSTER_TARGET_LINKS}> (min cmake 3.24) 
 if (APPLE)
-  set(WHOLE_ARCHIVE_LINK -Wl,-force-load,$<TARGET_FILE:ouster_client>)
+  set(WHOLE_ARCHIVE_LINK -Wl,-force_load,$<TARGET_FILE:ouster_client>)
   if (BUILD_PCAP)
-    list(APPEND WHOLE_ARCHIVE_LINK -Wl,-force-load,$<TARGET_FILE:ouster_pcap>)
+    list(APPEND WHOLE_ARCHIVE_LINK -Wl,-force_load,$<TARGET_FILE:ouster_pcap>)
   endif()
 else()
   set(WHOLE_ARCHIVE_LINK -Wl,--whole-archive ${OUSTER_TARGET_LINKS} -Wl,--no-whole-archive)
@@ -134,6 +134,7 @@ add_library(${PROJECT_NAME}_nodelets ${NODELET_SRC})
 target_link_libraries(
   ${PROJECT_NAME}_nodelets
   ouster_ros
+  ${OpenCV_LIBS}
 )
 add_dependencies(${PROJECT_NAME}_nodelets ${PROJECT_NAME}_gencpp)
 


### PR DESCRIPTION
## Related Issues & PRs
https://github.com/ouster-lidar/ouster-ros/pull/521

## Summary of Changes
This PR fixes two build issues on macOS:

- The linker was invoked with the wrong flag `-force-load` (hyphen) which ld on macOS rejects. It is now `-force_load` (underscore) in the Apple branch of CMakeLists.txt.

- The nodelets target was not explicitly linked against OpenCV, causing undefined cv:: symbols when building libouster_ros_nodelets.dylib. `${OpenCV_LIBS}` is now added to the nodelets target.

Files changed:
`CMakeLists.txt`

## Validation

1. before implement fixes in MacOS, result of `catkin_make --cmake-args -DCMAKE_BUILD_TYPE=Release`:

```sh
[ 93%] Linking CXX shared library /Users/achua/ouster_mac_ws/devel/lib/libouster_ros.dylib
ld: unknown option: -force-load
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [ouster-ros/CMakeFiles/ouster_ros.dir/build.make:193: /Users/achua/ouster_mac_ws/devel/lib/libouster_ros.dylib] Error 1
make[1]: *** [CMakeFiles/Makefile2:2327: ouster-ros/CMakeFiles/ouster_ros.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
Invoking "make -j12 -l12" failed
```

2. before implement linked  not explicitly linked against OpenCV, result of `catkin_make --cmake-args -DCMAKE_BUILD_TYPE=Release`:

```sh
Undefined symbols for architecture arm64:
  "cv::Mat::Mat(int, int, int, void*, unsigned long)", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      void cv::cv2eigen<int>(cv::Mat const&, Eigen::Matrix<int, -1, -1, 0, -1, -1>&) in os_driver_nodelet.cpp.o
  "cv::Mat::Mat()", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
      void cv::cv2eigen<int>(cv::Mat const&, Eigen::Matrix<int, -1, -1, 0, -1, -1>&) in os_driver_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
  "cv::Mat::~Mat()", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      cv::MatExpr::~MatExpr() in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      cv::MatExpr::~MatExpr() in os_image_nodelet.cpp.o
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
      void cv::cv2eigen<int>(cv::Mat const&, Eigen::Matrix<int, -1, -1, 0, -1, -1>&) in os_driver_nodelet.cpp.o
      cv::MatExpr::~MatExpr() in os_driver_nodelet.cpp.o
      ...
  "cv::Mat::operator=(cv::Mat const&)", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
  "cv::imread(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, int)", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
  "cv::resize(cv::_InputArray const&, cv::_OutputArray const&, cv::Size_<int>, double, double, int)", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
  "cv::transpose(cv::_InputArray const&, cv::_OutputArray const&)", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      void cv::cv2eigen<int>(cv::Mat const&, Eigen::Matrix<int, -1, -1, 0, -1, -1>&) in os_driver_nodelet.cpp.o
  "cv::Mat::t() const", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      void cv::cv2eigen<int>(cv::Mat const&, Eigen::Matrix<int, -1, -1, 0, -1, -1>&) in os_driver_nodelet.cpp.o
  "cv::Mat::empty() const", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_driver_nodelet.cpp.o
  "cv::Mat::convertTo(cv::_OutputArray const&, int, double, double) const", referenced from:
      Eigen::Array<unsigned int, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned int>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_cloud_nodelet.cpp.o
      Eigen::Array<unsigned short, -1, -1, 1, -1, -1> ouster_ros::impl::load_mask<unsigned short>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long, unsigned long) in os_image_nodelet.cpp.o
      void cv::cv2eigen<int>(cv::Mat const&, Eigen::Matrix<int, -1, -1, 0, -1, -1>&) in os_driver_nodelet.cpp.o
ld: symbol(s) not found for architecture arm64
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/build.make:219: /Users/achua/ouster_mac_ws/devel/lib/libouster_ros_nodelets.dylib] Error 1
make[1]: *** [CMakeFiles/Makefile2:2358: ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
Invoking "make -j12 -l12" failed
```

### Result after fixing:

1. compile result in MacOS
```sh
Base path: /Users/achua/ouster_mac_ws
Source space: /Users/achua/ouster_mac_ws/src
Build space: /Users/achua/ouster_mac_ws/build
Devel space: /Users/achua/ouster_mac_ws/devel
Install space: /Users/achua/ouster_mac_ws/install
####
#### Running command: "make cmake_check_build_system" in "/Users/achua/ouster_mac_ws/build"
####
-- Using CATKIN_DEVEL_PREFIX: /Users/achua/ouster_mac_ws/devel
-- Using CMAKE_PREFIX_PATH: /opt/homebrew/anaconda3/envs/noetic
-- This workspace overlays: /opt/homebrew/anaconda3/envs/noetic
-- Using PYTHON_EXECUTABLE: /opt/homebrew/anaconda3/envs/noetic/bin/python3.9
-- Using default Python package layout
-- Using empy: /opt/homebrew/anaconda3/envs/noetic/lib/python3.9/site-packages/em.py
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /Users/achua/ouster_mac_ws/build/test_results
-- Found gtest: gtests will be built
-- Using Python nosetests: /opt/homebrew/anaconda3/envs/noetic/bin/nosetests-3.9
-- catkin 0.8.10
-- BUILD_SHARED_LIBS is on
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 1 packages in topological order:
-- ~~  - ouster_ros
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin package: 'ouster_ros'
-- ==> add_subdirectory(ouster-ros)
-- Eigen found (include: /opt/homebrew/anaconda3/envs/noetic/include/eigen3, version: 3.4.0)
-- Found Boost: /opt/homebrew/anaconda3/envs/noetic/lib/cmake/Boost-1.78.0/BoostConfig.cmake (found suitable version "1.78.0", minimum required is "1.65.0") found components: system filesystem date_time iostreams 
-- looking for PCL_COMMON
-- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
-- Found Boost: /opt/homebrew/anaconda3/envs/noetic/lib/cmake/Boost-1.78.0/BoostConfig.cmake (found version "1.78.0")  
-- ouster_ros: 2 messages, 3 services
-- Using OusterSDK version from VERSION file: 0.16.1
-- Configuring done (3.5s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/achua/ouster_mac_ws/build
####
#### Running command: "make -j12 -l12" in "/Users/achua/ouster_mac_ws/build"
####
[  0%] Built target std_msgs_generate_messages_cpp
[  0%] Built target geometry_msgs_generate_messages_py
[  0%] Built target geometry_msgs_generate_messages_cpp
[  0%] Built target sensor_msgs_generate_messages_py
[  0%] Built target sensor_msgs_generate_messages_cpp
[  0%] Built target geometry_msgs_generate_messages_eus
[  0%] Built target _ouster_ros_generate_messages_check_deps_GetMetadata
[  0%] Built target _ouster_ros_generate_messages_check_deps_GetConfig
[  0%] Built target std_msgs_generate_messages_py
[  0%] Built target geometry_msgs_generate_messages_lisp
[  0%] Built target _ouster_ros_generate_messages_check_deps_PacketMsg
[  0%] Built target sensor_msgs_generate_messages_lisp
[  0%] Built target sensor_msgs_generate_messages_eus
[  0%] Built target _ouster_ros_generate_messages_check_deps_Telemetry
[  0%] Built target std_msgs_generate_messages_lisp
[  0%] Built target std_msgs_generate_messages_eus
[  0%] Built target geometry_msgs_generate_messages_nodejs
[  0%] Built target _ouster_ros_generate_messages_check_deps_SetConfig
[  0%] Built target sensor_msgs_generate_messages_nodejs
[  9%] Built target nmea
[  9%] Built target std_msgs_generate_messages_nodejs
Generating build info header
[ 15%] Built target ouster_ros_generate_messages_cpp
[ 20%] Built target ouster_ros_generate_messages_eus
[ 30%] Built target ouster_ros_generate_messages_lisp
[ 34%] Built target ouster_ros_generate_messages_py
[ 39%] Built target ouster_ros_generate_messages_nodejs
[ 39%] Built target ouster_ros_gencpp
[ 39%] Built target ouster_generate_header
[ 39%] Built target ouster_ros_generate_messages
[ 83%] Built target ouster_client
[ 91%] Built target ouster_sensor
[ 93%] Built target ouster_ros
[ 94%] Building CXX object ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/src/os_sensor_nodelet_base.cpp.o
[ 95%] Building CXX object ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/src/os_sensor_nodelet.cpp.o
[ 95%] Building CXX object ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/src/os_replay_nodelet.cpp.o
[ 96%] Building CXX object ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/src/os_cloud_nodelet.cpp.o
[ 97%] Building CXX object ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/src/os_driver_nodelet.cpp.o
[ 98%] Building CXX object ouster-ros/CMakeFiles/ouster_ros_nodelets.dir/src/os_image_nodelet.cpp.o
In file included from In file included from In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_driver_nodelet.cpp/Users/achua/ouster_mac_ws/src/ouster-ros/src/os_image_nodelet.cpp/Users/achua/ouster_mac_ws/src/ouster-ros/src/os_cloud_nodelet.cpp::12:
:In file included from 13/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_ros.h17::
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_ros.h::
3030:
:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_point.h/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_ros.h::/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_point.h30:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_point.h57::1257:: 12:warning: : 57:12warning: : 'const' type qualifier on return type has no effect [-Wignored-qualifiers]warning: 
'const' type qualifier on return type has no effect [-Wignored-qualifiers]'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {    inline const auto as_tuple() const {
    inline const auto as_tuple() const {
           ^~~~~~           ^~~~~~
           ^~~~~~
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_sensor_nodelet.cpp:12:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_ros.h:30:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_point.h:57:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_cloud_nodelet.cpp:27:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_processor.h:18:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_compose.h:7:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:81:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_driver_nodelet.cpp:24:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_processor.h:18:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_compose.h:7:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:81:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:177:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:177:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:257:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:257:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:333:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:333:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:433:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:433:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:523:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:523:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:601:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:601:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:682:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/sensor_point_types.h:682:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_cloud_nodelet.cpp:27:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_processor.h:18:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_compose.h:8:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/common_point_types.h:51:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/common_point_types.h:91:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_driver_nodelet.cpp:24:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_processor.h:18:
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/point_cloud_compose.h:8:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/common_point_types.h:51:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/common_point_types.h:91:12: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
    inline const auto as_tuple() const {
           ^~~~~~
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_image_nodelet.cpp:17:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_ros.h:165:25: warning: implicit conversion from 'unsigned long long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Wimplicit-const-int-float-conversion]
    if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
                      ~ ^~~~~~~~~~
/opt/homebrew/anaconda3/envs/noetic/lib/clang/16/include/limits.h:105:43: note: expanded from macro 'ULLONG_MAX'
#define ULLONG_MAX (__LONG_LONG_MAX__*2ULL+1ULL)
                    ~~~~~~~~~~~~~~~~~~~~~~^~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/src/lidar_packet_handler.h:231:22: note: in instantiation of function template specialization 'ouster_ros::impl::ulround<double>' requested here
        return impl::ulround(interpolated_value);
                     ^
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_cloud_nodelet.cpp:12:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_ros.h:165:25: warning: implicit conversion from 'unsigned long long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Wimplicit-const-int-float-conversion]
    if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
                      ~ ^~~~~~~~~~
/opt/homebrew/anaconda3/envs/noetic/lib/clang/16/include/limits.h:105:43: note: expanded from macro 'ULLONG_MAX'
#define ULLONG_MAX (__LONG_LONG_MAX__*2ULL+1ULL)
                    ~~~~~~~~~~~~~~~~~~~~~~^~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/src/lidar_packet_handler.h:231:22: note: in instantiation of function template specialization 'ouster_ros::impl::ulround<double>' requested here
        return impl::ulround(interpolated_value);
                     ^
In file included from /Users/achua/ouster_mac_ws/src/ouster-ros/src/os_driver_nodelet.cpp:13:
/Users/achua/ouster_mac_ws/src/ouster-ros/include/ouster_ros/os_ros.h:165:25: warning: implicit conversion from 'unsigned long long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Wimplicit-const-int-float-conversion]
    if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
                      ~ ^~~~~~~~~~
/opt/homebrew/anaconda3/envs/noetic/lib/clang/16/include/limits.h:105:43: note: expanded from macro 'ULLONG_MAX'
#define ULLONG_MAX (__LONG_LONG_MAX__*2ULL+1ULL)
                    ~~~~~~~~~~~~~~~~~~~~~~^~~~~
/Users/achua/ouster_mac_ws/src/ouster-ros/src/lidar_packet_handler.h:231:22: note: in instantiation of function template specialization 'ouster_ros::impl::ulround<double>' requested here
        return impl::ulround(interpolated_value);
                     ^
1 warning generated.
2 warnings generated.
12 warnings generated.
12 warnings generated.
[100%] Linking CXX shared library /Users/achua/ouster_mac_ws/devel/lib/libouster_ros_nodelets.dylib
ld: warning: -pie being ignored. It is only used when linking a main executable
[100%] Built target ouster_ros_nodelets
```

2. Compile in Ubuntu OS

3. Test result: `roslaunch ouster_ros sensor.launch sensor_hostname:=<hostname>`
  - in MacOS
    - <img width="1895" height="1039" alt="Screenshot 2026-03-12 at 4 44 56 PM" src="https://github.com/user-attachments/assets/ed843b82-9921-4328-84d4-dca65916474c" />



  - In Ubuntu
    - <img width="3813" height="2138" alt="Screenshot from 2026-03-12 15-28-06" src="https://github.com/user-attachments/assets/a7236630-f108-4fb0-aff5-a13bb42dcc9e" />

