### PR TITLE
Patch apply staggering to mask

### DIFF
--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -190,6 +190,29 @@ const std::vector<int>& pixel_shift_by_row)
 
 template <typename pixel_type>
 ouster::sdk::core::img_t<pixel_type> load_mask(const std::string& mask_path,
+                                    size_t height, size_t width {
+    if (mask_path.empty()) return ouster::sdk::core::img_t<pixel_type>();
+
+    cv::Mat image = cv::imread(mask_path, cv::IMREAD_GRAYSCALE);
+    if (image.empty()) {
+        throw std::runtime_error("Failed to load mask image from path: " + mask_path);
+    }
+
+    if (image.rows != static_cast<int>(height) || image.cols != static_cast<int>(width)) {
+        warn_mask_resized(image.cols, image.rows, static_cast<int>(height), static_cast<int>(width));
+        cv::Mat resized;
+        cv::resize(image, resized, cv::Size(width, height), 0, 0, cv::INTER_NEAREST);
+        image = resized;
+    }
+    Eigen::MatrixXi eigen_img(image.rows, image.cols);
+    cv::cv2eigen(image, eigen_img);
+    Eigen::MatrixXi zero_image = Eigen::MatrixXi::Zero(eigen_img.rows(), eigen_img.cols());
+    Eigen::MatrixXi ones_image = Eigen::MatrixXi::Ones(eigen_img.rows(), eigen_img.cols());
+    return(eigen_img.array() == 0.0).select(zero_image, ones_image).cast<pixel_type>();
+}
+
+template <typename pixel_type>
+ouster::sdk::core::img_t<pixel_type> load_mask(const std::string& mask_path,
                                     size_t height, size_t width,
                                     const std::vector<int>& pixel_shift_by_row) {
     if (mask_path.empty()) return ouster::sdk::core::img_t<pixel_type>();

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -166,8 +166,32 @@ void warn_mask_resized(int image_cols, int image_rows,
                        int scan_height, int scan_width);
 
 template <typename pixel_type>
+ouster::sdk::core::img_t<pixel_type> stagger_mask(
+const ouster::sdk::core::img_t<pixel_type>& mask_destaggered,
+const std::vector<int>& pixel_shift_by_row)
+{
+    const int h = mask_destaggered.rows();
+    const int w = mask_destaggered.cols();
+
+    ouster::sdk::core::img_t<pixel_type> mask_staggered(h, w);
+
+    for (int u = 0; u < h; ++u) {
+        for (int v = 0; v < w; ++v) {
+
+            int v_shift =
+                (v + w - pixel_shift_by_row[u]) % w;
+
+            mask_staggered(u, v_shift) =
+                mask_destaggered(u, v);
+        }
+    }
+    return mask_staggered;
+}
+
+template <typename pixel_type>
 ouster::sdk::core::img_t<pixel_type> load_mask(const std::string& mask_path,
-                                    size_t height, size_t width) {
+                                    size_t height, size_t width,
+                                    const std::vector<int>& pixel_shift_by_row) {
     if (mask_path.empty()) return ouster::sdk::core::img_t<pixel_type>();
 
     cv::Mat image = cv::imread(mask_path, cv::IMREAD_GRAYSCALE);
@@ -185,7 +209,8 @@ ouster::sdk::core::img_t<pixel_type> load_mask(const std::string& mask_path,
     cv::cv2eigen(image, eigen_img);
     Eigen::MatrixXi zero_image = Eigen::MatrixXi::Zero(eigen_img.rows(), eigen_img.cols());
     Eigen::MatrixXi ones_image = Eigen::MatrixXi::Ones(eigen_img.rows(), eigen_img.cols());
-    return (eigen_img.array() == 0.0).select(zero_image, ones_image).cast<pixel_type>();
+    ouster::sdk::core::img_t<pixel_type> mask_destaggered = (eigen_img.array() == 0.0).select(zero_image, ones_image).cast<pixel_type>();
+    return stagger_mask(mask_destaggered, pixel_shift_by_row);
 }
 
 } // namespace impl

--- a/ouster-ros/src/image_processor.h
+++ b/ouster-ros/src/image_processor.h
@@ -54,7 +54,7 @@ class ImageProcessor {
             init_image_msg(*it->second, H, W, frame);
         }
 
-        mask = impl::load_mask<pixel_type>(mask_path, H, W, info.format.pixel_shift_by_row);
+        mask = impl::load_mask<pixel_type>(mask_path, H, W);
     }
 
    private:

--- a/ouster-ros/src/image_processor.h
+++ b/ouster-ros/src/image_processor.h
@@ -54,7 +54,7 @@ class ImageProcessor {
             init_image_msg(*it->second, H, W, frame);
         }
 
-        mask = impl::load_mask<pixel_type>(mask_path, H, W);
+        mask = impl::load_mask<pixel_type>(mask_path, H, W, info.format.pixel_shift_by_row);
     }
 
    private:

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -72,7 +72,7 @@ class PointCloudProcessor {
         mask = impl::load_mask<uint32_t>(
                     mask_path,
                     info.format.pixels_per_column / rows_step,
-                    info.format.columns_per_frame);
+                    info.format.columns_per_frame, info.format.pixel_shift_by_row);
     }
 
    private:


### PR DESCRIPTION
## Related Issues & PRs
- https://github.com/ouster-lidar/ouster-ros/issues/544

## Summary of Changes
Masking of the point cloud is applied before the data is destaggered.
Therefor the required mask needs to be staggered -> which is hard to provide when creating the mask manually.

The change applies a staggering to the loaded (destaggered, human readable) mask.

But this only applies for the path of the 3D point cloud.
As the masking on the image path is done after destaggering.
So this addresses a active bug in the driver as well.

## Validation
I validated it on an OS0 Rev7 with FW3.2 and the latest `ros2` branch.

Validation was done visually on the image and point cloud path.
But, only with `destagger==true` parameter (default). 