### PR TITLE
Add ROS launch support for sensor time-sync and min_distance parameters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ Changelog
 ============
 * [BUGFIX]: Add the missing ``ament_cmake_gtest`` to the dependencies.
 * Use ``add_compile_definitions`` instead of ``add_definitions`` to set the ``EIGEN_MPL2_ONLY`` flag.
+* Add launch file and os_sensor_node support for additional sensor configuration parameters (time
+  synchronization, multipurpose IO, and minimum reported range on FW 3.1+):
+  - ``multipurpose_io_mode``
+  - ``nmea_in_polarity``, ``nmea_ignore_valid_char``, ``nmea_baud_rate``, ``nmea_leap_seconds``
+  - ``sync_pulse_in_polarity``, ``sync_pulse_out_polarity``, ``sync_pulse_out_frequency``,
+    ``sync_pulse_out_angle``, ``sync_pulse_out_pulse_width``
+  - ``min_distance`` (sensor field ``min_range_threshold_cm``)
 
 ouster_ros v0.14.0
 ==================

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -67,7 +67,7 @@
     }"/>
   <arg name="multipurpose_io_mode" default="OFF"
     description="multipurpose IO / time sync mode; possible values: {
-    OFF, 
+    OFF,
     INPUT_NMEA_UART,
     OUTPUT_FROM_INTERNAL_OSC,
     OUTPUT_FROM_SYNC_PULSE_IN,

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -65,6 +65,55 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="multipurpose_io_mode" default="OFF"
+    description="multipurpose IO / time sync mode; possible values: {
+    OFF, 
+    INPUT_NMEA_UART,
+    OUTPUT_FROM_INTERNAL_OSC,
+    OUTPUT_FROM_SYNC_PULSE_IN,
+    OUTPUT_FROM_PTP_1588,
+    OUTPUT_FROM_ENCODER_ANGLE
+    }"/>
+  <arg name="nmea_in_polarity" default="ACTIVE_HIGH"
+    description="polarity for NMEA UART input; possible values: ACTIVE_HIGH, ACTIVE_LOW"/>
+  <arg name="nmea_ignore_valid_char" default="false"
+    description="Set false if NMEA UART input $GPRMC messages should be ignored if valid character is not set,
+      and true if messages should be used for time syncing regardless of the valid character."/>
+  <arg name="nmea_baud_rate" default="BAUD_9600"
+    description="Expected baud for NMEA UART $GPRMC; possible values: {
+    BAUD_9600,
+    BAUD_115200
+    }"
+    />
+  <arg name="nmea_leap_seconds" default="0"
+    description="Set an integer number of leap seconds that will be added to the UDP timestamp
+      when calculating seconds since 00:00:00 Thursday, 1 January 1970. For Unix Epoch time, this should be set to 0."/>
+  <arg name="sync_pulse_in_polarity" default="ACTIVE_HIGH"
+    description="The polarity of SYNC_PULSE_IN input, which controls polarity of SYNC_PULSE_IN pin when timestamp_mode is set in TIME_FROM_SYNC_PULSE_IN;
+    possible values: {
+      ACTIVE_HIGH,
+      ACTIVE_LOW
+    }"/>
+  <arg name="sync_pulse_out_polarity" default="ACTIVE_LOW"
+    description="Polarity of SYNC_PULSE_OUT when this sensor is the time-sync master;
+    possible values: {
+      ACTIVE_HIGH,
+      ACTIVE_LOW
+    }"/>
+  <arg name="sync_pulse_out_frequency" default="-1"
+    description="The output SYNC_PULSE_OUT pulse rate in Hz. Valid inputs are integers >0 Hz,
+    but also limited by the criteria described in the Time Synchronization section of the Firmware User Manual."/>
+  <arg name="sync_pulse_out_angle" default="-1"
+    description="The angle in terms of degrees that the sensor traverses between each SYNC_PULSE_OUT pulse. 
+      E.g. a value of 180 means a sync pulse is sent out every 180° for a total of two pulses per revolution and angular frequency of 20 Hz;
+      values range [0, 360], -1 is unset"/>
+  <arg name="sync_pulse_out_pulse_width" default="-1"
+    description="The polarity of SYNC_PULSE_OUT output, if the sensor is set as the master sensor used for time synchronization.
+      Output SYNC_PULSE_OUT pulse width is in ms, increments in 1 ms. -1 is unset"/>
+  <arg name="min_distance" default="-1"
+    description="to change the sensor’s minimum reported range (cm);
+      available options (FW3.1+): {0, 30}
+      available options: {0, 30, 50} (FW3.2+)"/>
   <arg name="ptp_utc_tai_offset" default="-37.0"
     description="UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588"/>
   <arg name="metadata" default=""
@@ -204,6 +253,17 @@
       <param name="point_cloud_frame" value="$(var point_cloud_frame)"/>
       <param name="pub_static_tf" value="$(var pub_static_tf)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
+      <param name="multipurpose_io_mode" value="$(var multipurpose_io_mode)"/>
+      <param name="nmea_in_polarity" value="$(var nmea_in_polarity)"/>
+      <param name="nmea_ignore_valid_char" value="$(var nmea_ignore_valid_char)"/>
+      <param name="nmea_baud_rate" value="$(var nmea_baud_rate)"/>
+      <param name="nmea_leap_seconds" value="$(var nmea_leap_seconds)"/>
+      <param name="sync_pulse_in_polarity" value="$(var sync_pulse_in_polarity)"/>
+      <param name="sync_pulse_out_polarity" value="$(var sync_pulse_out_polarity)"/>
+      <param name="sync_pulse_out_frequency" value="$(var sync_pulse_out_frequency)"/>
+      <param name="sync_pulse_out_angle" value="$(var sync_pulse_out_angle)"/>
+      <param name="sync_pulse_out_pulse_width" value="$(var sync_pulse_out_pulse_width)"/>
+      <param name="min_distance" value="$(var min_distance)"/>
       <param name="ptp_utc_tai_offset" value="$(var ptp_utc_tai_offset)"/>
       <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
       <param name="proc_mask" value="$(var proc_mask)"/>

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -103,6 +103,17 @@ void OusterSensor::declare_parameters() {
     declare_parameter("lidar_frame_azimuth_offset", -1);
     declare_parameter("return_order", "");
     declare_parameter("bloom_reduction_optimization", "");
+    declare_parameter("multipurpose_io_mode", "OFF");
+    declare_parameter("nmea_in_polarity", "ACTIVE_HIGH");
+    declare_parameter("nmea_ignore_valid_char", false);
+    declare_parameter("nmea_baud_rate", "BAUD_9600");
+    declare_parameter("nmea_leap_seconds", 0);
+    declare_parameter("sync_pulse_in_polarity", "ACTIVE_HIGH");
+    declare_parameter("sync_pulse_out_polarity", "ACTIVE_LOW");
+    declare_parameter("sync_pulse_out_frequency", -1);
+    declare_parameter("sync_pulse_out_angle", -1);
+    declare_parameter("sync_pulse_out_pulse_width", -1);
+    declare_parameter("min_distance", -1);
 }
 
 bool OusterSensor::start() {
@@ -688,6 +699,109 @@ void OusterSensor::parse_signal_multiplier(SensorConfig& config) {
     config.signal_multiplier = signal_multiplier;
 }
 
+void OusterSensor::parse_multipurpose_io_mode(SensorConfig& config) {
+    auto arg = get_parameter("multipurpose_io_mode").as_string();
+    if (!is_arg_set(arg)) {
+        return;
+    }
+    auto mode = ouster::sdk::core::multipurpose_io_mode_of_string(arg);
+    if (!mode) {
+        auto error_msg = "Invalid multipurpose io mode: " + arg;
+        RCLCPP_FATAL_STREAM(get_logger(), error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.multipurpose_io_mode = mode.value();
+}
+
+void OusterSensor::parse_nmea_in_polarity(SensorConfig& config) {
+    auto arg = get_parameter("nmea_in_polarity").as_string();
+    if (!is_arg_set(arg)) {
+        return;
+    }
+    auto polarity = ouster::sdk::core::polarity_of_string(arg);
+    if (!polarity) {
+        auto error_msg = "Invalid nmea in polarity: " + arg;
+        RCLCPP_FATAL_STREAM(get_logger(), error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.nmea_in_polarity = polarity.value();
+}
+
+void OusterSensor::parse_nmea_ignore_valid_char(SensorConfig& config) {
+    config.nmea_ignore_valid_char =
+        get_parameter("nmea_ignore_valid_char").as_bool();
+}
+
+void OusterSensor::parse_nmea_baud_rate(SensorConfig& config) {
+    auto arg = get_parameter("nmea_baud_rate").as_string();
+    if (!is_arg_set(arg)) {
+        return;
+    }
+    auto rate = ouster::sdk::core::nmea_baud_rate_of_string(arg);
+    if (!rate) {
+        auto error_msg = "Invalid nmea baud rate: " + arg;
+        RCLCPP_FATAL_STREAM(get_logger(), error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.nmea_baud_rate = rate.value();
+}
+
+void OusterSensor::parse_nmea_leap_seconds(SensorConfig& config) {
+    config.nmea_leap_seconds = get_parameter("nmea_leap_seconds").as_int();
+}
+
+void OusterSensor::parse_sync_pulse_in_polarity(SensorConfig& config) {
+    auto arg = get_parameter("sync_pulse_in_polarity").as_string();
+    if (!is_arg_set(arg)) {
+        return;
+    }
+    auto polarity = ouster::sdk::core::polarity_of_string(arg);
+    if (!polarity) {
+        auto error_msg = "Invalid sync pulse in polarity: " + arg;
+        RCLCPP_FATAL_STREAM(get_logger(), error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.sync_pulse_in_polarity = polarity.value();
+}
+
+void OusterSensor::parse_sync_pulse_out_polarity(SensorConfig& config) {
+    auto arg = get_parameter("sync_pulse_out_polarity").as_string();
+    if (!is_arg_set(arg)) {
+        return;
+    }
+    auto polarity = ouster::sdk::core::polarity_of_string(arg);
+    if (!polarity) {
+        auto error_msg = "Invalid sync pulse out polarity: " + arg;
+        RCLCPP_FATAL_STREAM(get_logger(), error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.sync_pulse_out_polarity = polarity.value();
+}
+
+void OusterSensor::parse_sync_pulse_out_frequency(SensorConfig& config) {
+    auto val = get_parameter("sync_pulse_out_frequency").as_int();
+    if (val < 0) {
+        return;
+    }
+    config.sync_pulse_out_frequency = val;
+}
+
+void OusterSensor::parse_sync_pulse_out_angle(SensorConfig& config) {
+    auto val = get_parameter("sync_pulse_out_angle").as_int();
+    if (val < 0) {
+        return;
+    }
+    config.sync_pulse_out_angle = val;
+}
+
+void OusterSensor::parse_sync_pulse_out_pulse_width(SensorConfig& config) {
+    auto val = get_parameter("sync_pulse_out_pulse_width").as_int();
+    if (val < 0) {
+        return;
+    }
+    config.sync_pulse_out_pulse_width = val;
+}
+
 void OusterSensor::parse_phase_lock_and_offset(SensorConfig& config) {
     config.phase_lock_enable = get_parameter("phase_lock_enable").as_bool();
     auto phase_lock_offset = get_parameter("phase_lock_offset").as_int();
@@ -697,6 +811,22 @@ void OusterSensor::parse_phase_lock_and_offset(SensorConfig& config) {
         throw std::runtime_error(error_msg);
     }
     config.phase_lock_offset = phase_lock_offset;
+}
+
+void OusterSensor::parse_min_distance(SensorConfig& config) {
+    auto val = get_parameter("min_distance").as_int();
+    if (val < 0) {
+        return;
+    }
+    auto valid = std::vector<int>{0, 30, 50};
+    if (std::find(valid.begin(), valid.end(), val) == valid.end()) {
+        auto error_msg =
+            "Invalid min_distance: " + to_string(val) +
+            "; must be -1 (unset) or one of {0, 30, 50} (cm)";
+        RCLCPP_FATAL_STREAM(get_logger(), error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.min_range_threshold_cm = val;
 }
 
 void OusterSensor::parse_lidar_frame_azimuth_offset(SensorConfig& config) {
@@ -757,7 +887,18 @@ SensorConfig OusterSensor::parse_config_from_ros_parameters() {
     parse_azimuth_window(config);
     parse_operating_mode(config);
     parse_signal_multiplier(config);
+    parse_multipurpose_io_mode(config);
+    parse_nmea_in_polarity(config);
+    parse_nmea_ignore_valid_char(config);
+    parse_nmea_baud_rate(config);
+    parse_nmea_leap_seconds(config);
+    parse_sync_pulse_in_polarity(config);
+    parse_sync_pulse_out_polarity(config);
+    parse_sync_pulse_out_frequency(config);
+    parse_sync_pulse_out_angle(config);
+    parse_sync_pulse_out_pulse_width(config);
     parse_phase_lock_and_offset(config);
+    parse_min_distance(config);
     parse_lidar_frame_azimuth_offset(config);
     parse_return_order(config);
     parse_bloom_reduction_optimization(config);

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -105,7 +105,18 @@ class OusterSensor : public OusterSensorNodeBase {
     void parse_azimuth_window(ouster::sdk::core::SensorConfig& config);
     void parse_operating_mode(ouster::sdk::core::SensorConfig& config);
     void parse_signal_multiplier(ouster::sdk::core::SensorConfig& config);
+    void parse_multipurpose_io_mode(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_in_polarity(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_ignore_valid_char(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_baud_rate(ouster::sdk::core::SensorConfig& config);
+    void parse_nmea_leap_seconds(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_in_polarity(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_polarity(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_frequency(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_angle(ouster::sdk::core::SensorConfig& config);
+    void parse_sync_pulse_out_pulse_width(ouster::sdk::core::SensorConfig& config);
     void parse_phase_lock_and_offset(ouster::sdk::core::SensorConfig& config);
+    void parse_min_distance(ouster::sdk::core::SensorConfig& config);
     void parse_lidar_frame_azimuth_offset(ouster::sdk::core::SensorConfig& config);
     void parse_bloom_reduction_optimization(ouster::sdk::core::SensorConfig& config);
     void parse_return_order(ouster::sdk::core::SensorConfig& config);

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -105,6 +105,7 @@ class OusterSensor : public OusterSensorNodeBase {
     void parse_azimuth_window(ouster::sdk::core::SensorConfig& config);
     void parse_operating_mode(ouster::sdk::core::SensorConfig& config);
     void parse_signal_multiplier(ouster::sdk::core::SensorConfig& config);
+    void parse_min_distance(ouster::sdk::core::SensorConfig& config);
     void parse_multipurpose_io_mode(ouster::sdk::core::SensorConfig& config);
     void parse_nmea_in_polarity(ouster::sdk::core::SensorConfig& config);
     void parse_nmea_ignore_valid_char(ouster::sdk::core::SensorConfig& config);
@@ -116,7 +117,6 @@ class OusterSensor : public OusterSensorNodeBase {
     void parse_sync_pulse_out_angle(ouster::sdk::core::SensorConfig& config);
     void parse_sync_pulse_out_pulse_width(ouster::sdk::core::SensorConfig& config);
     void parse_phase_lock_and_offset(ouster::sdk::core::SensorConfig& config);
-    void parse_min_distance(ouster::sdk::core::SensorConfig& config);
     void parse_lidar_frame_azimuth_offset(ouster::sdk::core::SensorConfig& config);
     void parse_bloom_reduction_optimization(ouster::sdk::core::SensorConfig& config);
     void parse_return_order(ouster::sdk::core::SensorConfig& config);


### PR DESCRIPTION
## Related Issues & PRs
https://github.com/ouster-lidar/ouster-ros/issues/514

## Summary of Changes
This PR adds ROS 2 launch/config support for additional Ouster sensor configuration parameters that were previously not exposed through launch files.

Specifically, it adds support for:

- `multipurpose_io_mode`
- `nmea_in_polarity`
- `nmea_ignore_valid_char`
- `nmea_baud_rate`
- `nmea_leap_seconds`
- `sync_pulse_in_polarity`
- `sync_pulse_out_polarity`
- `sync_pulse_out_frequency`
- `sync_pulse_out_angle`
- `sync_pulse_out_pulse_width`
- `min_distance` (mapped to `min_range_threshold_cm`)

These parameters are now:

- **Parse order**: multipurpose/NMEA/sync block runs after `parse_signal_multiplier` and before `parse_phase_lock_and_offset`; `parse_min_distance` runs after phase lock and before `parse_lidar_frame_azimuth_offset` (matches ROS 1 ordering).
- **Launch**: `sensor.composite.launch.xml` - new `<arg>` defaults aligned with ROS 1 (e.g. `OFF`, `ACTIVE_HIGH`, `BAUD_9600`, `-1` sentinels where applicable) and `<param>` pass-through to `os_driver`.

