### PR TITLE
Add support for Autoware compatible point types XYZIRCAEDT and XYZIRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Other notable parameters include:
   - `xyzir`: same as xyzi type but adds ring (channel) field.
           this type is same as Velodyne point cloud type
           this type is not compatible with the low data profile.
+  - `xyzirc`: autoware, note that `r` is not ring, return type (set to 0). `c` is channel(ring). 
 
 This is not a comprehenisve list of all the parameters that the driver supports
 for more detailed list please refer to the `config/driver_params.yaml` file.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,8 @@ Other notable parameters include:
   - `xyzir`: same as xyzi type but adds ring (channel) field.
           this type is same as Velodyne point cloud type
           this type is not compatible with the low data profile.
-  - `xyzirc`: autoware, note that `r` is not ring, return type (set to 0). `c` is channel(ring). 
+  - `xyzirc`: autoware format, `r` is return type (0 for single), `c` is channel (ring).
+  - `xyzircaedt`: extended autoware format adding azimuth, elevation, distance (range), and time_stamp fields.
 
 This is not a comprehenisve list of all the parameters that the driver supports
 for more detailed list please refer to the `config/driver_params.yaml` file.

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -90,7 +90,7 @@ ouster/os_driver:
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
     use_system_default_qos: false
     # point_type[optional]: choose from: {original, native, xyz, xyzi, o_xyzi, 
-    #                                     yzir}
+    #                                     xyzir, xyzirc, xyzircaedt}
     # Here is a breif description of each option:
     #  - original: This uses the original point representation ouster_ros::Point
     #          of the ouster-ros driver.
@@ -104,6 +104,8 @@ ouster/os_driver:
     #  - xyzir: same as xyzi type but adds ring (channel) field.
     #          this type is same as Velodyne point cloud type
     #          this type is not compatible with the low data profile.
+    #  - xyzirc: autoware format, `r` is return type (0 for single), `c` is channel (ring).
+    #  - xyzircaedt: extended autoware format adding azimuth, elevation, distance (range), and time_stamp fields (per-point time).
     # for more details about the fields of each point type and their data refer
     # to the following header files:
     # - ouster_ros/os_point.h

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -43,6 +43,6 @@ ouster/os_cloud:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
     scan_ring: 0  # Use this parameter in conjunction with the SCAN flag and choose a
                   # value the range [0, sensor_beams_count)
-    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir}
+    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzirc, xyzircaedt}
 ouster/os_image:
     use_system_default_qos: false # needs to match the value defined for os_sensor node

--- a/ouster-ros/include/ouster_ros/common_point_types.h
+++ b/ouster-ros/include/ouster_ros/common_point_types.h
@@ -102,6 +102,61 @@ struct PointXYZIR : public _PointXYZIR {
     }
 };
 
+// Autoware specific point type XYZIRC
+// X 	            - 	X position
+// Y 	            - 	Y position
+// Z 	            - 	Z position
+// I (intensity) 	- 	Measured reflectivity, intensity of the point
+// R (return type)  - 	Laser return type for dual return lidars NOT RING
+// C (channel)   	- 	Channel ID of the laser that measured the point NOT RING, NOT RETURN TYPE
+
+// (float, x, x)
+// (float, y, y)
+// (float, z, z)
+// (uint8_t, intensity, intensity)
+// (uint8_t, return_type, return_type)
+// (uint16_t, channel, channel)
+
+struct EIGEN_ALIGN16 _PointXYZIRC {
+    // PCL_ADD_POINT4D;
+    float x;
+    float y;
+    float z;
+    uint8_t intensity;
+    uint8_t return_type;
+    uint16_t channel;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct PointXYZIRC : public _PointXYZIRC {
+    inline PointXYZIRC(const _PointXYZIRC& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; //data[3] = 1.0f;
+      intensity = pt.intensity; return_type = pt.return_type;
+      channel = pt.channel;
+    }
+
+    inline PointXYZIRC()
+    {
+      x = y = z = 0.0f; //data[3] = 1.0f;
+      intensity = 0; return_type = 0;
+      channel = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, intensity, return_type, channel);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity, return_type, channel);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
 }   // namespace ouster_ros
 
 // clang-format off
@@ -120,6 +175,15 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIR,
     (float, z, z)
     (float, intensity, intensity)
     (std::uint16_t, ring, ring)
+)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIRC,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (uint8_t, intensity, intensity)
+    (uint8_t, return_type, return_type)
+    (uint16_t, channel, channel)
 )
 
 // clang-format on

--- a/ouster-ros/include/ouster_ros/common_point_types.h
+++ b/ouster-ros/include/ouster_ros/common_point_types.h
@@ -157,6 +157,52 @@ struct PointXYZIRC : public _PointXYZIRC {
     }
 };
 
+struct EIGEN_ALIGN16 _PointXYZIRCAEDT {
+    float x;
+    float y;
+    float z;
+    uint8_t intensity;
+    uint8_t return_type;
+    uint16_t channel;
+    float azimuth;
+    float elevation;
+    float distance;
+    uint32_t time_stamp;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct PointXYZIRCAEDT : public _PointXYZIRCAEDT {
+    inline PointXYZIRCAEDT(const _PointXYZIRCAEDT& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z;
+      intensity = pt.intensity; return_type = pt.return_type;
+      channel = pt.channel; azimuth = pt.azimuth;
+      elevation = pt.elevation; distance = pt.distance;
+      time_stamp = pt.time_stamp;
+    }
+
+    inline PointXYZIRCAEDT()
+    {
+      x = y = z = 0.0f;
+      intensity = 0; return_type = 0; channel = 0;
+      azimuth = 0.0f; elevation = 0.0f; distance = 0.0f;
+      time_stamp = 0;
+    }
+
+    inline const auto as_tuple() const {
+        return std::tie(x, y, z, intensity, return_type, channel, azimuth, elevation, distance, time_stamp);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity, return_type, channel, azimuth, elevation, distance, time_stamp);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
 }   // namespace ouster_ros
 
 // clang-format off
@@ -184,6 +230,19 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIRC,
     (uint8_t, intensity, intensity)
     (uint8_t, return_type, return_type)
     (uint16_t, channel, channel)
+)
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::PointXYZIRCAEDT,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (uint8_t, intensity, intensity)
+    (uint8_t, return_type, return_type)
+    (uint16_t, channel, channel)
+    (float, azimuth, azimuth)
+    (float, elevation, elevation)
+    (float, distance, distance)
+    (uint32_t, time_stamp, time_stamp)
 )
 
 // clang-format on

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -122,7 +122,7 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
                      const ouster::sdk::core::LidarScan& ls,
                      const std::vector<int>& pixel_shift_by_row,
                      bool organized = false, bool destagger = true,
-                     int rows_step = 1) {
+                     int rows_step = 1, int return_index = 0) {
     auto ls_tuple = make_lidar_scan_tuple<0, N, PROFILE>(ls);
     auto timestamp = ls.timestamp();
 
@@ -170,6 +170,24 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
             // case of pcl::PointXYZ or pcl::PointXYZI.
             pt.t = static_cast<uint32_t>(ts);
             pt.ring = static_cast<uint16_t>(u);
+            
+            // Copy return type
+            if constexpr (point::has_return_type_v<decltype(pt)>) {
+                uint8_t mapped_return_type;
+                switch (return_index) {
+                    case 0: mapped_return_type = 1; break; // First return -> Strongest
+                    case 1: mapped_return_type = 2; break; // Second return -> Last
+                    default: mapped_return_type = 0; break; // Unknown/Not Marked
+                }
+                pt.return_type = static_cast<decltype(pt.return_type)>(mapped_return_type);
+            }
+            
+            // Set channel if the point type supports it (Velodyne-style: inverted ring)
+            if constexpr (point::has_channel_v<decltype(pt)>) {
+                // Invert ring numbering to match Velodyne convention (0 = lowest beam)
+                uint16_t max_ring = static_cast<uint16_t>(ls.h - 1); // ls.h is pixels_per_column (number of beams)
+                pt.channel = static_cast<decltype(pt.channel)>(max_ring - pt.ring);
+            }
             copy_lidar_scan_fields_to_point<0>(pt, ls_tuple, src_idx);
             // only perform point transform operation when PointT, and PointS
             // don't match

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -178,7 +178,7 @@ class PointCloudProcessorFactory {
 
    public:
     static bool point_type_requires_intensity(const std::string& point_type) {
-        return point_type == "xyzi" || point_type == "xyzir" ||
+        return point_type == "xyzi" || point_type == "xyzir" || point_type == "xyzirc" ||
                point_type == "original" || point_type == "o_xyzi";
     }
 
@@ -263,6 +263,11 @@ class PointCloudProcessorFactory {
                 mask_path, post_processing_fn);
         } else if (point_type == "xyzir") {
             return make_point_cloud_processor<PointXYZIR>(
+                info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
+                mask_path, post_processing_fn);
+        } else if (point_type == "xyzirc") {
+            return make_point_cloud_processor<PointXYZIRC>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
                 mask_path, post_processing_fn);

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -18,12 +18,12 @@ class PointCloudProcessorFactory {
                     const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
                     const ouster::sdk::core::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
-                    int /*return_index*/) {
+                    int return_index) {
 
                     Point_LEGACY staging_pt;
                     scan_to_cloud_f<Profile_LEGACY.size(), Profile_LEGACY>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row, organized, destagger, rows_step);
+                        pixel_shift_by_row, organized, destagger, rows_step, return_index);
                 };
 
             case UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_DUAL:
@@ -40,13 +40,13 @@ class PointCloudProcessorFactory {
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL.size(),
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, organized, destagger, rows_step, return_index);
                     } else {
                         scan_to_cloud_f<
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN.size(),
                             Profile_RNG19_RFL8_SIG16_NIR16_DUAL_2ND_RETURN>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, organized, destagger, rows_step, return_index);
                     }
                 };
 
@@ -56,14 +56,14 @@ class PointCloudProcessorFactory {
                     const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
                     const ouster::sdk::core::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
-                    int /*return_index*/) {
+                    int return_index) {
 
                     Point_RNG19_RFL8_SIG16_NIR16 staging_pt;
                     scan_to_cloud_f<
                         Profile_RNG19_RFL8_SIG16_NIR16.size(),
                         Profile_RNG19_RFL8_SIG16_NIR16>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, organized, destagger, rows_step, return_index);
                 };
 
             case UDPProfileLidar::RNG15_RFL8_NIR8:
@@ -72,14 +72,14 @@ class PointCloudProcessorFactory {
                     const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
                     const ouster::sdk::core::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
-                    int /*return_index*/) {
+                    int return_index) {
 
                     Point_RNG15_RFL8_NIR8 staging_pt;
                     scan_to_cloud_f<
                         Profile_RNG15_RFL8_NIR8.size(),
                         Profile_RNG15_RFL8_NIR8>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row, organized, destagger, rows_step);
+                        pixel_shift_by_row, organized, destagger, rows_step, return_index);
                 };
 
             case UDPProfileLidar::FUSA_RNG15_RFL8_NIR8_DUAL:
@@ -97,13 +97,13 @@ class PointCloudProcessorFactory {
                             Profile_RNG15_RFL8_NIR8_DUAL.size(),
                             Profile_RNG15_RFL8_NIR8_DUAL>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, organized, destagger, rows_step, return_index);
                     } else {
                         scan_to_cloud_f<
                             Profile_RNG15_RFL8_NIR8_DUAL_2ND_RETURN.size(),
                             Profile_RNG15_RFL8_NIR8_DUAL_2ND_RETURN>(
                             cloud, staging_pt, points, scan_ts, ls,
-                            pixel_shift_by_row, organized, destagger, rows_step);
+                            pixel_shift_by_row, organized, destagger, rows_step, return_index);
                     }
                 };
 
@@ -113,14 +113,14 @@ class PointCloudProcessorFactory {
                     const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
                     const ouster::sdk::core::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
-                    int /*return_index*/) {
+                    int return_index) {
 
                     Point_RNG15_RFL8_WIN8 staging_pt;
                     scan_to_cloud_f<
                         Profile_RNG15_RFL8_WIN8.size(),
                         Profile_RNG15_RFL8_WIN8>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row, organized, destagger, rows_step);
+                        pixel_shift_by_row, organized, destagger, rows_step, return_index);
                 };
 
             case UDPProfileLidar::RNG15_RFL8_NIR8_ZONE16:
@@ -129,14 +129,14 @@ class PointCloudProcessorFactory {
                     const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
                     const ouster::sdk::core::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
-                    int /*return_index*/) {
+                    int return_index) {
 
                     Point_RNG15_RFL8_NIR8_ZONE16 staging_pt;
                     scan_to_cloud_f<
                         Profile_RNG15_RFL8_NIR8_ZONE16.size(),
                         Profile_RNG15_RFL8_NIR8_ZONE16>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row, organized, destagger, rows_step);
+                        pixel_shift_by_row, organized, destagger, rows_step, return_index);
                 };
 
             case UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_ZONE16:
@@ -145,14 +145,14 @@ class PointCloudProcessorFactory {
                     const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
                     const ouster::sdk::core::LidarScan& ls,
                     const std::vector<int>& pixel_shift_by_row,
-                    int /*return_index*/) {
+                    int return_index) {
 
                     Point_RNG19_RFL8_SIG16_NIR16_ZONE16 staging_pt;
                     scan_to_cloud_f<
                         Profile_RNG19_RFL8_SIG16_NIR16_ZONE16.size(),
                         Profile_RNG19_RFL8_SIG16_NIR16_ZONE16>(
                         cloud, staging_pt, points, scan_ts, ls,
-                        pixel_shift_by_row, organized, destagger, rows_step);
+                        pixel_shift_by_row, organized, destagger, rows_step, return_index);
                 };
 
             default:
@@ -179,7 +179,7 @@ class PointCloudProcessorFactory {
    public:
     static bool point_type_requires_intensity(const std::string& point_type) {
         return point_type == "xyzi" || point_type == "xyzir" || point_type == "xyzirc" ||
-               point_type == "original" || point_type == "o_xyzi";
+               point_type == "xyzircaedt" || point_type == "original" || point_type == "o_xyzi";
     }
 
     static bool profile_has_intensity(UDPProfileLidar profile) {
@@ -268,6 +268,11 @@ class PointCloudProcessorFactory {
                 mask_path, post_processing_fn);
         } else if (point_type == "xyzirc") {
             return make_point_cloud_processor<PointXYZIRC>(
+                info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
+                mask_path, post_processing_fn);
+        } else if (point_type == "xyzircaedt") {
+            return make_point_cloud_processor<PointXYZIRCAEDT>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
                 mask_path, post_processing_fn);

--- a/ouster-ros/src/point_transform.h
+++ b/ouster-ros/src/point_transform.h
@@ -29,6 +29,8 @@ DEFINE_MEMBER_CHECKER(near_ir);
 DEFINE_MEMBER_CHECKER(flags);
 DEFINE_MEMBER_CHECKER(window);
 DEFINE_MEMBER_CHECKER(zone_mask);
+DEFINE_MEMBER_CHECKER(return_type);
+DEFINE_MEMBER_CHECKER(channel);
 
 template <typename PointTGT, typename PointSRC>
 void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
@@ -161,6 +163,47 @@ void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
     CondBinaryOp<has_zone_mask_v<PointTGT> && !has_zone_mask_v<PointSRC>>::run(tgt_pt, src_pt,
         [](auto& tgt_pt, const auto&) {
             tgt_pt.zone_mask = static_cast<decltype(tgt_pt.zone_mask)>(0);
+        }
+    );
+
+    // return_type
+    CondBinaryOp<has_return_type_v<PointTGT> && has_return_type_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            tgt_pt.return_type = src_pt.return_type; 
+        }
+    );
+
+    CondBinaryOp<has_return_type_v<PointTGT> && !has_return_type_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
+            tgt_pt.return_type = static_cast<decltype(tgt_pt.return_type)>(0);
+        }
+    );
+
+    // channel <- ring (Velodyne-style: invert ring numbering for compatibility)
+    CondBinaryOp<has_channel_v<PointTGT> && has_ring_v<PointSRC> && !has_channel_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            // For Velodyne compatibility: invert ring numbering 
+            // Assume common lidar configurations (16, 32, 64, 128 beams)
+            uint16_t max_ring;
+            if (src_pt.ring < 16) max_ring = 15;
+            else if (src_pt.ring < 32) max_ring = 31;
+            else if (src_pt.ring < 64) max_ring = 63;
+            else if (src_pt.ring < 128) max_ring = 127;
+            else max_ring = 255; // fallback for higher beam counts
+            
+            tgt_pt.channel = static_cast<decltype(tgt_pt.channel)>(max_ring - src_pt.ring);
+        }
+    );
+
+    CondBinaryOp<has_channel_v<PointTGT> && has_channel_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            tgt_pt.channel = src_pt.channel; 
+        }
+    );
+
+    CondBinaryOp<has_channel_v<PointTGT> && !has_channel_v<PointSRC> && !has_ring_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
+            tgt_pt.channel = static_cast<decltype(tgt_pt.channel)>(0);
         }
     );
 }

--- a/ouster-ros/src/point_transform.h
+++ b/ouster-ros/src/point_transform.h
@@ -31,6 +31,10 @@ DEFINE_MEMBER_CHECKER(window);
 DEFINE_MEMBER_CHECKER(zone_mask);
 DEFINE_MEMBER_CHECKER(return_type);
 DEFINE_MEMBER_CHECKER(channel);
+DEFINE_MEMBER_CHECKER(time_stamp);
+DEFINE_MEMBER_CHECKER(azimuth);
+DEFINE_MEMBER_CHECKER(elevation);
+DEFINE_MEMBER_CHECKER(distance);
 
 template <typename PointTGT, typename PointSRC>
 void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
@@ -77,9 +81,15 @@ void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
         }
     );
 
-    // intensity <- signal
-    // PointTGT should not have signal and intensity at the same time [normally]
-    CondBinaryOp<has_intensity_v<PointTGT> && has_signal_v<PointSRC>>::run(
+    // intensity <- reflectivity / 64 (Autoware specific format override)
+    CondBinaryOp<has_intensity_v<PointTGT> && has_reflectivity_v<PointSRC> && has_time_stamp_v<PointTGT>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) {
+            tgt_pt.intensity = static_cast<decltype(tgt_pt.intensity)>(src_pt.reflectivity / 64);
+        }
+    );
+
+    // intensity <- signal (Standard Ouster)
+    CondBinaryOp<has_intensity_v<PointTGT> && has_signal_v<PointSRC> && !has_time_stamp_v<PointTGT>>::run(
         tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) {
             tgt_pt.intensity = static_cast<decltype(tgt_pt.intensity)>(src_pt.signal);
         }
@@ -204,6 +214,48 @@ void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
     CondBinaryOp<has_channel_v<PointTGT> && !has_channel_v<PointSRC> && !has_ring_v<PointSRC>>::run(
         tgt_pt, src_pt, [](auto& tgt_pt, const auto&) {
             tgt_pt.channel = static_cast<decltype(tgt_pt.channel)>(0);
+        }
+    );
+
+    // time_stamp <- t
+    CondBinaryOp<has_time_stamp_v<PointTGT> && has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            tgt_pt.time_stamp = static_cast<decltype(tgt_pt.time_stamp)>(src_pt.t); 
+        }
+    );
+    CondBinaryOp<has_time_stamp_v<PointTGT> && !has_t_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto&) { tgt_pt.time_stamp = 0U; }
+    );
+
+    // distance <- range
+    CondBinaryOp<has_distance_v<PointTGT> && has_range_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            tgt_pt.distance = static_cast<float>(src_pt.range) / 1000.0f; 
+        }
+    );
+    CondBinaryOp<has_distance_v<PointTGT> && !has_range_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            tgt_pt.distance = std::sqrt(src_pt.x * src_pt.x + src_pt.y * src_pt.y + src_pt.z * src_pt.z); 
+        }
+    );
+
+    // azimuth <- x, y
+    CondBinaryOp<has_azimuth_v<PointTGT>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            tgt_pt.azimuth = std::atan2(src_pt.y, src_pt.x); 
+        }
+    );
+
+    // elevation <- z, distance
+    CondBinaryOp<has_elevation_v<PointTGT> && has_distance_v<PointTGT>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            tgt_pt.elevation = (tgt_pt.distance > 0.0f) ? std::asin(src_pt.z / tgt_pt.distance) : 0.0f; 
+        }
+    );
+    CondBinaryOp<has_elevation_v<PointTGT> && !has_distance_v<PointTGT>>::run(
+        tgt_pt, src_pt, [](auto& tgt_pt, const auto& src_pt) { 
+            float dist = std::sqrt(src_pt.x * src_pt.x + src_pt.y * src_pt.y + src_pt.z * src_pt.z);
+            tgt_pt.elevation = (dist > 0.0f) ? std::asin(src_pt.z / dist) : 0.0f; 
         }
     );
 }


### PR DESCRIPTION
This PR adds native support for `PointXYZIRC` and `PointXYZIRCAEDT` point types.

These point types are strictly required by [Autoware](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/components/sensing/data-types/point-cloud) across its entire perception and localization pipeline. By supporting these natively, we eliminate the need for an external, CPU-intensive point-cloud adaptation node which I've been using so far.

I cherry-picked some initial changes from [jkk-research/ouster-ros@672b960](https://github.com/jkk-research/ouster-ros/commit/672b9600e532cafe9376f76a460d87d6070125ac) for the `XYZIRC` implementation and expanded upon them to build full native support for the extended `XYZIRCAEDT` format.

## Related Issues & PRs
This issue has been requested by the community before in:
- https://github.com/ouster-lidar/ouster-ros/issues/383 
- https://github.com/ouster-lidar/ouster-ros/issues/217

It has also been actively discussed within the Autoware foundation: 
- https://github.com/orgs/autowarefoundation/discussions/5293

## Summary of Changes
- **Point Type Definitions**: Added `PointXYZIRC` and `PointXYZIRCAEDT` custom PCL structs to `common_point_types.h`.
- **Factory Registration**: Registered the `xyzirc` and `xyzircaedt` profiles in `point_cloud_processor_factory.h` for use in parameter configurations.
- **Transformation Logic (`point_transform.h`)**: 
  - **`channel`**: Mapped to native ring but inverted the ordering (top-to-bottom) to retain Velodyne compatibility as expected by Autoware.
  - **`intensity`**: Included Autoware-specific scaling (`reflectivity / 64`).
  - **`return_type`**: Mapped native return IDs (e.g., 1 for strongest, 2 for last).
  - **`azimuth`, `elevation`, `distance`**: Integrated calculations natively within the driver's point-filling loop to save external compute.
  - **`time_stamp`**: Mapped the native per-point nanosecond timestamp offset.
- **Documentation**: Updated `README.md` and configuration files (`driver_params.yaml`, `os_sensor_cloud_image_params.yaml`) to describe the new point type parameters.

## Validation
- **Compilation & Tests**: The package builds cleanly and all internal `ouster_ros` unit tests pass successfully (16/16).
- **Execution **: Launched the driver specifying `point_type: xyzircaedt` and confirmed that the output `sensor_msgs/PointCloud2` correctly encodes all 10 fields, matching the Autoware binary format specification.
- **Autoware Compatibility**: Integrated it directly into an active Autoware deployment. The point clouds were successfully ingested by Autoware's sensing, preprocessing, and localization pipelines without any compatibility warnings.
