### PR TITLE
[ROS2] Port RGB support to ROS2 branch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Changelog
   - ``min_distance`` (sensor field ``min_range_threshold_cm``)
 * [BUGFIX] Correct the order of ``FLAGS`` field.
 * Enable varying columns per packet.
+* Add support for Rev8 and the new RGB profiles
+* Add a ``columns_per_packet`` configuration property to launch file params.
+* Extend driver list of point types to include color capable types:
+  - ``pcl::XYZRGB``
+  - ``pcl::XYZRGBA``
+  - ``ouster_ros::ColorPoint`` same as ``ouster_ros::Point`` but adds color info.
 
 ouster_ros v0.14.0
 ==================

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -48,7 +48,12 @@ ouster/os_driver:
     # - RNG15_RFL8_WIN8 (requires FW3.2+)
     # - RNG15_RFL8_NIR8_ZONE16 (requires FW3.2+)
     # - RNG19_RFL8_SIG16_NIR16_ZONE16 (requires FW3.2+)
+    # - RNG19_RFL8_SIG16_NIR16_RGB16 (requires FW4.0+)
+    # - RNG19_RFL8_SIG16_NIR16_RGB16_DUAL (requires FW4.0+)
     udp_profile_lidar: ''
+    # columns_per_packet[optional]: number of columns per packet; possible values: {1, 2, 4, 8, 16, 32, 64};
+    # default is 0 (unset); requires FW4.0+.
+    columns_per_packet: 0
     # udp_profile_imu[optional]: imu packet profile; possible values:
     # - LEGACY: not recommended
     # - ACCEL32_GYRO32_NMEA (requires FW3.2+)
@@ -98,8 +103,8 @@ ouster/os_driver:
     # data QoS. This is preferrable for production but default QoS is needed for
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
     use_system_default_qos: false
-    # point_type[optional]: choose from: {original, native, xyz, xyzi, o_xyzi, 
-    #                                     yzir}
+    # point_type[optional]: choose from: {original, native, xyz, xyzi, o_xyzi,
+    #                                     xyzir, xyzrgb, xyzrgba}
     # Here is a breif description of each option:
     #  - original: This uses the original point representation ouster_ros::Point
     #          of the ouster-ros driver.
@@ -113,6 +118,9 @@ ouster/os_driver:
     #  - xyzir: same as xyzi type but adds ring (channel) field.
     #          this type is same as Velodyne point cloud type
     #          this type is not compatible with the low data profile.
+    #  - xyzrgb: same as xyz point type but adds RGB color fields.
+    #  - xyzrgba: same as xyzrgb point type but publishes the packed color as
+    #          PCL's RGBA field with an opaque alpha channel.
     # for more details about the fields of each point type and their data refer
     # to the following header files:
     # - ouster_ros/os_point.h

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -104,7 +104,7 @@ ouster/os_driver:
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
     use_system_default_qos: false
     # point_type[optional]: choose from: {original, native, xyz, xyzi, o_xyzi,
-    #                                     xyzir, xyzrgb, xyzrgba}
+    #                                     xyzir, xyzrgb, xyzrgba, color_point}
     # Here is a breif description of each option:
     #  - original: This uses the original point representation ouster_ros::Point
     #          of the ouster-ros driver.
@@ -121,6 +121,7 @@ ouster/os_driver:
     #  - xyzrgb: same as xyz point type but adds RGB color fields.
     #  - xyzrgba: same as xyzrgb point type but publishes the packed color as
     #          PCL's RGBA field with an opaque alpha channel.
+    #  - color_point: same as the original point type but adds RGB color fields.
     # for more details about the fields of each point type and their data refer
     # to the following header files:
     # - ouster_ros/os_point.h

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -11,6 +11,7 @@ ouster/os_sensor:
     lidar_mode: ''
     timestamp_mode: ''
     udp_profile_lidar: ''
+    columns_per_packet: 0
     udp_profile_imu: ''
     imu_packets_per_frame: 0
     gyro_fsr: ''
@@ -43,6 +44,6 @@ ouster/os_cloud:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
     scan_ring: 0  # Use this parameter in conjunction with the SCAN flag and choose a
                   # value the range [0, sensor_beams_count)
-    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir}
+    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzrgb, xyzrgba}
 ouster/os_image:
     use_system_default_qos: false # needs to match the value defined for os_sensor node

--- a/ouster-ros/include/ouster_ros/color_point.h
+++ b/ouster-ros/include/ouster_ros/color_point.h
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file color_point.h
+ * @brief PCL point datatype matching ouster_ros::Point with RGB color.
+ */
+
+#pragma once
+
+#include <pcl/point_types.h>
+
+#include <tuple>
+
+namespace ouster_ros {
+
+// Same field layout as _Point in os_point.h, extended with PCL's packed RGB
+// union. The r/g/b fields are populated by point::transform() when the source
+// native point type carries RGB channels; otherwise they remain zero.
+struct EIGEN_ALIGN16 _ColorPoint {
+    PCL_ADD_POINT4D;
+    float intensity;        // equivalent to signal
+    uint32_t t;
+    uint8_t reflectivity;
+    uint16_t ring;          // equivalent to channel
+    uint16_t ambient;       // equivalent to near_ir
+    uint32_t range;
+    PCL_ADD_RGB;
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct ColorPoint : public _ColorPoint {
+
+    inline ColorPoint(const _ColorPoint& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      intensity = pt.intensity;
+      t = pt.t;
+      reflectivity = pt.reflectivity;
+      ring = pt.ring;
+      ambient = pt.ambient;
+      range = pt.range;
+      r = pt.r; g = pt.g; b = pt.b;
+    }
+
+    inline ColorPoint()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      intensity = 0.0f;
+      t = 0;
+      reflectivity = 0;
+      ring = 0;
+      ambient = 0;
+      range = 0;
+      rgb = 0;
+    }
+
+    inline auto as_tuple() const {
+        return std::tie(x, y, z, intensity, t, reflectivity, ring, ambient,
+                        range, r, g, b);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, intensity, t, reflectivity, ring, ambient,
+                        range, r, g, b);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
+
+// clang-format off
+
+// COLOR_POINT: same fields as ouster_ros::Point plus packed RGB color.
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::ColorPoint,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (float, intensity, intensity)
+    (std::uint32_t, t, t)
+    (std::uint8_t, reflectivity, reflectivity)
+    (std::uint16_t, ring, ring)
+    (std::uint16_t, ambient, ambient)
+    (std::uint32_t, range, range)
+    (std::uint32_t, rgb, rgb)
+)
+
+// clang-format on

--- a/ouster-ros/include/ouster_ros/color_point.h
+++ b/ouster-ros/include/ouster_ros/color_point.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023, Ouster, Inc.
+ * Copyright (c) 2026, Ouster, Inc.
  * All rights reserved.
  *
  * @file color_point.h

--- a/ouster-ros/include/ouster_ros/sensor_point_types.h
+++ b/ouster-ros/include/ouster_ros/sensor_point_types.h
@@ -712,3 +712,201 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point_RNG19_RFL8_SIG16_NIR16_ZONE1
 )
 
 // clang-format on
+
+namespace ouster_ros {
+
+// Profile_RNG19_RFL8_SIG16_NIR16_RGB16: aka RGB single return.
+static constexpr ChanFieldTable<8> Profile_RNG19_RFL8_SIG16_NIR16_RGB16{{
+    {ChanField::RANGE, ChanFieldType::UINT32},
+    {ChanField::SIGNAL, ChanFieldType::UINT16},
+    {ChanField::REFLECTIVITY, ChanFieldType::UINT8},
+    {ChanField::NEAR_IR, ChanFieldType::UINT16},
+    {ChanField::FLAGS, ChanFieldType::UINT8},
+    {ChanField::R, ChanFieldType::UINT8},
+    {ChanField::G, ChanFieldType::UINT8},
+    {ChanField::B, ChanFieldType::UINT8},
+}};
+
+// auto=RNG19_RFL8_SIG16_NIR16_RGB16
+struct EIGEN_ALIGN16 _Point_RNG19_RFL8_SIG16_NIR16_RGB16 {
+    PCL_ADD_POINT4D;
+    uint32_t t;             // timestamp in nanoseconds relative to frame start
+    uint16_t ring;          // equivalent channel
+    uint32_t range;
+    uint16_t signal;        // equivalent to intensity
+    uint8_t reflectivity;
+    uint16_t near_ir;       // equivalent to ambient
+    uint8_t flags;
+    uint8_t r;              // red color channel
+    uint8_t g;              // green color channel
+    uint8_t b;              // blue color channel
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct Point_RNG19_RFL8_SIG16_NIR16_RGB16 :
+    public _Point_RNG19_RFL8_SIG16_NIR16_RGB16 {
+
+    inline Point_RNG19_RFL8_SIG16_NIR16_RGB16(
+        const _Point_RNG19_RFL8_SIG16_NIR16_RGB16& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      t = pt.t; ring = pt.ring;
+      range = pt.range; signal = pt.signal;
+      reflectivity = pt.reflectivity; near_ir = pt.near_ir;
+      flags = pt.flags;
+      r = pt.r; g = pt.g; b = pt.b;
+    }
+
+    inline Point_RNG19_RFL8_SIG16_NIR16_RGB16()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      t = 0; ring = 0;
+      range = 0; signal = 0;
+      reflectivity = 0; near_ir = 0;
+      flags = 0;
+      r = 0; g = 0; b = 0;
+    }
+
+    inline auto as_tuple() const {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity,
+                        near_ir, flags, r, g, b);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity,
+                        near_ir, flags, r, g, b);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
+
+// clang-format off
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point_RNG19_RFL8_SIG16_NIR16_RGB16,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (std::uint32_t, t, t)
+    (std::uint16_t, ring, ring)
+    (std::uint32_t, range, range)
+    (std::uint16_t, signal, signal)
+    (std::uint8_t, reflectivity, reflectivity)
+    (std::uint16_t, near_ir, near_ir)
+    (std::uint8_t, flags, flags)
+    (std::uint8_t, r, r)
+    (std::uint8_t, g, g)
+    (std::uint8_t, b, b)
+)
+
+// clang-format on
+
+namespace ouster_ros {
+
+// Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL: aka colored dual returns.
+static constexpr ChanFieldTable<8> Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL{{
+    {ChanField::RANGE, ChanFieldType::UINT32},
+    {ChanField::SIGNAL, ChanFieldType::UINT16},
+    {ChanField::REFLECTIVITY, ChanFieldType::UINT8},
+    {ChanField::NEAR_IR, ChanFieldType::UINT16},
+    {ChanField::FLAGS, ChanFieldType::UINT8},
+    {ChanField::R, ChanFieldType::UINT8},
+    {ChanField::G, ChanFieldType::UINT8},
+    {ChanField::B, ChanFieldType::UINT8}
+}};
+
+// 2nd return mirror of Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL. NEAR_IR and
+// the RGB tensor are not duplicated by the sensor and are therefore reused.
+static constexpr ChanFieldTable<8>
+    Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL_2ND_RETURN{{
+        {ChanField::RANGE2, ChanFieldType::UINT32},
+        {ChanField::SIGNAL2, ChanFieldType::UINT16},
+        {ChanField::REFLECTIVITY2, ChanFieldType::UINT8},
+        {ChanField::NEAR_IR, ChanFieldType::UINT16},
+        {ChanField::FLAGS2, ChanFieldType::UINT8},
+        {ChanField::R, ChanFieldType::UINT8},
+        {ChanField::G, ChanFieldType::UINT8},
+        {ChanField::B, ChanFieldType::UINT8}
+    }};
+
+// auto=RNG19_RFL8_SIG16_NIR16_RGB16_DUAL
+struct EIGEN_ALIGN16 _Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL {
+    PCL_ADD_POINT4D;
+    uint32_t t;             // timestamp in nanoseconds relative to frame start
+    uint16_t ring;          // equivalent channel
+    uint32_t range;
+    uint16_t signal;        // equivalent to intensity
+    uint8_t reflectivity;
+    uint16_t near_ir;       // equivalent to ambient
+    uint8_t flags;
+    uint8_t r;              // red color channel (decoded from float16)
+    uint8_t g;              // green color channel (decoded from float16)
+    uint8_t b;              // blue color channel (decoded from float16)
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+struct Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL :
+    public _Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL {
+
+    inline Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL(
+        const _Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL& pt)
+    {
+      x = pt.x; y = pt.y; z = pt.z; data[3] = 1.0f;
+      t = pt.t; ring = pt.ring;
+      range = pt.range; signal = pt.signal;
+      reflectivity = pt.reflectivity; near_ir = pt.near_ir;
+      flags = pt.flags;
+      r = pt.r; g = pt.g; b = pt.b;
+    }
+
+    inline Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL()
+    {
+      x = y = z = 0.0f; data[3] = 1.0f;
+      t = 0; ring = 0;
+      range = 0; signal = 0;
+      reflectivity = 0; near_ir = 0;
+      flags = 0;
+      r = 0; g = 0; b = 0;
+    }
+
+    inline auto as_tuple() const {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity,
+                        near_ir, flags, r, g, b);
+    }
+
+    inline auto as_tuple() {
+        return std::tie(x, y, z, t, ring, range, signal, reflectivity,
+                        near_ir, flags, r, g, b);
+    }
+
+    template<size_t I>
+    inline auto& get() {
+        return std::get<I>(as_tuple());
+    }
+};
+
+}   // namespace ouster_ros
+
+// clang-format off
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (std::uint32_t, t, t)
+    (std::uint16_t, ring, ring)
+    (std::uint32_t, range, range)
+    (std::uint16_t, signal, signal)
+    (std::uint8_t, reflectivity, reflectivity)
+    (std::uint16_t, near_ir, near_ir)
+    (std::uint8_t, flags, flags)
+    (std::uint8_t, r, r)
+    (std::uint8_t, g, g)
+    (std::uint8_t, b, b)
+)
+
+// clang-format on

--- a/ouster-ros/include/ouster_ros/sensor_point_types.h
+++ b/ouster-ros/include/ouster_ros/sensor_point_types.h
@@ -722,9 +722,9 @@ static constexpr ChanFieldTable<8> Profile_RNG19_RFL8_SIG16_NIR16_RGB16{{
     {ChanField::REFLECTIVITY, ChanFieldType::UINT8},
     {ChanField::NEAR_IR, ChanFieldType::UINT16},
     {ChanField::FLAGS, ChanFieldType::UINT8},
-    {ChanField::R, ChanFieldType::UINT8},
-    {ChanField::G, ChanFieldType::UINT8},
-    {ChanField::B, ChanFieldType::UINT8},
+    {ChanField::R8, ChanFieldType::UINT8},
+    {ChanField::G8, ChanFieldType::UINT8},
+    {ChanField::B8, ChanFieldType::UINT8},
 }};
 
 // auto=RNG19_RFL8_SIG16_NIR16_RGB16
@@ -814,9 +814,9 @@ static constexpr ChanFieldTable<8> Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL{{
     {ChanField::REFLECTIVITY, ChanFieldType::UINT8},
     {ChanField::NEAR_IR, ChanFieldType::UINT16},
     {ChanField::FLAGS, ChanFieldType::UINT8},
-    {ChanField::R, ChanFieldType::UINT8},
-    {ChanField::G, ChanFieldType::UINT8},
-    {ChanField::B, ChanFieldType::UINT8}
+    {ChanField::R8, ChanFieldType::UINT8},
+    {ChanField::G8, ChanFieldType::UINT8},
+    {ChanField::B8, ChanFieldType::UINT8}
 }};
 
 // 2nd return mirror of Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL. NEAR_IR and
@@ -828,9 +828,9 @@ static constexpr ChanFieldTable<8>
         {ChanField::REFLECTIVITY2, ChanFieldType::UINT8},
         {ChanField::NEAR_IR, ChanFieldType::UINT16},
         {ChanField::FLAGS2, ChanFieldType::UINT8},
-        {ChanField::R, ChanFieldType::UINT8},
-        {ChanField::G, ChanFieldType::UINT8},
-        {ChanField::B, ChanFieldType::UINT8}
+        {ChanField::R8, ChanFieldType::UINT8},
+        {ChanField::G8, ChanFieldType::UINT8},
+        {ChanField::B8, ChanFieldType::UINT8}
     }};
 
 // auto=RNG19_RFL8_SIG16_NIR16_RGB16_DUAL

--- a/ouster-ros/include/ouster_ros/sensor_point_types.h
+++ b/ouster-ros/include/ouster_ros/sensor_point_types.h
@@ -722,9 +722,9 @@ static constexpr ChanFieldTable<8> Profile_RNG19_RFL8_SIG16_NIR16_RGB16{{
     {ChanField::REFLECTIVITY, ChanFieldType::UINT8},
     {ChanField::NEAR_IR, ChanFieldType::UINT16},
     {ChanField::FLAGS, ChanFieldType::UINT8},
-    {ChanField::R8, ChanFieldType::UINT8},
-    {ChanField::G8, ChanFieldType::UINT8},
-    {ChanField::B8, ChanFieldType::UINT8},
+    {ChanField::R_U8, ChanFieldType::UINT8},
+    {ChanField::G_U8, ChanFieldType::UINT8},
+    {ChanField::B_U8, ChanFieldType::UINT8},
 }};
 
 // auto=RNG19_RFL8_SIG16_NIR16_RGB16
@@ -814,9 +814,9 @@ static constexpr ChanFieldTable<8> Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL{{
     {ChanField::REFLECTIVITY, ChanFieldType::UINT8},
     {ChanField::NEAR_IR, ChanFieldType::UINT16},
     {ChanField::FLAGS, ChanFieldType::UINT8},
-    {ChanField::R8, ChanFieldType::UINT8},
-    {ChanField::G8, ChanFieldType::UINT8},
-    {ChanField::B8, ChanFieldType::UINT8}
+    {ChanField::R_U8, ChanFieldType::UINT8},
+    {ChanField::G_U8, ChanFieldType::UINT8},
+    {ChanField::B_U8, ChanFieldType::UINT8}
 }};
 
 // 2nd return mirror of Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL. NEAR_IR and
@@ -828,9 +828,9 @@ static constexpr ChanFieldTable<8>
         {ChanField::REFLECTIVITY2, ChanFieldType::UINT8},
         {ChanField::NEAR_IR, ChanFieldType::UINT16},
         {ChanField::FLAGS2, ChanFieldType::UINT8},
-        {ChanField::R8, ChanFieldType::UINT8},
-        {ChanField::G8, ChanFieldType::UINT8},
-        {ChanField::B8, ChanFieldType::UINT8}
+        {ChanField::R_U8, ChanFieldType::UINT8},
+        {ChanField::G_U8, ChanFieldType::UINT8},
+        {ChanField::B_U8, ChanFieldType::UINT8}
     }};
 
 // auto=RNG19_RFL8_SIG16_NIR16_RGB16_DUAL

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -12,12 +12,6 @@
     description="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="0"
     description="port to which the sensor should send imu data"/>
-  <!-- The following profiles are only available with FW3.2:
-    RNG15_RFL8_NIR8_DUAL
-    RNG15_RFL8_WIN8,
-    RNG15_RFL8_NIR8_ZONE16,
-    RNG19_RFL8_SIG16_NIR16_ZONE16
-   -->
   <arg name="udp_profile_lidar" default=""
     description="lidar packet profile; possible values: {
     LEGACY,
@@ -28,8 +22,13 @@
     RNG15_RFL8_NIR8_DUAL (FW3.2+),
     RNG15_RFL8_WIN8 (FW3.2+),
     RNG15_RFL8_NIR8_ZONE16 (FW3.2+),
-    RNG19_RFL8_SIG16_NIR16_ZONE16 (FW3.2+)
+    RNG19_RFL8_SIG16_NIR16_ZONE16 (FW3.2+),
+    RNG19_RFL8_SIG16_NIR16_RGB16 (FW4.0+)
+    RNG19_RFL8_SIG16_NIR16_RGB16_DUAL (FW4.0+)
     }"/>
+  <!-- columns_per_packet is only available with FW4.0 -->
+  <arg name="columns_per_packet" default="0"
+    description="number of columns per packet; possible values: {1, 2, 4, 8, 16, 32, 64}; (0 is unset)"/>
   <!-- ACCEL32_GYRO32_NMEA is only available with FW3.2 -->
   <arg name="udp_profile_imu" default=""
     description="imu packet profile; possible values: {
@@ -38,7 +37,7 @@
     }"/>
   <!-- Only set this parameter when working with FW3.2 -->
   <arg name="imu_packets_per_frame" default="0"
-    description="number of IMU packets per frame; possible values: {1, 2, 4, 8}"/>
+    description="number of IMU packets per frame; possible values: {1, 2, 4, 8}; (0 is unset)"/>
   <!-- Only set this parameter when working with FW3.1 -->
   <arg name="gyro_fsr" default=""
     description="gyro full scale range (requires FW3.1+); possible values: {
@@ -110,7 +109,9 @@
     xyz,
     xyzi,
     o_xyzi,
-    xyzir
+    xyzir,
+    xyzrgb,
+    xyzrgba
     }"/>
 
   <arg name="organized" default="true"
@@ -202,6 +203,7 @@
         <param name="lidar_port" value="$(var lidar_port)"/>
         <param name="imu_port" value="$(var imu_port)"/>
         <param name="udp_profile_lidar" value="$(var udp_profile_lidar)"/>
+        <param name="columns_per_packet" value="$(var columns_per_packet)"/>
         <param name="udp_profile_imu" value="$(var udp_profile_imu)"/>
         <param name="imu_packets_per_frame" value="$(var imu_packets_per_frame)"/>
         <param name="gyro_fsr" value="$(var gyro_fsr)"/>

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -111,7 +111,8 @@
     o_xyzi,
     xyzir,
     xyzrgb,
-    xyzrgba
+    xyzrgba,
+    color_point
     }"/>
 
   <arg name="organized" default="true"

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -64,7 +64,9 @@
     xyz,
     xyzi,
     o_xyzi,
-    xyzir
+    xyzir,
+    xyzrgb,
+    xyzrgba
     }"/>
 
   <arg name="organized" default="true"

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -66,7 +66,8 @@
     o_xyzi,
     xyzir,
     xyzrgb,
-    xyzrgba
+    xyzrgba,
+    color_point
     }"/>
 
   <arg name="organized" default="true"

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -60,7 +60,9 @@
     xyz,
     xyzi,
     o_xyzi,
-    xyzir
+    xyzir,
+    xyzrgb,
+    xyzrgba
     }"/>
 
   <arg name="organized" default="true"

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -62,7 +62,8 @@
     o_xyzi,
     xyzir,
     xyzrgb,
-    xyzrgba
+    xyzrgba,
+    color_point
     }"/>
 
   <arg name="organized" default="true"

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -10,12 +10,6 @@
     description="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="0"
     description="port to which the sensor should send imu data"/>
-  <!-- The following profiles are only available with FW3.2:
-    RNG15_RFL8_NIR8_DUAL
-    RNG15_RFL8_WIN8,
-    RNG15_RFL8_NIR8_ZONE16,
-    RNG19_RFL8_SIG16_NIR16_ZONE16
-   -->
   <arg name="udp_profile_lidar" default=""
     description="lidar packet profile; possible values: {
     LEGACY,
@@ -163,7 +157,9 @@
     xyz,
     xyzi,
     o_xyzi,
-    xyzir
+    xyzir,
+    xyzrgb,
+    xyzrgba
     }"/>
 
   <arg name="azimuth_window_start" default="0" description="azimuth window start;

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -159,7 +159,8 @@
     o_xyzi,
     xyzir,
     xyzrgb,
-    xyzrgba
+    xyzrgba,
+    color_point
     }"/>
 
   <arg name="azimuth_window_start" default="0" description="azimuth window start;

--- a/ouster-ros/launch/sensor.composite.launch.xml
+++ b/ouster-ros/launch/sensor.composite.launch.xml
@@ -26,8 +26,13 @@
     RNG15_RFL8_NIR8_DUAL (FW3.2+),
     RNG15_RFL8_WIN8 (FW3.2+),
     RNG15_RFL8_NIR8_ZONE16 (FW3.2+),
-    RNG19_RFL8_SIG16_NIR16_ZONE16 (FW3.2+)
+    RNG19_RFL8_SIG16_NIR16_ZONE16 (FW3.2+),
+    RNG19_RFL8_SIG16_NIR16_RGB16 (FW4.0+)
+    RNG19_RFL8_SIG16_NIR16_RGB16_DUAL (FW4.0+)
     }"/>
+  <!-- columns_per_packet is only available with FW4.0 -->
+  <arg name="columns_per_packet" default="0"
+    description="number of columns per packet; possible values: {1, 2, 4, 8, 16, 32, 64}; (0 is unset)"/>
   <!-- ACCEL32_GYRO32_NMEA is only available with FW3.2 -->
   <arg name="udp_profile_imu" default=""
     description="imu packet profile; possible values: {
@@ -36,7 +41,7 @@
     }"/>
   <!-- Only set this parameter when working with FW3.2 -->
   <arg name="imu_packets_per_frame" default="0"
-    description="number of IMU packets per frame; possible values: {1, 2, 4, 8}"/>
+    description="number of IMU packets per frame; possible values: {1, 2, 4, 8}; (0 is unset)"/>
   <!-- Only set this parameter when working with FW3.1 -->
   <arg name="gyro_fsr" default=""
     description="gyro full scale range (requires FW3.1+); possible values: {
@@ -244,6 +249,7 @@
       <param name="lidar_port" value="$(var lidar_port)"/>
       <param name="imu_port" value="$(var imu_port)"/>
       <param name="udp_profile_lidar" value="$(var udp_profile_lidar)"/>
+      <param name="columns_per_packet" value="$(var columns_per_packet)"/>
       <param name="udp_profile_imu" value="$(var udp_profile_imu)"/>
       <param name="imu_packets_per_frame" value="$(var imu_packets_per_frame)"/>
       <param name="gyro_fsr" value="$(var gyro_fsr)"/>

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -115,7 +115,8 @@
     o_xyzi,
     xyzir,
     xyzrgb,
-    xyzrgba
+    xyzrgba,
+    color_point
     }"/>
 
   <arg name="azimuth_window_start" default="0" description="azimuth window start;

--- a/ouster-ros/launch/sensor_mtp.launch.xml
+++ b/ouster-ros/launch/sensor_mtp.launch.xml
@@ -18,12 +18,6 @@
     description="port to which the sensor should send lidar data"/>
   <arg name="imu_port" default="0"
     description="port to which the sensor should send imu data"/>
-  <!-- The following profiles are only available with FW3.2:
-    RNG15_RFL8_NIR8_DUAL
-    RNG15_RFL8_WIN8,
-    RNG15_RFL8_NIR8_ZONE16,
-    RNG19_RFL8_SIG16_NIR16_ZONE16
-   -->
   <arg name="udp_profile_lidar" default=""
     description="lidar packet profile; possible values: {
     LEGACY,
@@ -34,8 +28,13 @@
     RNG15_RFL8_NIR8_DUAL (FW3.2+),
     RNG15_RFL8_WIN8 (FW3.2+),
     RNG15_RFL8_NIR8_ZONE16 (FW3.2+),
-    RNG19_RFL8_SIG16_NIR16_ZONE16 (FW3.2+)
+    RNG19_RFL8_SIG16_NIR16_ZONE16 (FW3.2+),
+    RNG19_RFL8_SIG16_NIR16_RGB16 (FW4.0+)
+    RNG19_RFL8_SIG16_NIR16_RGB16_DUAL (FW4.0+)
     }"/>
+  <!-- columns_per_packet is only available with FW4.0 -->
+  <arg name="columns_per_packet" default="0"
+    description="number of columns per packet; possible values: {1, 2, 4, 8, 16, 32, 64}; (0 is unset)"/>
   <!-- ACCEL32_GYRO32_NMEA is only available with FW3.2 -->
   <arg name="udp_profile_imu" default=""
     description="imu packet profile; possible values: {
@@ -44,7 +43,7 @@
     }"/>
   <!-- Only set this parameter when working with FW3.2 -->
   <arg name="imu_packets_per_frame" default="0"
-    description="number of IMU packets per frame; possible values: {1, 2, 4, 8}"/>
+    description="number of IMU packets per frame; possible values: {1, 2, 4, 8}; (0 is unset)"/>
   <!-- Only set this parameter when working with FW3.1 -->
   <arg name="gyro_fsr" default=""
     description="gyro full scale range (requires FW3.1+); possible values: {
@@ -114,7 +113,9 @@
     xyz,
     xyzi,
     o_xyzi,
-    xyzir
+    xyzir,
+    xyzrgb,
+    xyzrgba
     }"/>
 
   <arg name="azimuth_window_start" default="0" description="azimuth window start;
@@ -181,6 +182,7 @@
       <param name="lidar_port" value="$(var lidar_port)"/>
       <param name="imu_port" value="$(var imu_port)"/>
       <param name="udp_profile_lidar" value="$(var udp_profile_lidar)"/>
+      <param name="columns_per_packet" value="$(var columns_per_packet)"/>
       <param name="udp_profile_imu" value="$(var udp_profile_imu)"/>
       <param name="imu_packets_per_frame" value="$(var imu_packets_per_frame)"/>
       <param name="gyro_fsr" value="$(var gyro_fsr)"/>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.14.1</version>
+  <version>0.15.0</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/image_processor.h
+++ b/ouster-ros/src/image_processor.h
@@ -55,6 +55,15 @@ class ImageProcessor {
         }
 
         mask = impl::load_mask<pixel_type>(mask_path, H, W);
+
+        has_rgb = info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+        info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
+
+        // TODO[UN]: Update the code to make rgb_processing conditional
+        // if (has_rgb) {
+            image_msgs[ChanField::RGB] = std::make_shared<sensor_msgs::msg::Image>();
+            init_image_msg_rgb(*image_msgs[ChanField::RGB], H, W, frame);
+        // }
     }
 
    private:
@@ -69,6 +78,16 @@ class ImageProcessor {
         // TODO: allow choosing higher image encoding representation
         msg.encoding = sensor_msgs::image_encodings::MONO16;
         msg.data.resize(W * H * sizeof(pixel_type));
+        msg.header.frame_id = frame;
+    }
+
+    static void init_image_msg_rgb(sensor_msgs::msg::Image& msg, size_t H, size_t W,
+                               const std::string& frame) {
+        msg.width = W;
+        msg.height = H;
+        msg.step = W * 3 * sizeof(uint8_t);
+        msg.encoding = sensor_msgs::image_encodings::RGB8;
+        msg.data.resize(H * msg.step);
         msg.header.frame_id = frame;
     }
 
@@ -104,6 +123,13 @@ class ImageProcessor {
         ouster::sdk::core::img_t<uint16_t> near_ir = impl::get_or_fill_zero<uint16_t>(
             impl::scan_return(ouster::sdk::core::ChanField::NEAR_IR, !first), lidar_scan);
 
+        ouster::sdk::core::img_t<uint8_t> r_data = impl::get_or_fill_zero<uint8_t>(
+            ouster::sdk::core::ChanField::R, lidar_scan);
+        ouster::sdk::core::img_t<uint8_t> g_data = impl::get_or_fill_zero<uint8_t>(
+            ouster::sdk::core::ChanField::G, lidar_scan);
+        ouster::sdk::core::img_t<uint8_t> b_data = impl::get_or_fill_zero<uint8_t>(
+            ouster::sdk::core::ChanField::B, lidar_scan);
+
         uint32_t H = info_.format.pixels_per_column;
         uint32_t W = info_.format.columns_per_frame;
 
@@ -121,6 +147,10 @@ class ImageProcessor {
         auto nearir_image_map = Eigen::Map<ouster::sdk::core::img_t<pixel_type>>(
             (pixel_type*)near_ir_msg->data.data(), H, W);
 
+        auto rgb_msg = image_msgs[ChanField::RGB];
+        auto rgb_image_map = Eigen::TensorMap<ouster::sdk::core::rgb_img_t<uint8_t>>(
+            (uint8_t*)rgb_msg->data.data(), H, W, 3);
+
         const auto& px_offset = info_.format.pixel_shift_by_row;
 
         ouster::sdk::core::img_t<float> signal_image_eigen(H, W);
@@ -131,6 +161,10 @@ class ImageProcessor {
         const auto sg = signal.data();
         const auto rf = reflectivity.data();
         const auto nr = near_ir.data();
+
+        const auto rd = r_data.data();
+        const auto gd = g_data.data();
+        const auto bd = b_data.data();
 
         // copy data out of Cloud message, with destaggering
         for (size_t u = 0; u < H; u++) {
@@ -144,15 +178,20 @@ class ImageProcessor {
                 signal_image_eigen(u, v) = sg[idx];
                 reflec_image_eigen(u, v) = rf[idx];
                 nearir_image_eigen(u, v) = nr[idx];
+                rgb_image_map(u, v, 0) = rd[idx];
+                rgb_image_map(u, v, 1) = gd[idx];
+                rgb_image_map(u, v, 2) = bd[idx];
             }
         }
 
-        signal_ae(signal_image_eigen, first);
-        reflec_ae(reflec_image_eigen, first);
-        nearir_buc(nearir_image_eigen);
-        nearir_ae(nearir_image_eigen, first);
+        signal_ae.update(signal_image_eigen, first);
+        reflec_ae.update(reflec_image_eigen, first);
+        nearir_buc.update(nearir_image_eigen);
+        nearir_ae.update(nearir_image_eigen, first);
         nearir_image_eigen = nearir_image_eigen.sqrt();
         signal_image_eigen = signal_image_eigen.sqrt();
+
+        // NOTE[UN]: RGB image data is readily autoexposed at the lidar packet handler step
 
         // copy data into image messages
         signal_image_map =
@@ -167,6 +206,9 @@ class ImageProcessor {
             signal_image_map = signal_image_map * mask;
             reflec_image_map = reflec_image_map * mask;
             nearir_image_map = nearir_image_map * mask;
+
+            // TODO[UN]: apply mask to an RGB image
+            // rgb_image_map = rgb_image_map * mask;
         }
     }
 
@@ -188,10 +230,11 @@ class ImageProcessor {
     PostProcessingFn post_processing_fn;
     ouster::sdk::core::SensorInfo info_;
 
-    ouster::sdk::core::AutoExposure nearir_ae, signal_ae, reflec_ae;
-    ouster::sdk::core::BeamUniformityCorrector nearir_buc;
+    ouster::sdk::core::image::AutoExposure nearir_ae, signal_ae, reflec_ae;
+    ouster::sdk::core::image::BeamUniformityCorrector nearir_buc;
 
     ouster::sdk::core::img_t<pixel_type> mask;
+    bool has_rgb;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/image_processor.h
+++ b/ouster-ros/src/image_processor.h
@@ -150,6 +150,7 @@ class ImageProcessor {
         const auto sg = signal.data();
         const auto rf = reflectivity.data();
         const auto nr = near_ir.data();
+        const bool has_mask = mask.size() != 0;
 
         // copy data out of Cloud message, with destaggering
         auto process_pixel = [&](size_t u, size_t v, size_t idx) {
@@ -159,7 +160,9 @@ class ImageProcessor {
             range_image_map(u, v) = r > pixel_value_max ? 0 : r;
             signal_image_eigen(u, v) = sg[idx];
             reflec_image_eigen(u, v) = rf[idx];
-            nearir_image_eigen(u, v) = nr[idx];
+            if (first) {
+                nearir_image_eigen(u, v) = nr[idx];
+            }
         };
 
         const bool process_rgb = has_rgb_ && first;
@@ -193,6 +196,19 @@ class ImageProcessor {
                     rgb_image_map(u, v, 2) = bd[idx];
                 }
             }
+
+            if (has_mask) {
+                using MaskTensorMap =
+                    Eigen::TensorMap<const Eigen::Tensor<pixel_type, 2, Eigen::RowMajor>>;
+                MaskTensorMap mask_tensor(mask.data(), H, W);
+                const Eigen::array<Eigen::Index, 3> mask_shape = {
+                    static_cast<Eigen::Index>(H), static_cast<Eigen::Index>(W), 1};
+                const Eigen::array<Eigen::Index, 3> mask_broadcast = {1, 1, 3};
+                rgb_image_map *=
+                    mask_tensor.reshape(mask_shape)
+                    .broadcast(mask_broadcast)
+                    .cast<uint8_t>();
+            }
         } else {
             for (size_t u = 0; u < H; u++) {
                 for (size_t v = 0; v < W; v++) {
@@ -204,30 +220,35 @@ class ImageProcessor {
         }
 
         signal_ae.update(signal_image_eigen, first);
-        reflec_ae.update(reflec_image_eigen, first);
-        nearir_buc.update(nearir_image_eigen);
-        nearir_ae.update(nearir_image_eigen, first);
-        nearir_image_eigen = nearir_image_eigen.sqrt();
         signal_image_eigen = signal_image_eigen.sqrt();
+        reflec_ae.update(reflec_image_eigen, first);
+        if (first) {
+            nearir_buc.update(nearir_image_eigen);
+            nearir_ae.update(nearir_image_eigen, first);
+            nearir_image_eigen = nearir_image_eigen.sqrt();
+        }
 
-        // NOTE[UN]: RGB image data is readily autoexposed at the lidar packet handler step
+        // NOTE[UN]: RGB image data is readily autoexposed at the lidar packet handler
+        // and therefore, we don't need to apply auto exposure to the RGB image here
 
         // copy data into image messages
         signal_image_map =
             (signal_image_eigen * pixel_value_max).cast<pixel_type>();
         reflec_image_map =
             (reflec_image_eigen * pixel_value_max).cast<pixel_type>();
-        nearir_image_map =
-            (nearir_image_eigen * pixel_value_max).cast<pixel_type>();
 
-        if (mask.size() != 0) {
+        if (first) {
+            nearir_image_map =
+                (nearir_image_eigen * pixel_value_max).cast<pixel_type>();
+        }
+
+        if (has_mask) {
             range_image_map = range_image_map * mask;
             signal_image_map = signal_image_map * mask;
             reflec_image_map = reflec_image_map * mask;
-            nearir_image_map = nearir_image_map * mask;
-
-            // TODO[UN]: apply mask to an RGB image
-            // rgb_image_map = rgb_image_map * mask;
+            if (first) {
+                nearir_image_map = nearir_image_map * mask;
+            }
         }
     }
 

--- a/ouster-ros/src/image_processor.h
+++ b/ouster-ros/src/image_processor.h
@@ -168,13 +168,13 @@ class ImageProcessor {
         const bool process_rgb = has_rgb_ && first;
         if (process_rgb) {
             ouster::sdk::core::img_t<uint8_t> r_data =
-                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::R8,
+                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::R_U8,
                                                 lidar_scan);
             ouster::sdk::core::img_t<uint8_t> g_data =
-                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::G8,
+                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::G_U8,
                                                 lidar_scan);
             ouster::sdk::core::img_t<uint8_t> b_data =
-                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::B8,
+                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::B_U8,
                                                 lidar_scan);
 
             auto rgb_msg = image_msgs[ChanField::RGB];

--- a/ouster-ros/src/image_processor.h
+++ b/ouster-ros/src/image_processor.h
@@ -56,15 +56,14 @@ class ImageProcessor {
 
         mask = impl::load_mask<pixel_type>(mask_path, H, W);
 
-        has_rgb =
+        has_rgb_ =
             info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
             info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
 
-        // TODO[UN]: Update the code to make rgb_processing conditional
-        // if (has_rgb) {
+        if (has_rgb_) {
             image_msgs[ChanField::RGB] = std::make_shared<sensor_msgs::msg::Image>();
             init_image_msg_rgb(*image_msgs[ChanField::RGB], H, W, frame);
-        // }
+        }
     }
 
    private:
@@ -83,7 +82,7 @@ class ImageProcessor {
     }
 
     static void init_image_msg_rgb(sensor_msgs::msg::Image& msg, size_t H, size_t W,
-                               const std::string& frame) {
+                                   const std::string& frame) {
         msg.width = W;
         msg.height = H;
         msg.step = W * 3 * sizeof(uint8_t);
@@ -124,13 +123,6 @@ class ImageProcessor {
         ouster::sdk::core::img_t<uint16_t> near_ir = impl::get_or_fill_zero<uint16_t>(
             impl::scan_return(ouster::sdk::core::ChanField::NEAR_IR, !first), lidar_scan);
 
-        ouster::sdk::core::img_t<uint8_t> r_data = impl::get_or_fill_zero<uint8_t>(
-            ouster::sdk::core::ChanField::R8, lidar_scan);
-        ouster::sdk::core::img_t<uint8_t> g_data = impl::get_or_fill_zero<uint8_t>(
-            ouster::sdk::core::ChanField::G8, lidar_scan);
-        ouster::sdk::core::img_t<uint8_t> b_data = impl::get_or_fill_zero<uint8_t>(
-            ouster::sdk::core::ChanField::B8, lidar_scan);
-
         uint32_t H = info_.format.pixels_per_column;
         uint32_t W = info_.format.columns_per_frame;
 
@@ -148,10 +140,6 @@ class ImageProcessor {
         auto nearir_image_map = Eigen::Map<ouster::sdk::core::img_t<pixel_type>>(
             (pixel_type*)near_ir_msg->data.data(), H, W);
 
-        auto rgb_msg = image_msgs[ChanField::RGB];
-        auto rgb_image_map = Eigen::TensorMap<ouster::sdk::core::rgb_img_t<uint8_t>>(
-            (uint8_t*)rgb_msg->data.data(), H, W, 3);
-
         const auto& px_offset = info_.format.pixel_shift_by_row;
 
         ouster::sdk::core::img_t<float> signal_image_eigen(H, W);
@@ -163,25 +151,55 @@ class ImageProcessor {
         const auto rf = reflectivity.data();
         const auto nr = near_ir.data();
 
-        const auto rd = r_data.data();
-        const auto gd = g_data.data();
-        const auto bd = b_data.data();
-
         // copy data out of Cloud message, with destaggering
-        for (size_t u = 0; u < H; u++) {
-            for (size_t v = 0; v < W; v++) {
-                const size_t vv = (v + W - px_offset[u]) % W;
-                const size_t idx = u * W + vv;
-                // TODO: re-examine this truncation later
-                // 16 bit img: use 4mm resolution and throw out returns > 260m
-                auto r = (rg[idx] + 0b10) >> 2;
-                range_image_map(u, v) = r > pixel_value_max ? 0 : r;
-                signal_image_eigen(u, v) = sg[idx];
-                reflec_image_eigen(u, v) = rf[idx];
-                nearir_image_eigen(u, v) = nr[idx];
-                rgb_image_map(u, v, 0) = rd[idx];
-                rgb_image_map(u, v, 1) = gd[idx];
-                rgb_image_map(u, v, 2) = bd[idx];
+        auto process_pixel = [&](size_t u, size_t v, size_t idx) {
+            // TODO: re-examine this truncation later
+            // 16 bit img: use 4mm resolution and throw out returns > 260m
+            auto r = (rg[idx] + 0b10) >> 2;
+            range_image_map(u, v) = r > pixel_value_max ? 0 : r;
+            signal_image_eigen(u, v) = sg[idx];
+            reflec_image_eigen(u, v) = rf[idx];
+            nearir_image_eigen(u, v) = nr[idx];
+        };
+
+        const bool process_rgb = has_rgb_ && first;
+        if (process_rgb) {
+            ouster::sdk::core::img_t<uint8_t> r_data =
+                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::R8,
+                                                lidar_scan);
+            ouster::sdk::core::img_t<uint8_t> g_data =
+                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::G8,
+                                                lidar_scan);
+            ouster::sdk::core::img_t<uint8_t> b_data =
+                impl::get_or_fill_zero<uint8_t>(ouster::sdk::core::ChanField::B8,
+                                                lidar_scan);
+
+            auto rgb_msg = image_msgs[ChanField::RGB];
+            auto rgb_image_map =
+                Eigen::TensorMap<ouster::sdk::core::rgb_img_t<uint8_t>>(
+                    (uint8_t*)rgb_msg->data.data(), H, W, 3);
+
+            const auto rd = r_data.data();
+            const auto gd = g_data.data();
+            const auto bd = b_data.data();
+
+            for (size_t u = 0; u < H; u++) {
+                for (size_t v = 0; v < W; v++) {
+                    const size_t vv = (v + W - px_offset[u]) % W;
+                    const size_t idx = u * W + vv;
+                    process_pixel(u, v, idx);
+                    rgb_image_map(u, v, 0) = rd[idx];
+                    rgb_image_map(u, v, 1) = gd[idx];
+                    rgb_image_map(u, v, 2) = bd[idx];
+                }
+            }
+        } else {
+            for (size_t u = 0; u < H; u++) {
+                for (size_t v = 0; v < W; v++) {
+                    const size_t vv = (v + W - px_offset[u]) % W;
+                    const size_t idx = u * W + vv;
+                    process_pixel(u, v, idx);
+                }
             }
         }
 
@@ -235,7 +253,7 @@ class ImageProcessor {
     ouster::sdk::core::image::BeamUniformityCorrector nearir_buc;
 
     ouster::sdk::core::img_t<pixel_type> mask;
-    bool has_rgb;
+    bool has_rgb_ = false;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/image_processor.h
+++ b/ouster-ros/src/image_processor.h
@@ -56,8 +56,9 @@ class ImageProcessor {
 
         mask = impl::load_mask<pixel_type>(mask_path, H, W);
 
-        has_rgb = info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
-        info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
+        has_rgb =
+            info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+            info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
 
         // TODO[UN]: Update the code to make rgb_processing conditional
         // if (has_rgb) {
@@ -124,11 +125,11 @@ class ImageProcessor {
             impl::scan_return(ouster::sdk::core::ChanField::NEAR_IR, !first), lidar_scan);
 
         ouster::sdk::core::img_t<uint8_t> r_data = impl::get_or_fill_zero<uint8_t>(
-            ouster::sdk::core::ChanField::R, lidar_scan);
+            ouster::sdk::core::ChanField::R8, lidar_scan);
         ouster::sdk::core::img_t<uint8_t> g_data = impl::get_or_fill_zero<uint8_t>(
-            ouster::sdk::core::ChanField::G, lidar_scan);
+            ouster::sdk::core::ChanField::G8, lidar_scan);
         ouster::sdk::core::img_t<uint8_t> b_data = impl::get_or_fill_zero<uint8_t>(
-            ouster::sdk::core::ChanField::B, lidar_scan);
+            ouster::sdk::core::ChanField::B8, lidar_scan);
 
         uint32_t H = info_.format.pixels_per_column;
         uint32_t W = info_.format.columns_per_frame;

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -116,16 +116,17 @@ class LidarPacketHandler {
         if (info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
             info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL) {
             has_rgb_ = true;
-            using ouster::sdk::core::img_t;
-            r_field_float = img_t<float>(info.format.columns_per_frame, info.format.pixels_per_column);
-            g_field_float = img_t<float>(info.format.columns_per_frame, info.format.pixels_per_column);
-            b_field_float = img_t<float>(info.format.columns_per_frame, info.format.pixels_per_column);
+            uint32_t H = info.format.pixels_per_column;
+            uint32_t W = info.format.columns_per_frame;
+            r_field_float = ouster::sdk::core::img_t<float>(H, W);
+            g_field_float = ouster::sdk::core::img_t<float>(H, W);
+            b_field_float = ouster::sdk::core::img_t<float>(H, W);
             auto_exposure_ = std::make_unique<ouster::sdk::core::image::AutoExposure>();
             for (auto& ls : lidar_scans) {
                 using ouster::sdk::core::fd_array;
-                ls->add_field(ChanField::R8, fd_array<uint8_t>(ls->h, ls->w));
-                ls->add_field(ChanField::G8, fd_array<uint8_t>(ls->h, ls->w));
-                ls->add_field(ChanField::B8, fd_array<uint8_t>(ls->h, ls->w));
+                ls->add_field(ChanField::R8, fd_array<uint8_t>(H, W));
+                ls->add_field(ChanField::G8, fd_array<uint8_t>(H, W));
+                ls->add_field(ChanField::B8, fd_array<uint8_t>(H, W));
             }
         }
 

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -27,6 +27,10 @@
 #include <vector>
 #include <string>
 
+#include <ouster/image_processing.h>
+
+namespace ChanField = ouster::sdk::core::ChanField;
+
 namespace {
 
 template <typename T, typename UnaryPredicate>
@@ -52,6 +56,21 @@ uint64_t linear_interpolate(int x0, uint64_t y0, int x1, uint64_t y1, int x) {
         sign = -1;
     }
     return y0 + (x - x0) * sign * (max_v - min_v) / (x1 - x0);
+}
+
+// Fast float16 -> float32 conversion for normal-range values.
+inline float f16_bits_to_f32(uint16_t bits) {
+    if (bits == 0) return 0.0f;
+    const uint32_t expanded = static_cast<uint32_t>(bits + 0x1C000u) << 13;
+    float result;
+    std::memcpy(&result, &expanded, sizeof(float));
+    return result;
+}
+
+inline uint8_t f32_to_u8(float v) {
+    if (v < 0.0f) v = 0.0f;
+    if (v > 1.0f) v = 1.0f;
+    return static_cast<uint8_t>(v * 255.0f + 0.5f);
 }
 
 }  // namespace
@@ -87,9 +106,10 @@ class LidarPacketHandler {
         mutexes.resize(LIDAR_SCAN_COUNT);
 
         for (size_t i = 0; i < lidar_scans.size(); ++i) {
-            lidar_scans[i] = std::make_unique<ouster::sdk::core::LidarScan>(
-                info.format.columns_per_frame, info.format.pixels_per_column,
-                info.format.udp_profile_lidar, info.format.columns_per_packet);
+            // NOTE: must construct with SensorInfo (not the
+            // (w, h, UDPProfileLidar, cols_per_packet) overload) so that the
+            // RGB profile's RGB channel is created as a 3D (h x w x 3) field.
+            lidar_scans[i] = std::make_unique<ouster::sdk::core::LidarScan>(info);
             mutexes[i] = std::make_unique<std::mutex>();
         }
 
@@ -205,9 +225,65 @@ class LidarPacketHandler {
 
         std::unique_lock<std::mutex> lock(*mutexes[ring_buffer.read_head()]);
 
+        // apply auto exposure to the rgb data only if the point cloud has rgb fields
+        static ouster::sdk::core::image::AutoExposure auto_exposure;
+        // NOTE[UN]: Copy the lidar scan to avoid modifying the original scan in the ring buffer
+        ouster::sdk::core::LidarScan ls = *lidar_scans[ring_buffer.read_head()];
+
+        if (ls.has_field(ChanField::R) && ls.has_field(ChanField::G) && ls.has_field(ChanField::B)) {
+
+            Eigen::Ref<ouster::sdk::core::img_t<uint16_t>> r_data = ls.field<uint16_t>(ChanField::R);
+            Eigen::Ref<ouster::sdk::core::img_t<uint16_t>> g_data = ls.field<uint16_t>(ChanField::G);
+            Eigen::Ref<ouster::sdk::core::img_t<uint16_t>> b_data = ls.field<uint16_t>(ChanField::B);
+
+            ouster::sdk::core::img_t<float> r_data_float(r_data.rows(), r_data.cols());
+            ouster::sdk::core::img_t<float> g_data_float(g_data.rows(), g_data.cols());
+            ouster::sdk::core::img_t<float> b_data_float(b_data.rows(), b_data.cols());
+
+            // Get raw pointers for speed
+            const uint16_t* r_in = r_data.data();
+            const uint16_t* g_in = g_data.data();
+            const uint16_t* b_in = b_data.data();
+
+            float* r_out = r_data_float.data();
+            float* g_out = g_data_float.data();
+            float* b_out = b_data_float.data();
+
+            for (int i = 0; i < r_data.size(); ++i) {
+                r_out[i] = f16_bits_to_f32(r_in[i]);
+                g_out[i] = f16_bits_to_f32(g_in[i]);
+                b_out[i] = f16_bits_to_f32(b_in[i]);
+            }
+
+            auto_exposure.update(r_data_float, g_data_float, b_data_float, true);
+
+            ouster::sdk::core::img_t<uint8_t> r_data_uint8(r_data.rows(), r_data.cols());
+            ouster::sdk::core::img_t<uint8_t> g_data_uint8(g_data.rows(), g_data.cols());
+            ouster::sdk::core::img_t<uint8_t> b_data_uint8(b_data.rows(), b_data.cols());
+
+            uint8_t* r_out_uint8 = r_data_uint8.data();
+            uint8_t* g_out_uint8 = g_data_uint8.data();
+            uint8_t* b_out_uint8 = b_data_uint8.data();
+
+            for (int i = 0; i < r_data.size(); ++i) {
+                r_out_uint8[i] = f32_to_u8(r_out[i]);
+                g_out_uint8[i] = f32_to_u8(g_out[i]);
+                b_out_uint8[i] = f32_to_u8(b_out[i]);
+            }
+
+            ls.del_field(ChanField::R);
+            ls.add_field(ChanField::R, ouster::sdk::core::fd_array<uint8_t>(r_data.rows(), r_data.cols()));
+            ls.del_field(ChanField::G);
+            ls.add_field(ChanField::G, ouster::sdk::core::fd_array<uint8_t>(g_data.rows(), g_data.cols()));
+            ls.del_field(ChanField::B);
+            ls.add_field(ChanField::B, ouster::sdk::core::fd_array<uint8_t>(b_data.rows(), b_data.cols()));
+            ls.field<uint8_t>(ChanField::R) = r_data_uint8;
+            ls.field<uint8_t>(ChanField::G) = g_data_uint8;
+            ls.field<uint8_t>(ChanField::B) = b_data_uint8;
+        }
+
         for (auto h : lidar_scan_handlers) {
-            h(*lidar_scans[ring_buffer.read_head()], lidar_scan_estimated_ts,
-              lidar_scan_estimated_msg_ts);
+            h(ls, lidar_scan_estimated_ts, lidar_scan_estimated_msg_ts);
         }
 
         // when we hit percent amount of the ring_buffer capacity throttle

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -124,9 +124,9 @@ class LidarPacketHandler {
             auto_exposure_ = std::make_unique<ouster::sdk::core::image::AutoExposure>();
             for (auto& ls : lidar_scans) {
                 using ouster::sdk::core::fd_array;
-                ls->add_field(ChanField::R8, fd_array<uint8_t>(H, W));
-                ls->add_field(ChanField::G8, fd_array<uint8_t>(H, W));
-                ls->add_field(ChanField::B8, fd_array<uint8_t>(H, W));
+                ls->add_field(ChanField::R_U8, fd_array<uint8_t>(H, W));
+                ls->add_field(ChanField::G_U8, fd_array<uint8_t>(H, W));
+                ls->add_field(ChanField::B_U8, fd_array<uint8_t>(H, W));
             }
         }
 
@@ -269,9 +269,9 @@ class LidarPacketHandler {
 
             auto_exposure_->update(r_field_float, g_field_float, b_field_float, true);
 
-            Eigen::Ref<img_t<uint8_t>> r_field_uint8 = ls.field<uint8_t>(ChanField::R8);
-            Eigen::Ref<img_t<uint8_t>> g_field_uint8 = ls.field<uint8_t>(ChanField::G8);
-            Eigen::Ref<img_t<uint8_t>> b_field_uint8 = ls.field<uint8_t>(ChanField::B8);
+            Eigen::Ref<img_t<uint8_t>> r_field_uint8 = ls.field<uint8_t>(ChanField::R_U8);
+            Eigen::Ref<img_t<uint8_t>> g_field_uint8 = ls.field<uint8_t>(ChanField::G_U8);
+            Eigen::Ref<img_t<uint8_t>> b_field_uint8 = ls.field<uint8_t>(ChanField::B_U8);
 
             uint8_t* r_out_uint8 = r_field_uint8.data();
             uint8_t* g_out_uint8 = g_field_uint8.data();

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -113,6 +113,22 @@ class LidarPacketHandler {
             mutexes[i] = std::make_unique<std::mutex>();
         }
 
+        if (info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+            info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL) {
+            has_rgb_ = true;
+            using ouster::sdk::core::img_t;
+            r_field_float = img_t<float>(info.format.columns_per_frame, info.format.pixels_per_column);
+            g_field_float = img_t<float>(info.format.columns_per_frame, info.format.pixels_per_column);
+            b_field_float = img_t<float>(info.format.columns_per_frame, info.format.pixels_per_column);
+            auto_exposure_ = std::make_unique<ouster::sdk::core::image::AutoExposure>();
+            for (auto& ls : lidar_scans) {
+                using ouster::sdk::core::fd_array;
+                ls->add_field(ChanField::R8, fd_array<uint8_t>(ls->h, ls->w));
+                ls->add_field(ChanField::G8, fd_array<uint8_t>(ls->h, ls->w));
+                ls->add_field(ChanField::B8, fd_array<uint8_t>(ls->h, ls->w));
+            }
+        }
+
         lidar_scans_processing_thread = std::make_unique<std::thread>([this]() {
             while (lidar_scans_processing_active) {
                 process_scans();
@@ -226,60 +242,45 @@ class LidarPacketHandler {
         std::unique_lock<std::mutex> lock(*mutexes[ring_buffer.read_head()]);
 
         // apply auto exposure to the rgb data only if the point cloud has rgb fields
-        static ouster::sdk::core::image::AutoExposure auto_exposure;
-        // NOTE[UN]: Copy the lidar scan to avoid modifying the original scan in the ring buffer
-        ouster::sdk::core::LidarScan ls = *lidar_scans[ring_buffer.read_head()];
+        // NOTE[UN]: Don't copy the lidar scan to avoid modifying the original scan in the ring buffer
+        ouster::sdk::core::LidarScan& ls = *lidar_scans[ring_buffer.read_head()];
 
-        if (ls.has_field(ChanField::R) && ls.has_field(ChanField::G) && ls.has_field(ChanField::B)) {
-
-            Eigen::Ref<ouster::sdk::core::img_t<uint16_t>> r_data = ls.field<uint16_t>(ChanField::R);
-            Eigen::Ref<ouster::sdk::core::img_t<uint16_t>> g_data = ls.field<uint16_t>(ChanField::G);
-            Eigen::Ref<ouster::sdk::core::img_t<uint16_t>> b_data = ls.field<uint16_t>(ChanField::B);
-
-            ouster::sdk::core::img_t<float> r_data_float(r_data.rows(), r_data.cols());
-            ouster::sdk::core::img_t<float> g_data_float(g_data.rows(), g_data.cols());
-            ouster::sdk::core::img_t<float> b_data_float(b_data.rows(), b_data.cols());
+        if (has_rgb_) {
+            using ouster::sdk::core::img_t;
+            Eigen::Ref<img_t<uint16_t>> r_field = ls.field<uint16_t>(ChanField::R);
+            Eigen::Ref<img_t<uint16_t>> g_field = ls.field<uint16_t>(ChanField::G);
+            Eigen::Ref<img_t<uint16_t>> b_field = ls.field<uint16_t>(ChanField::B);
 
             // Get raw pointers for speed
-            const uint16_t* r_in = r_data.data();
-            const uint16_t* g_in = g_data.data();
-            const uint16_t* b_in = b_data.data();
+            const uint16_t* r_in = r_field.data();
+            const uint16_t* g_in = g_field.data();
+            const uint16_t* b_in = b_field.data();
 
-            float* r_out = r_data_float.data();
-            float* g_out = g_data_float.data();
-            float* b_out = b_data_float.data();
+            float* r_out = r_field_float.data();
+            float* g_out = g_field_float.data();
+            float* b_out = b_field_float.data();
 
-            for (int i = 0; i < r_data.size(); ++i) {
+            for (Eigen::Index i = 0; i < r_field.size(); ++i) {
                 r_out[i] = f16_bits_to_f32(r_in[i]);
                 g_out[i] = f16_bits_to_f32(g_in[i]);
                 b_out[i] = f16_bits_to_f32(b_in[i]);
             }
 
-            auto_exposure.update(r_data_float, g_data_float, b_data_float, true);
+            auto_exposure_->update(r_field_float, g_field_float, b_field_float, true);
 
-            ouster::sdk::core::img_t<uint8_t> r_data_uint8(r_data.rows(), r_data.cols());
-            ouster::sdk::core::img_t<uint8_t> g_data_uint8(g_data.rows(), g_data.cols());
-            ouster::sdk::core::img_t<uint8_t> b_data_uint8(b_data.rows(), b_data.cols());
+            Eigen::Ref<img_t<uint8_t>> r_field_uint8 = ls.field<uint8_t>(ChanField::R8);
+            Eigen::Ref<img_t<uint8_t>> g_field_uint8 = ls.field<uint8_t>(ChanField::G8);
+            Eigen::Ref<img_t<uint8_t>> b_field_uint8 = ls.field<uint8_t>(ChanField::B8);
 
-            uint8_t* r_out_uint8 = r_data_uint8.data();
-            uint8_t* g_out_uint8 = g_data_uint8.data();
-            uint8_t* b_out_uint8 = b_data_uint8.data();
+            uint8_t* r_out_uint8 = r_field_uint8.data();
+            uint8_t* g_out_uint8 = g_field_uint8.data();
+            uint8_t* b_out_uint8 = b_field_uint8.data();
 
-            for (int i = 0; i < r_data.size(); ++i) {
+            for (Eigen::Index i = 0; i < r_field_uint8.size(); ++i) {
                 r_out_uint8[i] = f32_to_u8(r_out[i]);
                 g_out_uint8[i] = f32_to_u8(g_out[i]);
                 b_out_uint8[i] = f32_to_u8(b_out[i]);
             }
-
-            ls.del_field(ChanField::R);
-            ls.add_field(ChanField::R, ouster::sdk::core::fd_array<uint8_t>(r_data.rows(), r_data.cols()));
-            ls.del_field(ChanField::G);
-            ls.add_field(ChanField::G, ouster::sdk::core::fd_array<uint8_t>(g_data.rows(), g_data.cols()));
-            ls.del_field(ChanField::B);
-            ls.add_field(ChanField::B, ouster::sdk::core::fd_array<uint8_t>(b_data.rows(), b_data.cols()));
-            ls.field<uint8_t>(ChanField::R) = r_data_uint8;
-            ls.field<uint8_t>(ChanField::G) = g_data_uint8;
-            ls.field<uint8_t>(ChanField::B) = b_data_uint8;
         }
 
         for (auto h : lidar_scan_handlers) {
@@ -468,6 +469,13 @@ class LidarPacketHandler {
     int64_t ptp_utc_tai_offset_;
 
     float min_scan_valid_columns_ratio_ = 0.0f;
+
+    bool has_rgb_ = false;
+    ouster::sdk::core::img_t<float> r_field_float;
+    ouster::sdk::core::img_t<float> g_field_float;
+    ouster::sdk::core::img_t<float> b_field_float;
+
+    std::unique_ptr<ouster::sdk::core::image::AutoExposure> auto_exposure_;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -187,7 +187,8 @@ class OusterDriver : public OusterSensor {
                     {ChanField::RANGE, "range_image"},
                     {ChanField::SIGNAL, "signal_image"},
                     {ChanField::REFLECTIVITY, "reflec_image"},
-                    {ChanField::NEAR_IR, "nearir_image"}};
+                    {ChanField::NEAR_IR, "nearir_image"},
+                    {ChanField::RGB, "rgb_image"}};
 
             const std::map<std::string, std::string>
                 channel_field_topic_map_2{
@@ -197,7 +198,8 @@ class OusterDriver : public OusterSensor {
                     {ChanField::NEAR_IR, "nearir_image"},
                     {ChanField::RANGE2, "range_image2"},
                     {ChanField::SIGNAL2, "signal_image2"},
-                    {ChanField::REFLECTIVITY2, "reflec_image2"}};
+                    {ChanField::REFLECTIVITY2, "reflec_image2"},
+                    {ChanField::RGB, "rgb_image"}};
 
             auto which_map = num_returns == 1 ? &channel_field_topic_map_1
                                               : &channel_field_topic_map_2;

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -79,7 +79,8 @@ class OusterImage : public OusterProcessingNodeBase {
                 {ChanField::RANGE, "range_image"},
                 {ChanField::SIGNAL, "signal_image"},
                 {ChanField::REFLECTIVITY, "reflec_image"},
-                {ChanField::NEAR_IR, "nearir_image"}};
+                {ChanField::NEAR_IR, "nearir_image"},
+                {ChanField::RGB, "rgb_image"}};
 
         const std::map<std::string, std::string>
             channel_field_topic_map_2 {
@@ -89,7 +90,8 @@ class OusterImage : public OusterProcessingNodeBase {
                 {ChanField::NEAR_IR, "nearir_image"},
                 {ChanField::RANGE2, "range_image2"},
                 {ChanField::SIGNAL2, "signal_image2"},
-                {ChanField::REFLECTIVITY2, "reflec_image2"}};
+                {ChanField::REFLECTIVITY2, "reflec_image2"},
+                {ChanField::RGB, "rgb_image"}};
 
         auto which_map = n_returns == 1 ? &channel_field_topic_map_1
                                         : &channel_field_topic_map_2;

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -288,7 +288,7 @@ void OusterSensor::update_metadata(ouster::sdk::sensor::Client& cli) {
 
     info = ouster::sdk::core::SensorInfo(cached_metadata);
     // TODO: revist when *min_version* is changed
-    populate_metadata_defaults(info, LidarMode::UNSPECIFIED);
+    populate_metadata_defaults(info, LidarMode::_2048x10);
 
     publish_metadata();
     save_metadata();
@@ -473,7 +473,7 @@ std::shared_ptr<ouster::sdk::sensor::Client> OusterSensor::create_sensor_client(
     } else {
         // use the full init_client to generate and assign random ports to
         // sensor
-        cli = ouster::sdk::sensor::init_client(hostname, udp_dest, LidarMode::UNSPECIFIED,
+        cli = ouster::sdk::sensor::init_client(hostname, udp_dest, LidarMode::_2048x10,
                                   TimestampMode::UNSPECIFIED, lidar_port, imu_port);
     }
 
@@ -623,13 +623,14 @@ void OusterSensor::parse_lidar_mode(SensorConfig& config) {
         return;
     }
 
-    auto lidar_mode = ouster::sdk::core::lidar_mode_of_string(lidar_mode_arg);
-    if (lidar_mode == LidarMode::MODE_UNSPEC) {
-        auto error_msg = "Invalid lidar mode: " + lidar_mode_arg;
+    try {
+        auto lidar_mode = ouster::sdk::core::lidar_mode_of_string(lidar_mode_arg);
+        config.lidar_mode = lidar_mode;
+    } catch (const std::exception& e) {
+        auto error_msg = "Invalid lidar mode: " + lidar_mode_arg + ", exception details: " + e.what();
         RCLCPP_FATAL_STREAM(get_logger(), error_msg);
         throw std::runtime_error(error_msg);
     }
-    config.lidar_mode = lidar_mode;
 }
 
 void OusterSensor::parse_timestamp_mode(SensorConfig& config) {

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -85,6 +85,7 @@ void OusterSensor::declare_parameters() {
     declare_parameter("lidar_mode", "");
     declare_parameter("timestamp_mode", "");
     declare_parameter("udp_profile_lidar", "");
+    declare_parameter("columns_per_packet", 0);
     declare_parameter("udp_profile_imu", "");
     declare_parameter("imu_packets_per_frame", 0);
     declare_parameter("gyro_fsr", "");
@@ -288,7 +289,7 @@ void OusterSensor::update_metadata(ouster::sdk::sensor::Client& cli) {
 
     info = ouster::sdk::core::SensorInfo(cached_metadata);
     // TODO: revist when *min_version* is changed
-    populate_metadata_defaults(info, LidarMode::_2048x10);
+    populate_metadata_defaults(info);
 
     publish_metadata();
     save_metadata();
@@ -473,7 +474,7 @@ std::shared_ptr<ouster::sdk::sensor::Client> OusterSensor::create_sensor_client(
     } else {
         // use the full init_client to generate and assign random ports to
         // sensor
-        cli = ouster::sdk::sensor::init_client(hostname, udp_dest, LidarMode::_2048x10,
+        cli = ouster::sdk::sensor::init_client(hostname, udp_dest, LidarMode(0, 0),
                                   TimestampMode::UNSPECIFIED, lidar_port, imu_port);
     }
 
@@ -564,6 +565,19 @@ void OusterSensor::parse_udp_profile_lidar(SensorConfig& config) {
         throw std::runtime_error(error_msg);
     }
     config.udp_profile_lidar = udp_profile_lidar;
+}
+
+void OusterSensor::parse_columns_per_packet(SensorConfig& config) {
+    auto columns_per_packet = get_parameter("columns_per_packet").as_int();
+    if (columns_per_packet == 0) {
+        return;
+    }
+    auto valid_values = std::vector<int>{1, 2, 4, 8, 16, 32, 64};
+    if (std::find(valid_values.begin(), valid_values.end(), columns_per_packet) == valid_values.end()) {
+        RCLCPP_FATAL(get_logger(), "columns_per_packet needs to be one of the values: {1, 2, 4, 8, 16, 32, 64}");
+        throw std::runtime_error("invalid columns_per_packet value!");
+    }
+    config.columns_per_packet = columns_per_packet;
 }
 
 void OusterSensor::parse_udp_profile_imu_and_settings(SensorConfig& config) {
@@ -883,6 +897,7 @@ SensorConfig OusterSensor::parse_config_from_ros_parameters() {
     SensorConfig config;
     parse_udp_dest_and_ports(config);
     parse_udp_profile_lidar(config);
+    parse_columns_per_packet(config);
     parse_udp_profile_imu_and_settings(config);
     parse_lidar_mode(config);
     parse_timestamp_mode(config);
@@ -977,7 +992,7 @@ bool OusterSensor::configure_sensor(
 
 // fill in values that could not be parsed from metadata
 void OusterSensor::populate_metadata_defaults(
-    SensorInfo& info, LidarMode specified_lidar_mode) {
+    SensorInfo& info) {
     ouster::sdk::core::Version v = ouster::sdk::core::version_from_string(info.image_rev);
     if (v == ouster::sdk::core::INVALID_VERSION)
         RCLCPP_WARN(
@@ -987,13 +1002,6 @@ void OusterSensor::populate_metadata_defaults(
         RCLCPP_WARN(get_logger(),
                     "Firmware < %s not supported; output may not be reliable",
                     ouster::sdk::sensor::MIN_VERSION.simple_version_string().c_str());
-
-    if (!info.config.lidar_mode) {
-        RCLCPP_WARN(
-            get_logger(),
-            "Lidar mode not found in metadata; output may not be reliable");
-        info.config.lidar_mode = specified_lidar_mode;
-    }
 
     if (!info.prod_line.size()) info.prod_line = "UNKNOWN";
 

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -99,6 +99,7 @@ class OusterSensor : public OusterSensorNodeBase {
     // helper methods for parsing individual config fields from ros parameters
     void parse_udp_dest_and_ports(ouster::sdk::core::SensorConfig& config);
     void parse_udp_profile_lidar(ouster::sdk::core::SensorConfig& config);
+    void parse_columns_per_packet(ouster::sdk::core::SensorConfig& config);
     void parse_udp_profile_imu_and_settings(ouster::sdk::core::SensorConfig& config);
     void parse_lidar_mode(ouster::sdk::core::SensorConfig& config);
     void parse_timestamp_mode(ouster::sdk::core::SensorConfig& config);
@@ -130,8 +131,7 @@ class OusterSensor : public OusterSensorNodeBase {
     std::string load_config_file(const std::string& config_file);
 
     // fill in values that could not be parsed from metadata
-    void populate_metadata_defaults(ouster::sdk::core::SensorInfo& info,
-                                    ouster::sdk::core::LidarMode specified_lidar_mode);
+    void populate_metadata_defaults(ouster::sdk::core::SensorInfo& info);
 
     void allocate_buffers();
 

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -57,7 +57,7 @@ void OusterSensorNodeBase::display_lidar_info(const SensorInfo& info) {
     auto fw_ver = ouster::sdk::core::version_from_string(info.image_rev);
     auto lidar_profile = info.format.udp_profile_lidar;
     auto imu_profile = info.format.udp_profile_imu;
-    auto lidar_mode = info.config.lidar_mode.value_or(LidarMode::MODE_UNSPEC);
+    auto lidar_mode = info.config.lidar_mode.value();
     RCLCPP_INFO_STREAM(
         get_logger(),
         "ouster client version: "

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -57,7 +57,7 @@ void OusterSensorNodeBase::display_lidar_info(const SensorInfo& info) {
     auto fw_ver = ouster::sdk::core::version_from_string(info.image_rev);
     auto lidar_profile = info.format.udp_profile_lidar;
     auto imu_profile = info.format.udp_profile_imu;
-    auto lidar_mode = info.config.lidar_mode.value();
+    auto lidar_mode = info.config.lidar_mode.value_or(LidarMode(0, 0));
     auto columns_per_packet = info.format.columns_per_packet;
     RCLCPP_INFO_STREAM(
         get_logger(),

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -58,6 +58,7 @@ void OusterSensorNodeBase::display_lidar_info(const SensorInfo& info) {
     auto lidar_profile = info.format.udp_profile_lidar;
     auto imu_profile = info.format.udp_profile_imu;
     auto lidar_mode = info.config.lidar_mode.value();
+    auto columns_per_packet = info.format.columns_per_packet;
     RCLCPP_INFO_STREAM(
         get_logger(),
         "ouster client version: "
@@ -66,7 +67,8 @@ void OusterSensorNodeBase::display_lidar_info(const SensorInfo& info) {
             << "firmware ver: " << fw_ver.simple_version_string() << "\n"
             << "lidar mode: " << ouster::sdk::core::to_string(lidar_mode) << ", "
             << "lidar udp profile: " << ouster::sdk::core::to_string(lidar_profile) << ", "
-            << "imu udp profile: " << ouster::sdk::core::to_string(imu_profile));
+            << "imu udp profile: " << ouster::sdk::core::to_string(imu_profile) << "\n"
+            << "columns per packet: " << columns_per_packet);
 }
 
 std::string OusterSensorNodeBase::transition_id_to_string(uint8_t transition_id) {

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -4,6 +4,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include "ouster_ros/os_point.h"
+#include "ouster_ros/color_point.h"
 #include "ouster_ros/sensor_point_types.h"
 #include "ouster_ros/common_point_types.h"
 

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -326,6 +326,11 @@ class PointCloudProcessorFactory {
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
                 mask_path, post_processing_fn);
+        } else if (point_type == "xyzrgba") {
+            return make_point_cloud_processor<pcl::PointXYZRGBA>(
+                info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
+                mask_path, post_processing_fn);
         } else if (point_type == "original") {
             return make_point_cloud_processor<ouster_ros::Point>(
                 info, frame, apply_lidar_to_sensor_transform,

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -155,6 +155,46 @@ class PointCloudProcessorFactory {
                         pixel_shift_by_row, organized, destagger, rows_step);
                 };
 
+            case UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16:
+                return [organized, destagger, rows_step](
+                    ouster_ros::Cloud<PointT>& cloud,
+                    const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
+                    const ouster::sdk::core::LidarScan& ls,
+                    const std::vector<int>& pixel_shift_by_row,
+                    int /*return_index*/) {
+
+                    Point_RNG19_RFL8_SIG16_NIR16_RGB16 staging_pt;
+                    scan_to_cloud_f<
+                        Profile_RNG19_RFL8_SIG16_NIR16_RGB16.size(),
+                        Profile_RNG19_RFL8_SIG16_NIR16_RGB16>(
+                        cloud, staging_pt, points, scan_ts, ls,
+                        pixel_shift_by_row, organized, destagger, rows_step);
+                };
+
+            case UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL:
+                return [organized, destagger, rows_step](
+                    ouster_ros::Cloud<PointT>& cloud,
+                    const ouster::sdk::core::PointCloudXYZf& points, uint64_t scan_ts,
+                    const ouster::sdk::core::LidarScan& ls,
+                    const std::vector<int>& pixel_shift_by_row,
+                    int return_index) {
+
+                    Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL staging_pt;
+                    if (return_index == 0) {
+                        scan_to_cloud_f<
+                            Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL.size(),
+                            Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL>(
+                            cloud, staging_pt, points, scan_ts, ls,
+                            pixel_shift_by_row, organized, destagger, rows_step);
+                    } else {
+                        scan_to_cloud_f<
+                            Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL_2ND_RETURN.size(),
+                            Profile_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL_2ND_RETURN>(
+                            cloud, staging_pt, points, scan_ts, ls,
+                            pixel_shift_by_row, organized, destagger, rows_step);
+                    }
+                };
+
             default:
                 throw std::runtime_error("unsupported udp_profile_lidar");
         }
@@ -186,7 +226,9 @@ class PointCloudProcessorFactory {
         return profile == UDPProfileLidar::LEGACY ||
                profile == UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_DUAL ||
                profile == UDPProfileLidar::RNG19_RFL8_SIG16_NIR16 ||
-               profile == UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_ZONE16;
+               profile == UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_ZONE16 ||
+               profile == UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+               profile == UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
     }
 
     static LidarScanProcessor create_point_cloud_processor(
@@ -242,6 +284,18 @@ class PointCloudProcessorFactory {
                         info, frame, apply_lidar_to_sensor_transform,
                         organized, destagger, min_range, max_range, rows_step,
                         mask_path, post_processing_fn);
+                case UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16:
+                        return make_point_cloud_processor<
+                            Point_RNG19_RFL8_SIG16_NIR16_RGB16>(
+                            info, frame, apply_lidar_to_sensor_transform,
+                            organized, destagger, min_range, max_range, rows_step,
+                            mask_path, post_processing_fn);
+                case UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL:
+                        return make_point_cloud_processor<
+                            Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL>(
+                            info, frame, apply_lidar_to_sensor_transform,
+                            organized, destagger, min_range, max_range, rows_step,
+                            mask_path, post_processing_fn);
                 default:
                     // TODO: implement fallback?
                     throw std::runtime_error("unsupported udp_profile_lidar");
@@ -263,6 +317,11 @@ class PointCloudProcessorFactory {
                 mask_path, post_processing_fn);
         } else if (point_type == "xyzir") {
             return make_point_cloud_processor<PointXYZIR>(
+                info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
+                mask_path, post_processing_fn);
+        } else if (point_type == "xyzrgb") {
+            return make_point_cloud_processor<pcl::PointXYZRGB>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
                 mask_path, post_processing_fn);

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -219,7 +219,8 @@ class PointCloudProcessorFactory {
    public:
     static bool point_type_requires_intensity(const std::string& point_type) {
         return point_type == "xyzi" || point_type == "xyzir" ||
-               point_type == "original" || point_type == "o_xyzi";
+               point_type == "original" || point_type == "o_xyzi" ||
+               point_type == "color_point";
     }
 
     static bool profile_has_intensity(UDPProfileLidar profile) {
@@ -327,6 +328,11 @@ class PointCloudProcessorFactory {
                 mask_path, post_processing_fn);
         } else if (point_type == "original") {
             return make_point_cloud_processor<ouster_ros::Point>(
+                info, frame, apply_lidar_to_sensor_transform,
+                organized, destagger, min_range, max_range, rows_step,
+                mask_path, post_processing_fn);
+        } else if (point_type == "color_point") {
+            return make_point_cloud_processor<ouster_ros::ColorPoint>(
                 info, frame, apply_lidar_to_sensor_transform,
                 organized, destagger, min_range, max_range, rows_step,
                 mask_path, post_processing_fn);

--- a/ouster-ros/src/point_meta_helpers.h
+++ b/ouster-ros/src/point_meta_helpers.h
@@ -113,6 +113,27 @@ inline  constexpr auto& get<2, pcl::PointXYZI>(pcl::PointXYZI& point) { return p
 template <>
 inline  constexpr auto& get<3, pcl::PointXYZI>(pcl::PointXYZI& point) { return point.intensity; }
 
+// pcl::PointXYZRGB has x/y/z plus r/g/b (and a packed rgb/rgba alias). We only
+// expose the 3 color channels here since they are the only fields produced
+// by ouster_ros for RGB-capable lidar profiles. The alpha channel and packed
+// representations are derived from the r/g/b bytes via PCL's union and are
+// updated implicitly when r/g/b are written.
+template <>
+inline constexpr std::size_t size<pcl::PointXYZRGB>(const pcl::PointXYZRGB&) { return 6U; }
+
+template <>
+inline constexpr auto& get<0, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { return point.x; }
+template <>
+inline constexpr auto& get<1, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { return point.y; }
+template <>
+inline constexpr auto& get<2, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { return point.z; }
+template <>
+inline constexpr auto& get<3, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { return point.r; }
+template <>
+inline constexpr auto& get<4, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { return point.g; }
+template <>
+inline constexpr auto& get<5, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { return point.b; }
+
 // TODO: create a generalized vardiac templates of apply and enumerate functions
 
 /**

--- a/ouster-ros/src/point_meta_helpers.h
+++ b/ouster-ros/src/point_meta_helpers.h
@@ -134,6 +134,24 @@ inline constexpr auto& get<4, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { retur
 template <>
 inline constexpr auto& get<5, pcl::PointXYZRGB>(pcl::PointXYZRGB& point) { return point.b; }
 
+// pcl::PointXYZRGBA has the same x/y/z/r/g/b access pattern as PointXYZRGB.
+// Alpha is set by point::transform() to PCL's default opaque value.
+template <>
+inline constexpr std::size_t size<pcl::PointXYZRGBA>(const pcl::PointXYZRGBA&) { return 6U; }
+
+template <>
+inline constexpr auto& get<0, pcl::PointXYZRGBA>(pcl::PointXYZRGBA& point) { return point.x; }
+template <>
+inline constexpr auto& get<1, pcl::PointXYZRGBA>(pcl::PointXYZRGBA& point) { return point.y; }
+template <>
+inline constexpr auto& get<2, pcl::PointXYZRGBA>(pcl::PointXYZRGBA& point) { return point.z; }
+template <>
+inline constexpr auto& get<3, pcl::PointXYZRGBA>(pcl::PointXYZRGBA& point) { return point.r; }
+template <>
+inline constexpr auto& get<4, pcl::PointXYZRGBA>(pcl::PointXYZRGBA& point) { return point.g; }
+template <>
+inline constexpr auto& get<5, pcl::PointXYZRGBA>(pcl::PointXYZRGBA& point) { return point.b; }
+
 // TODO: create a generalized vardiac templates of apply and enumerate functions
 
 /**

--- a/ouster-ros/src/point_transform.h
+++ b/ouster-ros/src/point_transform.h
@@ -29,6 +29,16 @@ DEFINE_MEMBER_CHECKER(near_ir);
 DEFINE_MEMBER_CHECKER(flags);
 DEFINE_MEMBER_CHECKER(window);
 DEFINE_MEMBER_CHECKER(zone_mask);
+DEFINE_MEMBER_CHECKER(r);
+DEFINE_MEMBER_CHECKER(g);
+DEFINE_MEMBER_CHECKER(b);
+
+// Compile-time predicate identifying point types that expose a complete
+// (r, g, b) color triplet directly accessible by name. Used for direct
+// per-channel mapping during point transforms and as the gating condition
+// for RGB ingestion in scan_to_cloud_f.
+template <typename T>
+inline constexpr bool has_rgb_v = has_r_v<T> && has_g_v<T> && has_b_v<T>;
 
 template <typename PointTGT, typename PointSRC>
 void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
@@ -161,6 +171,23 @@ void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
     CondBinaryOp<has_zone_mask_v<PointTGT> && !has_zone_mask_v<PointSRC>>::run(tgt_pt, src_pt,
         [](auto& tgt_pt, const auto&) {
             tgt_pt.zone_mask = static_cast<decltype(tgt_pt.zone_mask)>(0);
+        }
+    );
+
+    // RGB: only copy if both source and target support direct color access
+    CondBinaryOp<has_rgb_v<PointTGT> && has_rgb_v<PointSRC>>::run(tgt_pt, src_pt,
+        [](auto& tgt_pt, const auto& src_pt) {
+            tgt_pt.r = static_cast<decltype(tgt_pt.r)>(src_pt.r);
+            tgt_pt.g = static_cast<decltype(tgt_pt.g)>(src_pt.g);
+            tgt_pt.b = static_cast<decltype(tgt_pt.b)>(src_pt.b);
+        }
+    );
+
+    CondBinaryOp<has_rgb_v<PointTGT> && !has_rgb_v<PointSRC>>::run(tgt_pt, src_pt,
+        [](auto& tgt_pt, const auto&) {
+            tgt_pt.r = static_cast<decltype(tgt_pt.r)>(0);
+            tgt_pt.g = static_cast<decltype(tgt_pt.g)>(0);
+            tgt_pt.b = static_cast<decltype(tgt_pt.b)>(0);
         }
     );
 }

--- a/ouster-ros/src/point_transform.h
+++ b/ouster-ros/src/point_transform.h
@@ -32,6 +32,7 @@ DEFINE_MEMBER_CHECKER(zone_mask);
 DEFINE_MEMBER_CHECKER(r);
 DEFINE_MEMBER_CHECKER(g);
 DEFINE_MEMBER_CHECKER(b);
+DEFINE_MEMBER_CHECKER(a);
 
 // Compile-time predicate identifying point types that expose a complete
 // (r, g, b) color triplet directly accessible by name. Used for direct
@@ -188,6 +189,12 @@ void transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
             tgt_pt.r = static_cast<decltype(tgt_pt.r)>(0);
             tgt_pt.g = static_cast<decltype(tgt_pt.g)>(0);
             tgt_pt.b = static_cast<decltype(tgt_pt.b)>(0);
+        }
+    );
+
+    CondBinaryOp<has_a_v<PointTGT>>::run(tgt_pt, src_pt,
+        [](auto& tgt_pt, const auto&) {
+            tgt_pt.a = static_cast<decltype(tgt_pt.a)>(255);
         }
     );
 }

--- a/ouster-ros/test/point_transform_test.cpp
+++ b/ouster-ros/test/point_transform_test.cpp
@@ -33,6 +33,8 @@ class PointTransformTest : public ::testing::Test {
         initialize_point_elements_with_randoms<point::size(pt_xyz)>(pt_xyz);
         initialize_point_elements_with_randoms<point::size(pt_xyzi)>(pt_xyzi);
         initialize_point_elements_with_randoms<point::size(pt_xyzir)>(pt_xyzir);
+        initialize_point_elements_with_randoms<point::size(pt_xyzrgb)>(
+            pt_xyzrgb);
         // native sensor point types
         initialize_point_elements_with_randoms<point::size(pt_legacy)>(
             pt_legacy);
@@ -42,6 +44,11 @@ class PointTransformTest : public ::testing::Test {
             pt_rg19_rf8_sg16_nr16)>(pt_rg19_rf8_sg16_nr16);
         initialize_point_elements_with_randoms<point::size(pt_rg15_rfl8_nr8)>(
             pt_rg15_rfl8_nr8);
+        initialize_point_elements_with_randoms<point::size(
+            pt_rg19_rf8_sg16_nr16_rgb16)>(pt_rg19_rf8_sg16_nr16_rgb16);
+        initialize_point_elements_with_randoms<point::size(
+            pt_rg19_rf8_sg16_nr16_rgb16_dual)>(
+            pt_rg19_rf8_sg16_nr16_rgb16_dual);
         // ouster_ros original/legacy point type
         initialize_point_elements_with_randoms<point::size(pt_os_point)>(
             pt_os_point);
@@ -53,11 +60,15 @@ class PointTransformTest : public ::testing::Test {
     static pcl::PointXYZ pt_xyz;
     static pcl::PointXYZI pt_xyzi;
     static PointXYZIR pt_xyzir;
+    static pcl::PointXYZRGB pt_xyzrgb;
     // native point types
     static Point_LEGACY pt_legacy;
     static Point_RNG19_RFL8_SIG16_NIR16_DUAL pt_rg19_rf8_sg16_nr16_dual;
     static Point_RNG19_RFL8_SIG16_NIR16 pt_rg19_rf8_sg16_nr16;
     static Point_RNG15_RFL8_NIR8 pt_rg15_rfl8_nr8;
+    static Point_RNG19_RFL8_SIG16_NIR16_RGB16 pt_rg19_rf8_sg16_nr16_rgb16;
+    static Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL
+        pt_rg19_rf8_sg16_nr16_rgb16_dual;
     // ouster_ros original/legacy point (not to be confused with Point_LEGACY)
     static ouster_ros::Point pt_os_point;
 };
@@ -66,12 +77,17 @@ class PointTransformTest : public ::testing::Test {
 pcl::PointXYZ PointTransformTest::pt_xyz;
 pcl::PointXYZI PointTransformTest::pt_xyzi;
 PointXYZIR PointTransformTest::pt_xyzir;
+pcl::PointXYZRGB PointTransformTest::pt_xyzrgb;
 // native point types
 Point_LEGACY PointTransformTest::pt_legacy;
 Point_RNG19_RFL8_SIG16_NIR16_DUAL
     PointTransformTest::pt_rg19_rf8_sg16_nr16_dual;
 Point_RNG19_RFL8_SIG16_NIR16 PointTransformTest::pt_rg19_rf8_sg16_nr16;
 Point_RNG15_RFL8_NIR8 PointTransformTest::pt_rg15_rfl8_nr8;
+Point_RNG19_RFL8_SIG16_NIR16_RGB16
+    PointTransformTest::pt_rg19_rf8_sg16_nr16_rgb16;
+Point_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL
+    PointTransformTest::pt_rg19_rf8_sg16_nr16_rgb16_dual;
 // ouster_ros original/legacy point (not to be confused with Point_LEGACY)
 ouster_ros::Point PointTransformTest::pt_os_point;
 
@@ -173,6 +189,42 @@ void verify_point_transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
         tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
             EXPECT_EQ(tgt_pt.ambient, static_cast<decltype(tgt_pt.ambient)>(0));
         });
+
+    // r/g/b: direct per-channel mapping. We don't perform any source-derived
+    // synthesis on these channels - if the source point lacks a given channel
+    // the target's corresponding channel is expected to be zeroed.
+    CondBinaryOp<has_r_v<PointTGT> && has_r_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.r,
+                      static_cast<decltype(tgt_pt.r)>(src_pt.r));
+        });
+
+    CondBinaryOp<has_r_v<PointTGT> && !has_r_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.r, static_cast<decltype(tgt_pt.r)>(0));
+        });
+
+    CondBinaryOp<has_g_v<PointTGT> && has_g_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.g,
+                      static_cast<decltype(tgt_pt.g)>(src_pt.g));
+        });
+
+    CondBinaryOp<has_g_v<PointTGT> && !has_g_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.g, static_cast<decltype(tgt_pt.g)>(0));
+        });
+
+    CondBinaryOp<has_b_v<PointTGT> && has_b_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
+            EXPECT_EQ(tgt_pt.b,
+                      static_cast<decltype(tgt_pt.b)>(src_pt.b));
+        });
+
+    CondBinaryOp<has_b_v<PointTGT> && !has_b_v<PointSRC>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.b, static_cast<decltype(tgt_pt.b)>(0));
+        });
 }
 
 // lambda function to check that point elements other than xyz have been zeroed
@@ -193,6 +245,10 @@ TEST_F(PointTransformTest, ExpectPointFieldZeroed) {
     expect_points_xyz_equal(pt_xyzir, pt_xyz);
     expect_point_fields_zeros<point::size(pt_xyzir)>(pt_xyzir);
 
+    point::transform(pt_xyzrgb, pt_xyz);
+    expect_points_xyz_equal(pt_xyzrgb, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_xyzrgb)>(pt_xyzrgb);
+
     point::transform(pt_legacy, pt_xyz);
     expect_points_xyz_equal(pt_legacy, pt_xyz);
     expect_point_fields_zeros<point::size(pt_legacy)>(pt_legacy);
@@ -210,6 +266,16 @@ TEST_F(PointTransformTest, ExpectPointFieldZeroed) {
     point::transform(pt_rg15_rfl8_nr8, pt_xyz);
     expect_points_xyz_equal(pt_rg15_rfl8_nr8, pt_xyz);
     expect_point_fields_zeros<point::size(pt_rg15_rfl8_nr8)>(pt_rg15_rfl8_nr8);
+
+    point::transform(pt_rg19_rf8_sg16_nr16_rgb16, pt_xyz);
+    expect_points_xyz_equal(pt_rg19_rf8_sg16_nr16_rgb16, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_rg19_rf8_sg16_nr16_rgb16)>(
+        pt_rg19_rf8_sg16_nr16_rgb16);
+
+    point::transform(pt_rg19_rf8_sg16_nr16_rgb16_dual, pt_xyz);
+    expect_points_xyz_equal(pt_rg19_rf8_sg16_nr16_rgb16_dual, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_rg19_rf8_sg16_nr16_rgb16_dual)>(
+        pt_rg19_rf8_sg16_nr16_rgb16_dual);
 
     point::transform(pt_os_point, pt_xyz);
     expect_points_xyz_equal(pt_os_point, pt_xyz);
@@ -289,4 +355,65 @@ TEST_F(PointTransformTest,
     point::transform(pt_os_point, pt_rg15_rfl8_nr8);
     expect_points_xyz_equal(pt_os_point, pt_rg15_rfl8_nr8);
     verify_point_transform(pt_os_point, pt_rg15_rfl8_nr8);
+
+    point::transform(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16);
+    expect_points_xyz_equal(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16);
+    verify_point_transform(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16);
+
+    point::transform(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    expect_points_xyz_equal(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    verify_point_transform(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+}
+
+TEST_F(PointTransformTest, TestTransformReduce_RNG19_RFL8_SIG16_NIR16_RGB16) {
+    point::transform(pt_xyz, pt_rg19_rf8_sg16_nr16_rgb16);
+    expect_points_xyz_equal(pt_xyz, pt_rg19_rf8_sg16_nr16_rgb16);
+    verify_point_transform(pt_xyz, pt_rg19_rf8_sg16_nr16_rgb16);
+
+    point::transform(pt_xyzi, pt_rg19_rf8_sg16_nr16_rgb16);
+    expect_points_xyz_equal(pt_xyzi, pt_rg19_rf8_sg16_nr16_rgb16);
+    verify_point_transform(pt_xyzi, pt_rg19_rf8_sg16_nr16_rgb16);
+
+    point::transform(pt_xyzir, pt_rg19_rf8_sg16_nr16_rgb16);
+    expect_points_xyz_equal(pt_xyzir, pt_rg19_rf8_sg16_nr16_rgb16);
+    verify_point_transform(pt_xyzir, pt_rg19_rf8_sg16_nr16_rgb16);
+
+    point::transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16);
+    expect_points_xyz_equal(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16);
+    verify_point_transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16);
+}
+
+TEST_F(PointTransformTest,
+       TestTransformReduce_RNG19_RFL8_SIG16_NIR16_RGB16_DUAL) {
+    point::transform(pt_xyz, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    expect_points_xyz_equal(pt_xyz, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    verify_point_transform(pt_xyz, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+
+    point::transform(pt_xyzi, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    expect_points_xyz_equal(pt_xyzi, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    verify_point_transform(pt_xyzi, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+
+    point::transform(pt_xyzir, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    expect_points_xyz_equal(pt_xyzir, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    verify_point_transform(pt_xyzir, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+
+    point::transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    expect_points_xyz_equal(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    verify_point_transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+}
+
+// Validates that transforming a non-RGB native sensor point into pcl::PointXYZRGB
+// results in zeroed color channels (rather than uninitialized memory).
+TEST_F(PointTransformTest, TestTransformReduce_NonRGB_to_PointXYZRGB) {
+    point::transform(pt_xyzrgb, pt_legacy);
+    expect_points_xyz_equal(pt_xyzrgb, pt_legacy);
+    EXPECT_EQ(pt_xyzrgb.r, 0);
+    EXPECT_EQ(pt_xyzrgb.g, 0);
+    EXPECT_EQ(pt_xyzrgb.b, 0);
+
+    point::transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16);
+    expect_points_xyz_equal(pt_xyzrgb, pt_rg19_rf8_sg16_nr16);
+    EXPECT_EQ(pt_xyzrgb.r, 0);
+    EXPECT_EQ(pt_xyzrgb.g, 0);
+    EXPECT_EQ(pt_xyzrgb.b, 0);
 }

--- a/ouster-ros/test/point_transform_test.cpp
+++ b/ouster-ros/test/point_transform_test.cpp
@@ -35,6 +35,8 @@ class PointTransformTest : public ::testing::Test {
         initialize_point_elements_with_randoms<point::size(pt_xyzir)>(pt_xyzir);
         initialize_point_elements_with_randoms<point::size(pt_xyzrgb)>(
             pt_xyzrgb);
+        initialize_point_elements_with_randoms<point::size(pt_xyzrgba)>(
+            pt_xyzrgba);
         // native sensor point types
         initialize_point_elements_with_randoms<point::size(pt_legacy)>(
             pt_legacy);
@@ -61,6 +63,7 @@ class PointTransformTest : public ::testing::Test {
     static pcl::PointXYZI pt_xyzi;
     static PointXYZIR pt_xyzir;
     static pcl::PointXYZRGB pt_xyzrgb;
+    static pcl::PointXYZRGBA pt_xyzrgba;
     // native point types
     static Point_LEGACY pt_legacy;
     static Point_RNG19_RFL8_SIG16_NIR16_DUAL pt_rg19_rf8_sg16_nr16_dual;
@@ -78,6 +81,7 @@ pcl::PointXYZ PointTransformTest::pt_xyz;
 pcl::PointXYZI PointTransformTest::pt_xyzi;
 PointXYZIR PointTransformTest::pt_xyzir;
 pcl::PointXYZRGB PointTransformTest::pt_xyzrgb;
+pcl::PointXYZRGBA PointTransformTest::pt_xyzrgba;
 // native point types
 Point_LEGACY PointTransformTest::pt_legacy;
 Point_RNG19_RFL8_SIG16_NIR16_DUAL
@@ -225,6 +229,11 @@ void verify_point_transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
         tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
             EXPECT_EQ(tgt_pt.b, static_cast<decltype(tgt_pt.b)>(0));
         });
+
+    CondBinaryOp<has_a_v<PointTGT>>::run(
+        tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
+            EXPECT_EQ(tgt_pt.a, static_cast<decltype(tgt_pt.a)>(255));
+        });
 }
 
 // lambda function to check that point elements other than xyz have been zeroed
@@ -248,6 +257,12 @@ TEST_F(PointTransformTest, ExpectPointFieldZeroed) {
     point::transform(pt_xyzrgb, pt_xyz);
     expect_points_xyz_equal(pt_xyzrgb, pt_xyz);
     expect_point_fields_zeros<point::size(pt_xyzrgb)>(pt_xyzrgb);
+    EXPECT_EQ(pt_xyzrgb.a, 255);
+
+    point::transform(pt_xyzrgba, pt_xyz);
+    expect_points_xyz_equal(pt_xyzrgba, pt_xyz);
+    expect_point_fields_zeros<point::size(pt_xyzrgba)>(pt_xyzrgba);
+    EXPECT_EQ(pt_xyzrgba.a, 255);
 
     point::transform(pt_legacy, pt_xyz);
     expect_points_xyz_equal(pt_legacy, pt_xyz);
@@ -381,6 +396,10 @@ TEST_F(PointTransformTest, TestTransformReduce_RNG19_RFL8_SIG16_NIR16_RGB16) {
     point::transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16);
     expect_points_xyz_equal(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16);
     verify_point_transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16);
+
+    point::transform(pt_xyzrgba, pt_rg19_rf8_sg16_nr16_rgb16);
+    expect_points_xyz_equal(pt_xyzrgba, pt_rg19_rf8_sg16_nr16_rgb16);
+    verify_point_transform(pt_xyzrgba, pt_rg19_rf8_sg16_nr16_rgb16);
 }
 
 TEST_F(PointTransformTest,
@@ -400,20 +419,40 @@ TEST_F(PointTransformTest,
     point::transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16_dual);
     expect_points_xyz_equal(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16_dual);
     verify_point_transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+
+    point::transform(pt_xyzrgba, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    expect_points_xyz_equal(pt_xyzrgba, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+    verify_point_transform(pt_xyzrgba, pt_rg19_rf8_sg16_nr16_rgb16_dual);
 }
 
-// Validates that transforming a non-RGB native sensor point into pcl::PointXYZRGB
-// results in zeroed color channels (rather than uninitialized memory).
-TEST_F(PointTransformTest, TestTransformReduce_NonRGB_to_PointXYZRGB) {
+// Validates that transforming a non-RGB native sensor point into PCL RGB point
+// types results in zeroed color channels (rather than uninitialized memory).
+TEST_F(PointTransformTest, TestTransformReduce_NonRGB_to_PclColorPoints) {
     point::transform(pt_xyzrgb, pt_legacy);
     expect_points_xyz_equal(pt_xyzrgb, pt_legacy);
     EXPECT_EQ(pt_xyzrgb.r, 0);
     EXPECT_EQ(pt_xyzrgb.g, 0);
     EXPECT_EQ(pt_xyzrgb.b, 0);
+    EXPECT_EQ(pt_xyzrgb.a, 255);
+
+    point::transform(pt_xyzrgba, pt_legacy);
+    expect_points_xyz_equal(pt_xyzrgba, pt_legacy);
+    EXPECT_EQ(pt_xyzrgba.r, 0);
+    EXPECT_EQ(pt_xyzrgba.g, 0);
+    EXPECT_EQ(pt_xyzrgba.b, 0);
+    EXPECT_EQ(pt_xyzrgba.a, 255);
 
     point::transform(pt_xyzrgb, pt_rg19_rf8_sg16_nr16);
     expect_points_xyz_equal(pt_xyzrgb, pt_rg19_rf8_sg16_nr16);
     EXPECT_EQ(pt_xyzrgb.r, 0);
     EXPECT_EQ(pt_xyzrgb.g, 0);
     EXPECT_EQ(pt_xyzrgb.b, 0);
+    EXPECT_EQ(pt_xyzrgb.a, 255);
+
+    point::transform(pt_xyzrgba, pt_rg19_rf8_sg16_nr16);
+    expect_points_xyz_equal(pt_xyzrgba, pt_rg19_rf8_sg16_nr16);
+    EXPECT_EQ(pt_xyzrgba.r, 0);
+    EXPECT_EQ(pt_xyzrgba.g, 0);
+    EXPECT_EQ(pt_xyzrgba.b, 0);
+    EXPECT_EQ(pt_xyzrgba.a, 255);
 }


### PR DESCRIPTION
## Related Issues & PRs
ROS1: #543

## Summary of Changes
* Switch to using ouster-sdk 0.16.2 build
* Add support for RGB profiles and `pcl::XYZRGB` point type
* Add support for `pcl::PointXYZRGBA`.
* Defined a new point type `color_point` that has the same field as `ouster_ros::Point` but adds color fields
* Turn on RGB processing only when needed

### Remaining TODOs
* ~Publish RGB color images~
* ~Apply auto-exposure~
* ~Make RGB [completely] processing optional~
* Add a flag to turn on/off auto-exposure (later)
* Update RVIZ file to readily show RGB data.


## Validation
* No auto-exposure
<img width="3700" height="2350" alt="image" src="https://github.com/user-attachments/assets/fc6754ce-cddd-4d3b-a2d0-1cb6652495d7" />
* with auto-exposure
<img width="3844" height="2164" alt="image" src="https://github.com/user-attachments/assets/7d10b14c-9753-454b-afeb-332a10b93144" />

