### PR TITLE
Add ROS launch support for sensor time-sync and min_distance parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Changelog
 * Restore ``whole-archive`` only on ouster_ros library to avoid double free corruption issue.
   - The ``ouster_client`` library is now linked normally without whole-archive.
 * Use ``add_compile_definitions`` instead of ``add_definitions`` to set the ``EIGEN_MPL2_ONLY`` flag.
+* Add launch file and nodelet support for additional sensor configuration parameters (time
+  synchronization, multipurpose IO, and minimum reported range on FW 3.1+):
+  - ``multipurpose_io_mode``
+  - ``nmea_in_polarity``, ``nmea_ignore_valid_char``, ``nmea_baud_rate``, ``nmea_leap_seconds``
+  - ``sync_pulse_in_polarity``, ``sync_pulse_out_polarity``, ``sync_pulse_out_frequency``,
+    ``sync_pulse_out_angle``, ``sync_pulse_out_pulse_width``
+  - ``min_distance`` (sensor field ``min_range_threshold_cm``)
 
 ouster_ros v0.14.0
 ==================

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -60,6 +60,67 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+
+  <arg name="multipurpose_io_mode" default="OFF"
+    doc="Configure the mode of the MULTIPURPOSE_IO pin; possible values: {
+    OFF,
+    OUTPUT_FROM_INTERNAL_OSC,
+    OUTPUT_FROM_SYNC_PULSE_IN,
+    OUTPUT_FROM_PTP_1588,
+    INPUT_NMEA_UART,
+    OUTPUT_FROM_ENCODER_ANGLE
+    }"/>
+
+  <arg name="nmea_in_polarity" default="ACTIVE_HIGH"
+    doc="Set the polarity of NMEA UART input $GPRMC messages,
+      Use ACTIVE_HIGH if UART is active high, idle low, and start bit is after a falling edge.;
+      possible values: {
+        ACTIVE_HIGH,
+        ACTIVE_LOW
+    }"/>
+  
+  <arg name="nmea_ignore_valid_char" default="false"
+    doc="Set false if NMEA UART input $GPRMC messages should be ignored if valid character is not set,
+      and true if messages should be used for time syncing regardless of the valid character."/>
+
+  <arg name="nmea_baud_rate" default="BAUD_9600"
+    doc="BAUD_9600 (default) or BAUD_115200 for the expected baud rate the sensor is attempting to decode for NMEA UART input $GPRMC messages;
+      possible values: {
+        BAUD_4800,
+        BAUD_9600
+    }"/>
+  
+  <arg name="nmea_leap_seconds" default="0"
+    doc="Set an integer number of leap seconds that will be added to the UDP timestamp when calculating seconds since 00:00:00 Thursday, 1 January 1970.
+      For Unix Epoch time, this should be set to 0."/>
+  
+  <arg name="sync_pulse_in_polarity" default="ACTIVE_HIGH"
+    doc="The polarity of SYNC_PULSE_IN input, which controls polarity of SYNC_PULSE_IN pin when timestamp_mode is set in TIME_FROM_SYNC_PULSE_IN;
+      possible values: {
+        ACTIVE_HIGH,
+        ACTIVE_LOW
+    }"/>
+
+  <arg name="sync_pulse_out_polarity" default="ACTIVE_HIGH"
+    doc="The polarity of SYNC_PULSE_OUT output, if the sensor is set as the master sensor used for time synchronization.;
+      possible values: {
+        ACTIVE_HIGH,
+        ACTIVE_LOW
+    }"/>
+  
+  <arg name="sync_pulse_out_frequency" default="1"
+    doc="The output SYNC_PULSE_OUT pulse rate in Hz. Valid inputs are integers >0 Hz,
+    but also limited by the criteria described in the Time Synchronization section of the Firmware User Manual."/>
+
+  <arg name="sync_pulse_out_angle" default="360"
+    doc="The angle in terms of degrees that the sensor traverses between each SYNC_PULSE_OUT pulse. 
+      E.g. a value of 180 means a sync pulse is sent out every 180° for a total of two pulses per revolution and angular frequency of 20 Hz;
+      values range [1, 360]"/>
+
+  <arg name="sync_pulse_out_pulse_width" default="10"
+    doc="The polarity of SYNC_PULSE_OUT output, if the sensor is set as the master sensor used for time synchronization.
+      Output SYNC_PULSE_OUT pulse width is in ms, increments in 1 ms. "/>
+
   <arg name="ptp_utc_tai_offset" default="-37.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
@@ -136,6 +197,10 @@
     NEAREST_TO_FARTHEST
     "/>
 
+  <!-- Only set this parameter when working with FW 3.1+ -->
+  <arg name="min_distance" default="0"
+    doc="minimum lidar distance to configure to sensor (cm); available options: {0, 30, 50}"/>
+
   <!-- Only set this parameter when working with FW 3.2+ -->
   <arg name="bloom_reduction_optimization" default=" "
     doc="level of bloom reduction optimization to apply on the sensor (FW3.2+); possible values:
@@ -194,6 +259,16 @@
       <param name="~/accel_fsr" type="str" value="$(arg accel_fsr)"/>
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/multipurpose_io_mode" type="str" value="$(arg multipurpose_io_mode)"/>
+      <param name="~/nmea_in_polarity" type="str" value="$(arg nmea_in_polarity)"/>
+      <param name="~/nmea_ignore_valid_char" type="bool" value="$(arg nmea_ignore_valid_char)"/>
+      <param name="~/nmea_baud_rate" type="str" value="$(arg nmea_baud_rate)"/>
+      <param name="~/nmea_leap_seconds" type="int" value="$(arg nmea_leap_seconds)"/>
+      <param name="~/sync_pulse_in_polarity" type="str" value="$(arg sync_pulse_in_polarity)"/>
+      <param name="~/sync_pulse_out_polarity" type="str" value="$(arg sync_pulse_out_polarity)"/>
+      <param name="~/sync_pulse_out_frequency" type="int" value="$(arg sync_pulse_out_frequency)"/>
+      <param name="~/sync_pulse_out_angle" type="int" value="$(arg sync_pulse_out_angle)"/>
+      <param name="~/sync_pulse_out_pulse_width" type="int" value="$(arg sync_pulse_out_pulse_width)"/>
       <param name="~/ptp_utc_tai_offset" type="double"
         value="$(arg ptp_utc_tai_offset)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
@@ -223,6 +298,7 @@
              value="$(arg max_failed_reconnect_attempts)"/>
       <param name="~/organized" value="$(arg organized)"/>
       <param name="~/destagger" value="$(arg destagger)"/>
+      <param name="~/min_distance" value="$(arg min_distance)"/>
       <param name="~/min_range" value="$(arg min_range)"/>
       <param name="~/max_range" value="$(arg max_range)"/>
       <param name="~/v_reduction" value="$(arg v_reduction)"/>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -199,7 +199,10 @@
 
   <!-- Only set this parameter when working with FW 3.1+ -->
   <arg name="min_distance" default="0"
-    doc="minimum lidar distance to configure to sensor (cm); available options: {0, 30, 50}"/>
+    doc="to change the sensor’s minimum reported range (cm);
+    available options (FW3.1+): {0, 30}
+    available options (FW3.2+): {0, 30, 50}"
+     />
 
   <!-- Only set this parameter when working with FW 3.2+ -->
   <arg name="bloom_reduction_optimization" default=" "

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -197,7 +197,7 @@
     "/>
 
   <!-- Only set this parameter when working with FW 3.1+ -->
-  <arg name="min_distance" default="0"
+  <arg name="min_distance" default="-1"
     doc="to change the sensor’s minimum reported range (cm);
     available options (FW3.1+): {0, 30}
     available options (FW3.2+): {0, 30, 50}"

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -70,15 +70,15 @@
     OUTPUT_FROM_PTP_1588,
     OUTPUT_FROM_ENCODER_ANGLE
     }"/>
-
+ 
   <arg name="nmea_in_polarity" default="ACTIVE_HIGH"
-    doc="Set the polarity of NMEA UART input $GPRMC messages,
-      Use ACTIVE_HIGH if UART is active high, idle low, and start bit is after a falling edge.;
+    doc="Set the polarity of NMEA UART input $GPRMC messages.
+      Use ACTIVE_HIGH if UART is active high, idle low, and start bit is after a falling edge.
       possible values: {
         ACTIVE_HIGH,
         ACTIVE_LOW
     }"/>
-  
+   
   <arg name="nmea_ignore_valid_char" default="false"
     doc="Set false if NMEA UART input $GPRMC messages should be ignored if valid character is not set,
       and true if messages should be used for time syncing regardless of the valid character."/>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -64,10 +64,10 @@
   <arg name="multipurpose_io_mode" default="OFF"
     doc="Configure the mode of the MULTIPURPOSE_IO pin; possible values: {
     OFF,
+    INPUT_NMEA_UART,
     OUTPUT_FROM_INTERNAL_OSC,
     OUTPUT_FROM_SYNC_PULSE_IN,
     OUTPUT_FROM_PTP_1588,
-    INPUT_NMEA_UART,
     OUTPUT_FROM_ENCODER_ANGLE
     }"/>
 
@@ -84,10 +84,9 @@
       and true if messages should be used for time syncing regardless of the valid character."/>
 
   <arg name="nmea_baud_rate" default="BAUD_9600"
-    doc="BAUD_9600 (default) or BAUD_115200 for the expected baud rate the sensor is attempting to decode for NMEA UART input $GPRMC messages;
-      possible values: {
-        BAUD_4800,
-        BAUD_9600
+    doc="Expected baud for NMEA UART $GPRMC; possible values: {
+        BAUD_9600,
+        BAUD_115200
     }"/>
   
   <arg name="nmea_leap_seconds" default="0"
@@ -101,25 +100,25 @@
         ACTIVE_LOW
     }"/>
 
-  <arg name="sync_pulse_out_polarity" default="ACTIVE_HIGH"
-    doc="The polarity of SYNC_PULSE_OUT output, if the sensor is set as the master sensor used for time synchronization.;
+  <arg name="sync_pulse_out_polarity" default="ACTIVE_LOW"
+    doc="Polarity of SYNC_PULSE_OUT when this sensor is the time-sync master;
       possible values: {
         ACTIVE_HIGH,
         ACTIVE_LOW
     }"/>
   
-  <arg name="sync_pulse_out_frequency" default="1"
+  <arg name="sync_pulse_out_frequency" default="-1"
     doc="The output SYNC_PULSE_OUT pulse rate in Hz. Valid inputs are integers >0 Hz,
     but also limited by the criteria described in the Time Synchronization section of the Firmware User Manual."/>
 
-  <arg name="sync_pulse_out_angle" default="360"
+  <arg name="sync_pulse_out_angle" default="-1"
     doc="The angle in terms of degrees that the sensor traverses between each SYNC_PULSE_OUT pulse. 
       E.g. a value of 180 means a sync pulse is sent out every 180° for a total of two pulses per revolution and angular frequency of 20 Hz;
-      values range [1, 360]"/>
+      values range [0, 360], -1 is unset"/>
 
-  <arg name="sync_pulse_out_pulse_width" default="10"
+  <arg name="sync_pulse_out_pulse_width" default="-1"
     doc="The polarity of SYNC_PULSE_OUT output, if the sensor is set as the master sensor used for time synchronization.
-      Output SYNC_PULSE_OUT pulse width is in ms, increments in 1 ms. "/>
+      Output SYNC_PULSE_OUT pulse width is in ms, increments in 1 ms. -1 is unset"/>
 
   <arg name="ptp_utc_tai_offset" default="-37.0"
     doc="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -453,6 +453,112 @@ void OusterSensor::parse_udp_profile_imu_and_settings(SensorConfig& config) {
     }
 }
 
+void OusterSensor::parse_multipurpose_io_mode(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto arg = nh.param("multipurpose_io_mode", std::string{});
+    if (!is_arg_set(arg)) return;
+
+    auto mode = ouster::sdk::core::multipurpose_io_mode_of_string(arg);
+    if (!mode) {
+        auto error_msg = "Invalid multipurpose io mode: " + arg;
+        NODELET_FATAL_STREAM(error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.multipurpose_io_mode = mode.value();
+}
+
+void OusterSensor::parse_nmea_in_polarity(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto arg = nh.param("nmea_in_polarity", std::string{});
+    if (!is_arg_set(arg)) return;
+
+    auto pol = ouster::sdk::core::polarity_of_string(arg);
+    if (!pol) {
+        auto error_msg = "Invalid nmea_in_polarity: " + arg;
+        NODELET_FATAL_STREAM(error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.nmea_in_polarity = pol.value();
+}
+
+void OusterSensor::parse_nmea_ignore_valid_char(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    config.nmea_ignore_valid_char = nh.param("nmea_ignore_valid_char", false);
+}
+
+void OusterSensor::parse_nmea_baud_rate(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto arg = nh.param("nmea_baud_rate", std::string{});
+    if (!is_arg_set(arg)) return;
+
+    auto rate = ouster::sdk::core::nmea_baud_rate_of_string(arg);
+    if (!rate) {
+        auto error_msg = "Invalid nmea_baud_rate: " + arg;
+        NODELET_FATAL_STREAM(error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.nmea_baud_rate = rate.value();
+}
+
+void OusterSensor::parse_nmea_leap_seconds(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto val = nh.param("nmea_leap_seconds", 0);
+    config.nmea_leap_seconds = val;
+}
+
+void OusterSensor::parse_sync_pulse_in_polarity(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto arg = nh.param("sync_pulse_in_polarity", std::string{});
+    if (!is_arg_set(arg)) return;
+
+    auto pol = ouster::sdk::core::polarity_of_string(arg);
+    if (!pol) {
+        auto error_msg = "Invalid sync_pulse_in_polarity: " + arg;
+        NODELET_FATAL_STREAM(error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.sync_pulse_in_polarity = pol.value();
+}
+
+void OusterSensor::parse_sync_pulse_out_polarity(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto arg = nh.param("sync_pulse_out_polarity", std::string{});
+    if (!is_arg_set(arg)) return;
+
+    auto pol = ouster::sdk::core::polarity_of_string(arg);
+    if (!pol) {
+        auto error_msg = "Invalid sync_pulse_out_polarity: " + arg;
+        NODELET_FATAL_STREAM(error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.sync_pulse_out_polarity = pol.value();
+}
+
+void OusterSensor::parse_sync_pulse_out_frequency(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto val = nh.param("sync_pulse_out_frequency", 0);
+    if (val <= 0) return;
+    config.sync_pulse_out_frequency = val;
+}
+
+void OusterSensor::parse_sync_pulse_out_angle(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto val = nh.param("sync_pulse_out_angle", 0);
+    if (val <= 0) return;
+    config.sync_pulse_out_angle = val;
+}
+
+void OusterSensor::parse_sync_pulse_out_pulse_width(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    auto val = nh.param("sync_pulse_out_pulse_width", 0);
+    if (val < 0) {
+        auto error_msg = "sync_pulse_out_pulse_width must be >= 0";
+        NODELET_FATAL_STREAM(error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.sync_pulse_out_pulse_width = val;
+}
+
 void OusterSensor::parse_lidar_mode(SensorConfig& config) {
     auto& nh = getPrivateNodeHandle();
     auto lidar_mode_arg = nh.param("lidar_mode", std::string{});
@@ -552,6 +658,17 @@ void OusterSensor::parse_phase_lock_and_offset(SensorConfig& config) {
     config.phase_lock_offset = phase_lock_offset;
 }
 
+void OusterSensor::parse_min_distance(SensorConfig& config) {
+    auto& nh = getPrivateNodeHandle();
+    int min_distance = nh.param("min_distance", 50);
+    // Only allow exact values: 0, 30, or 50 (cm)
+    if (min_distance != 0 && min_distance != 30 && min_distance != 50) {
+        NODELET_FATAL("min_distance must be one of {0, 30, 50} cm");
+        throw std::runtime_error("invalid min_distance value!");
+    }
+    config.min_range_threshold_cm = min_distance;
+}
+
 void OusterSensor::parse_lidar_frame_azimuth_offset(SensorConfig& config) {
     auto& nh = getPrivateNodeHandle();
     auto azimuth_offset = nh.param("lidar_frame_azimuth_offset", -1);
@@ -614,7 +731,18 @@ SensorConfig OusterSensor::parse_config_from_ros_parameters() {
     parse_azimuth_window(config);
     parse_operating_mode(config);
     parse_signal_multiplier(config);
+    parse_multipurpose_io_mode(config);
+    parse_nmea_in_polarity(config);
+    parse_nmea_ignore_valid_char(config);
+    parse_nmea_baud_rate(config);
+    parse_nmea_leap_seconds(config);
+    parse_sync_pulse_in_polarity(config);
+    parse_sync_pulse_out_polarity(config);
+    parse_sync_pulse_out_frequency(config);
+    parse_sync_pulse_out_angle(config);
+    parse_sync_pulse_out_pulse_width(config);
     parse_phase_lock_and_offset(config);
+    parse_min_distance(config);
     parse_lidar_frame_azimuth_offset(config);
     parse_return_order(config);
     parse_bloom_reduction_optimization(config);

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -536,26 +536,22 @@ void OusterSensor::parse_sync_pulse_out_polarity(SensorConfig& config) {
 
 void OusterSensor::parse_sync_pulse_out_frequency(SensorConfig& config) {
     auto& nh = getPrivateNodeHandle();
-    auto val = nh.param("sync_pulse_out_frequency", 0);
-    if (val <= 0) return;
+    auto val = nh.param("sync_pulse_out_frequency", -1);
+    if (val < 0) return;
     config.sync_pulse_out_frequency = val;
 }
 
 void OusterSensor::parse_sync_pulse_out_angle(SensorConfig& config) {
     auto& nh = getPrivateNodeHandle();
-    auto val = nh.param("sync_pulse_out_angle", 0);
-    if (val <= 0) return;
+    auto val = nh.param("sync_pulse_out_angle", -1);
+    if (val < 0) return;
     config.sync_pulse_out_angle = val;
 }
 
 void OusterSensor::parse_sync_pulse_out_pulse_width(SensorConfig& config) {
     auto& nh = getPrivateNodeHandle();
-    auto val = nh.param("sync_pulse_out_pulse_width", 0);
-    if (val < 0) {
-        auto error_msg = "sync_pulse_out_pulse_width must be >= 0";
-        NODELET_FATAL_STREAM(error_msg);
-        throw std::runtime_error(error_msg);
-    }
+    auto val = nh.param("sync_pulse_out_pulse_width", -1);
+    if (val < 0) return;
     config.sync_pulse_out_pulse_width = val;
 }
 

--- a/src/os_sensor_nodelet.cpp
+++ b/src/os_sensor_nodelet.cpp
@@ -656,7 +656,8 @@ void OusterSensor::parse_phase_lock_and_offset(SensorConfig& config) {
 
 void OusterSensor::parse_min_distance(SensorConfig& config) {
     auto& nh = getPrivateNodeHandle();
-    int min_distance = nh.param("min_distance", 50);
+    auto min_distance = nh.param("min_distance", -1);
+    if (min_distance < 0) return;
     // Only allow exact values: 0, 30, or 50 (cm)
     if (min_distance != 0 && min_distance != 30 && min_distance != 50) {
         NODELET_FATAL("min_distance must be one of {0, 30, 50} cm");

--- a/src/os_sensor_nodelet.h
+++ b/src/os_sensor_nodelet.h
@@ -91,6 +91,17 @@ class OusterSensor : public OusterSensorNodeletBase {
     void parse_operating_mode(ouster::sdk::core::SensorConfig& config);
     void parse_signal_multiplier(ouster::sdk::core::SensorConfig& config);
     void parse_phase_lock_and_offset(ouster::sdk::core::SensorConfig& config);
+    void parse_min_distance(ouster::sdk::core::SensorConfig& config);
+    void parse_multipurpose_io_mode(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_in_polarity(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_ignore_valid_char(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_baud_rate(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_leap_seconds(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_in_polarity(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_polarity(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_frequency(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_angle(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_pulse_width(ouster::sdk::core::SensorConfig& config);
     void parse_lidar_frame_azimuth_offset(ouster::sdk::core::SensorConfig& config);
     void parse_bloom_reduction_optimization(ouster::sdk::core::SensorConfig& config);
     void parse_return_order(ouster::sdk::core::SensorConfig& config);


### PR DESCRIPTION
## Related Issues & PRs
https://github.com/ouster-lidar/ouster-ros/issues/514
## Summary of Changes
This PR adds ROS launch/config support for additional Ouster sensor configuration parameters that were previously not exposed through launch files.
Specifically, it adds support for:
- `multipurpose_io_mode`
- `nmea_in_polarity`
- `nmea_ignore_valid_char`
- `nmea_baud_rate`
- `nmea_leap_seconds`
- `sync_pulse_in_polarity`
- `sync_pulse_out_polarity`
- `sync_pulse_out_frequency`
- `sync_pulse_out_angle`
- `sync_pulse_out_pulse_width`
- `min_distance` (mapped to `min_range_threshold_cm`)

These parameters are now:

1. Declared in `launch/driver.launch`
2. Passed as ROS params to the driver nodelet
3. Parsed and validated in `OusterSensor::parse_config_from_ros_parameters()`


## Validation

1. Negative launch tests with invalid values to confirm

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false multipurpose_io_mode:=NOT_A_MODE`
  - Result as expected:```[FATAL] [1774944611.740671777]: Invalid multipurpose io mode: NOT_A_MODE```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false nmea_in_polarity:=INVALID`
  - Result as expected: ```[FATAL] [1774944632.906592306]: Invalid nmea_in_polarity: INVALID```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false nmea_baud_rate:=BAUD_WRONG`
  - Result as expected: ```[FATAL] [1774945239.693337135]: Invalid nmea_baud_rate: BAUD_WRONG```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false sync_pulse_in_polarity:=BAD`
  - Result as expected: ```[FATAL] [1774945264.367987478]: Invalid sync_pulse_in_polarity: BAD```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false sync_pulse_out_polarity:=BAD`
  - Result as expected: ``` [FATAL] [1774945288.618221329]: Invalid sync_pulse_out_polarity: BAD```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false min_distance:=15`
  - Result as expected: ```[FATAL] [1774945307.403053328]: min_distance must be one of {0, 30, 50} cm```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false sync_pulse_out_pulse_width:=-1`
  - Result as expected: ```[FATAL] [1774945330.791298768]: sync_pulse_out_pulse_width must be >= 0```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false phase_lock_enable:=true phase_lock_offset:=-1`
  - Result as expected:```[FATAL] [1774946302.513515982]: phase_lock_offset must be between 0 and 360000 millidegrees```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false phase_lock_enable:=true phase_lock_offset:=360001`
  - Result as expected:```[FATAL] [1774946337.020423188]: phase_lock_offset must be between 0 and 360000 millidegrees```

- `roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false multipurpose_io_mode:=OFF phase_lock_enable:=false phase_lock_offset:=0`
  - Result as expected:```[ERROR] [1774946396.812676702]: Error connecting to sensor os-122531002356.local, details: CurlClient::execute_request failed for url: [os-122531002356.local/api/v1/sensor/config?staging=true&reinit=true&persist=false] with the code: [400] - and return: {"error": {"title": "400 Bad Request", "description": "Timestamp_mode TIME_FROM_INTERNAL_OSC incompatible with phase_lock_enable. An external time sync source is required, see the documentation for details."}}```
  - And the configuration is in staged
  - <img width="1369" height="1317" alt="image" src="https://github.com/user-attachments/assets/701e1486-b981-4c86-a7a9-d9b7172813a7" />

2. Manual testing (positive)
The following roslaunch runs completed successfully against sensor os-122531002356.local (driver starts, no parameter parse failures observed):
 - default parameter:
```bash
roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false \
  multipurpose_io_mode:=OFF \
  nmea_in_polarity:=ACTIVE_HIGH nmea_ignore_valid_char:=false nmea_baud_rate:=BAUD_9600 nmea_leap_seconds:=0 \
  sync_pulse_in_polarity:=ACTIVE_HIGH sync_pulse_out_polarity:=ACTIVE_HIGH \
  sync_pulse_out_frequency:=1 sync_pulse_out_angle:=360 sync_pulse_out_pulse_width:=10 \
  min_distance:=0
```

 - NMEA UART on MULTIPURPOSE_IO:
```
roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false \
  multipurpose_io_mode:=INPUT_NMEA_UART \
  nmea_in_polarity:=ACTIVE_LOW nmea_ignore_valid_char:=true \
  nmea_baud_rate:=BAUD_115200 \
  nmea_leap_seconds:=0
```
 - Sync pulse out (frequency / angle / width)
```
roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false \
  timestamp_mode:=TIME_FROM_INTERNAL_OSC \
  sync_pulse_out_polarity:=ACTIVE_LOW \
  sync_pulse_out_frequency:=2 sync_pulse_out_angle:=180 sync_pulse_out_pulse_width:=5
min_distance (each allowed value)
```

```
roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false min_distance:=0
roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false min_distance:=30
roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false min_distance:=50
```
 - PTP + MIO output from PTP
```
roslaunch ouster_ros driver.launch sensor_hostname:=os-122531002356.local viz:=false \
  timestamp_mode:=TIME_FROM_PTP_1588 \
  multipurpose_io_mode:=OUTPUT_FROM_PTP_1588 \
  phase_lock_enable:=false phase_lock_offset:=0
```