### PR TITLE
os_sensor_nodelet: Fix sensor fw version check

### DIFF
--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -691,7 +691,7 @@ bool OusterSensor::configure_sensor(const std::string& hostname,
 
 void OusterSensor::populate_metadata_defaults(
     SensorInfo& info, LidarMode specified_lidar_mode) {
-    ouster::sdk::core::Version v = ouster::sdk::core::version_from_string(info.fw_rev);
+    ouster::sdk::core::Version v = ouster::sdk::core::version_from_string(info.image_rev);
     if (v == ouster::sdk::core::INVALID_VERSION)
         NODELET_WARN(
             "Unknown sensor firmware version; output may not be reliable");


### PR DESCRIPTION
Just saw a version warning from this. 
'fw_rev' just gives a hash, while 'image_rev' has the version string expected by ouster::sdk::core::version_from_string


https://github.com/ouster-lidar/ouster-ros/blob/24f89d10425edd0b6422397ad4bb734810e63648/src/os_sensor_nodelet_base.cpp#L50 uses image_rev, so I suppose it was just forgotten in os_sensor_nodelet. 

## Related Issues & PRs

## Summary of Changes

## Validation
