### PR TITLE
Fix multi_purpose_io parsing failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,13 @@ Changelog
 ============
 * [BUGFIX]: Add the missing ``ament_cmake_gtest`` to the dependencies.
 * Use ``add_compile_definitions`` instead of ``add_definitions`` to set the ``EIGEN_MPL2_ONLY`` flag.
-* Add launch file and os_sensor_node support for additional sensor configuration parameters (time
-  synchronization, and minimum reported range on FW 3.1+):
+* Add launch file, driver params, and os_sensor_node support for additional sensor configuration
+  parameters (time synchronization, and minimum reported range on FW 3.1+):
+  - ``multipurpose_io_mode``
   - ``nmea_in_polarity``, ``nmea_ignore_valid_char``, ``nmea_baud_rate``, ``nmea_leap_seconds``
   - ``sync_pulse_in_polarity``, ``sync_pulse_out_polarity``, ``sync_pulse_out_frequency``,
     ``sync_pulse_out_angle``, ``sync_pulse_out_pulse_width``
   - ``min_distance`` (sensor field ``min_range_threshold_cm``)
-  - The ``multipurpose_io_mode`` is not enabled yet.
 * [BUGFIX] Correct the order of ``FLAGS`` field.
 * Enable varying columns per packet.
 

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -34,7 +34,7 @@ ouster/os_driver:
     # - OUTPUT_FROM_SYNC_PULSE_IN
     # - OUTPUT_FROM_PTP_1588
     # - OUTPUT_FROM_ENCODER_ANGLE
-    multipurpose_io_mode: OFF
+    multipurpose_io_mode: 'OFF'
     # ptp_utc_tai_offset[optional]: UTC/TAI offset in seconds to apply when
     # TIME_FROM_PTP_1588 timestamp mode is used.
     ptp_utc_tai_offset: -37.0
@@ -224,7 +224,7 @@ ouster/os_driver:
     sync_pulse_out_angle: -1
     # sync_pulse_out_pulse_width[optional]: The polarity of SYNC_PULSE_OUT output, if the sensor is set as the master
     # sensor used for time synchronization. Output SYNC_PULSE_OUT pulse width is in ms, increments in 1 ms;
-    # possible values:
+    #possible values:
     # - -1 (unset)
     # - integer >0 ms
     sync_pulse_out_pulse_width: -1

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -26,6 +26,15 @@ ouster/os_driver:
     #                       packet of a LidarScan as the timestamp of the IMU,
     #                       PointCloud2 and LaserScan messages.
     timestamp_mode: ''
+    # multipurpose_io_mode[optional]: multipurpose IO / time sync mode;
+    # possible values:
+    # - OFF
+    # - INPUT_NMEA_UART
+    # - OUTPUT_FROM_INTERNAL_OSC
+    # - OUTPUT_FROM_SYNC_PULSE_IN
+    # - OUTPUT_FROM_PTP_1588
+    # - OUTPUT_FROM_ENCODER_ANGLE
+    multipurpose_io_mode: OFF
     # ptp_utc_tai_offset[optional]: UTC/TAI offset in seconds to apply when
     # TIME_FROM_PTP_1588 timestamp mode is used.
     ptp_utc_tai_offset: -37.0
@@ -215,7 +224,7 @@ ouster/os_driver:
     sync_pulse_out_angle: -1
     # sync_pulse_out_pulse_width[optional]: The polarity of SYNC_PULSE_OUT output, if the sensor is set as the master
     # sensor used for time synchronization. Output SYNC_PULSE_OUT pulse width is in ms, increments in 1 ms;
-    #possible values:
+    # possible values:
     # - -1 (unset)
     # - integer >0 ms
     sync_pulse_out_pulse_width: -1

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -65,7 +65,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
-  <!--
+  
   <arg name="multipurpose_io_mode" default="OFF"
     description="multipurpose IO / time sync mode; possible values: {
     OFF,
@@ -75,7 +75,7 @@
     OUTPUT_FROM_PTP_1588,
     OUTPUT_FROM_ENCODER_ANGLE
     }"/>
-  -->
+ 
   <arg name="nmea_in_polarity" default="ACTIVE_HIGH"
     description="polarity for NMEA UART input; possible values: ACTIVE_HIGH, ACTIVE_LOW"/>
   <arg name="nmea_ignore_valid_char" default="false"
@@ -256,7 +256,7 @@
       <param name="point_cloud_frame" value="$(var point_cloud_frame)"/>
       <param name="pub_static_tf" value="$(var pub_static_tf)"/>
       <param name="timestamp_mode" value="$(var timestamp_mode)"/>
-      <!-- <param name="multipurpose_io_mode" value="$(var multipurpose_io_mode)"/> -->
+      <param name="multipurpose_io_mode" value="$(var multipurpose_io_mode)" type="str"/>
       <param name="nmea_in_polarity" value="$(var nmea_in_polarity)"/>
       <param name="nmea_ignore_valid_char" value="$(var nmea_ignore_valid_char)"/>
       <param name="nmea_baud_rate" value="$(var nmea_baud_rate)"/>

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -104,7 +104,7 @@ void OusterSensor::declare_parameters() {
     declare_parameter("lidar_frame_azimuth_offset", -1);
     declare_parameter("return_order", "");
     declare_parameter("bloom_reduction_optimization", "");
-    // declare_parameter("multipurpose_io_mode", "OFF");
+    declare_parameter("multipurpose_io_mode", "OFF");
     declare_parameter("nmea_in_polarity", "ACTIVE_HIGH");
     declare_parameter("nmea_ignore_valid_char", false);
     declare_parameter("nmea_baud_rate", "BAUD_9600");
@@ -700,19 +700,19 @@ void OusterSensor::parse_signal_multiplier(SensorConfig& config) {
     config.signal_multiplier = signal_multiplier;
 }
 
-// void OusterSensor::parse_multipurpose_io_mode(SensorConfig& config) {
-//     auto arg = get_parameter("multipurpose_io_mode").as_string();
-//     if (!is_arg_set(arg)) {
-//         return;
-//     }
-//     auto mode = ouster::sdk::core::multipurpose_io_mode_of_string(arg);
-//     if (!mode) {
-//         auto error_msg = "Invalid multipurpose io mode: " + arg;
-//         RCLCPP_FATAL_STREAM(get_logger(), error_msg);
-//         throw std::runtime_error(error_msg);
-//     }
-//     config.multipurpose_io_mode = mode.value();
-// }
+void OusterSensor::parse_multipurpose_io_mode(SensorConfig& config) {
+    auto arg = get_parameter("multipurpose_io_mode").as_string();
+    if (!is_arg_set(arg)) {
+        return;
+    }
+    auto mode = ouster::sdk::core::multipurpose_io_mode_of_string(arg);
+    if (!mode) {
+        auto error_msg = "Invalid multipurpose io mode: " + arg;
+        RCLCPP_FATAL_STREAM(get_logger(), error_msg);
+        throw std::runtime_error(error_msg);
+    }
+    config.multipurpose_io_mode = mode.value();
+}
 
 void OusterSensor::parse_nmea_in_polarity(SensorConfig& config) {
     auto arg = get_parameter("nmea_in_polarity").as_string();
@@ -888,7 +888,7 @@ SensorConfig OusterSensor::parse_config_from_ros_parameters() {
     parse_azimuth_window(config);
     parse_operating_mode(config);
     parse_signal_multiplier(config);
-    // parse_multipurpose_io_mode(config);
+    parse_multipurpose_io_mode(config);
     parse_nmea_in_polarity(config);
     parse_nmea_ignore_valid_char(config);
     parse_nmea_baud_rate(config);

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -106,7 +106,7 @@ class OusterSensor : public OusterSensorNodeBase {
     void parse_operating_mode(ouster::sdk::core::SensorConfig& config);
     void parse_signal_multiplier(ouster::sdk::core::SensorConfig& config);
     void parse_min_distance(ouster::sdk::core::SensorConfig& config);
-    // void parse_multipurpose_io_mode(ouster::sdk::core::SensorConfig& config);
+    void parse_multipurpose_io_mode(ouster::sdk::core::SensorConfig& config);
     void parse_nmea_in_polarity(ouster::sdk::core::SensorConfig& config);
     void parse_nmea_ignore_valid_char(ouster::sdk::core::SensorConfig& config);
     void parse_nmea_baud_rate(ouster::sdk::core::SensorConfig& config);


### PR DESCRIPTION
## Related Issues & PRs
https://github.com/ouster-lidar/ouster-ros/issues/539

## Summary of Changes

The multi-purpose IO parsing failure is due to boolean coercion issue (parsing `OFF` and XML considered it as boolean in `sensor.launch.xml`)
Fixed by define the ros_param is `str` and parsing to Node

More changes:
- Add `multipurpose_io_mode` to the ROS2 driver params YAML with the same default and allowed values exposed by `sensor.composite.launch.xml`.
- Keep the NMEA, sync pulse, and `min_distance` sensor configuration parameters documented in the default driver config.
- Update the unreleased changelog entry to reflect driver params support for these sensor configuration options.


## Validation

Tested and works as expected with
- `ros2 launch ouster_ros driver.launch.py`
- `ros2 launch ouster_ros sensor.launch.xml sensor_hostname:=<sensor ip> multipurpose_io_mode:=OFF`