### PR TITLE
[ROS2] Harden timing, packet processing, lifecycle, and PCAP replay

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -233,6 +233,7 @@ if(BUILD_TESTING)
   ament_add_gtest(${PROJECT_NAME}_test
     src/os_ros.cpp
     test/test_main.cpp
+    test/lidar_packet_handler_test.cpp
     test/lock_free_ring_buffer_test.cpp
     test/point_accessor_test.cpp
     test/point_transform_test.cpp

--- a/ouster-ros/config/community_driver_config.yaml
+++ b/ouster-ros/config/community_driver_config.yaml
@@ -8,7 +8,7 @@ ouster_driver:
     imu_port: 7503
     lidar_port: 7502
     sensor_frame: laser_sensor_frame
-    laser_frame: laser_data_frame
+    lidar_frame: laser_data_frame
     imu_frame: imu_data_frame
 
     # if False, data are published with sensor data QoS. This is preferrable

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -103,6 +103,16 @@ ouster/os_driver:
     # data QoS. This is preferrable for production but default QoS is needed for
     # rosbag. See: https://github.com/ros2/rosbag2/issues/125
     use_system_default_qos: false
+    # PointCloud2 publisher QoS may be overridden independently using ROS 2's
+    # standard qos_overrides parameters. The topic key is fully resolved, so
+    # update it if the default `ouster` namespace changes; repeat for points2
+    # with dual returns. Example:
+    # qos_overrides:
+    #   /ouster/points:
+    #     publisher:
+    #       reliability: reliable
+    #       history: keep_last
+    #       depth: 10
     # point_type[optional]: choose from: {original, native, xyz, xyzi, o_xyzi,
     #                                     xyzir, xyzrgb, xyzrgba, color_point}
     # Here is a breif description of each option:

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -46,4 +46,5 @@ ouster/os_cloud:
                   # value the range [0, sensor_beams_count)
     point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzrgb, xyzrgba}
 ouster/os_image:
+  ros__parameters:
     use_system_default_qos: false # needs to match the value defined for os_sensor node

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -42,9 +42,13 @@ ouster/os_cloud:
     ptp_utc_tai_offset: -37.0 # UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588
     proc_mask: IMU|PCL|SCAN|TLM # pick IMU, PCL, SCAN, TLM or any combination of the 4 options
     use_system_default_qos: false # needs to match the value defined for os_sensor node
+    # PointCloud2 publishers accept ROS 2 per-topic QoS overrides independently
+    # of the packet subscription QoS above. For example, configure
+    # qos_overrides./ouster/points.publisher.reliability and depth; repeat for
+    # /ouster/points2 when using dual returns.
     scan_ring: 0  # Use this parameter in conjunction with the SCAN flag and choose a
                   # value the range [0, sensor_beams_count)
-    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzrgb, xyzrgba}
+    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzrgb, xyzrgba, color_point}
 ouster/os_image:
   ros__parameters:
     use_system_default_qos: false # needs to match the value defined for os_sensor node

--- a/ouster-ros/include/ouster_ros/color_point.h
+++ b/ouster-ros/include/ouster_ros/color_point.h
@@ -40,7 +40,7 @@ struct ColorPoint : public _ColorPoint {
       ring = pt.ring;
       ambient = pt.ambient;
       range = pt.range;
-      r = pt.r; g = pt.g; b = pt.b;
+      rgba = pt.rgba;
     }
 
     inline ColorPoint()
@@ -86,7 +86,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(ouster_ros::ColorPoint,
     (std::uint16_t, ring, ring)
     (std::uint16_t, ambient, ambient)
     (std::uint32_t, range, range)
-    (std::uint32_t, rgb, rgb)
+    (float, rgb, rgb)
 )
 
 // clang-format on

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -22,6 +22,8 @@
 #include <sensor_msgs/msg/laser_scan.hpp>
 
 #include <chrono>
+#include <climits>
+#include <cmath>
 #include <string>
 #include <vector>
 
@@ -148,7 +150,13 @@ inline ouster::sdk::core::img_t<T> get_or_fill_zero(const std::string& field,
  * @remark method does not check upper boundary
  */
 inline uint64_t ts_safe_offset_add(uint64_t ts, int64_t offset) {
-    return offset < 0 && ts < static_cast<uint64_t>(std::abs(offset)) ? 0 : ts + offset;
+    if (offset < 0) {
+        const uint64_t magnitude =
+            static_cast<uint64_t>(-(offset + 1)) + 1ULL;
+        return ts < magnitude ? 0 : ts - magnitude;
+    }
+    const uint64_t positive = static_cast<uint64_t>(offset);
+    return ts > ULLONG_MAX - positive ? ULLONG_MAX : ts + positive;
 }
 
 std::set<std::string> parse_tokens(const std::string& input, char delim);
@@ -164,7 +172,8 @@ template <typename T>
 uint64_t ulround(T value) {
     T rounded_value = std::round(value);
     if (rounded_value < 0) return 0ULL;
-    if (rounded_value > ULLONG_MAX) return ULLONG_MAX;
+    if (static_cast<double>(rounded_value) >= 18446744073709551616.0)
+        return ULLONG_MAX;
     return static_cast<uint64_t>(rounded_value);
 }
 

--- a/ouster-ros/include/ouster_ros/os_sensor_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_sensor_node_base.h
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <chrono>
+#include <mutex>
 #include <vector>
 
 #include <rclcpp/rclcpp.hpp>
@@ -58,6 +59,7 @@ class OusterSensorNodeBase : public rclcpp_lifecycle::LifecycleNode {
     ouster::sdk::core::SensorInfo info;
     rclcpp::Service<ouster_sensor_msgs::srv::GetMetadata>::SharedPtr get_metadata_srv;
     std::string cached_metadata;
+    mutable std::mutex cached_metadata_mutex;
     rclcpp::Publisher<std_msgs::msg::String>::SharedPtr metadata_pub;
 };
 

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -264,7 +264,7 @@
     <arg name="rviz_config" value="$(var rviz_config)"/>
   </include>
 
-  <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'b\'')"/>
+  <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'\'')"/>
   <!-- TODO: find out why this doesn't work when passing to record -->
   <!-- <let name="_topics_to_record" value="/imu_packets /lidar_packets"/> -->
 

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -150,12 +150,7 @@
   <arg name="phase_lock_offset" default="0"
     description="Angle that sensors are locked to in millidegrees, values range [0, 360000]"/>
 
-  <!-- Only set this parameter when working with FW3.2 -->
-  <arg name="lidar_frame_azimuth_offset" default="-1"
-    description="The lidar frame azimuth offset for the sensor to use in millidegrees;
-    values range [0, 360000], -1 is unset"/>
-
-  <!-- Only set this parameter when working with FW3.2 -->
+  <!-- Only set this parameter when working with FW3.2+ -->
   <arg name="lidar_frame_azimuth_offset" default="-1"
     description="The lidar frame azimuth offset for the sensor to use in millidegrees (FW3.2+);
     values range [0, 360000], -1 is unset"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -129,7 +129,7 @@
     <arg name="rviz_config" value="$(var rviz_config)"/>
   </include>
 
-  <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'b\'')"/>
+  <let name="_use_bag_file_name" value="$(eval '\'$(var bag_file)\' != \'\'')"/>
 
   <executable if="$(var _use_bag_file_name)" output="screen"
     launch-prefix="bash -c 'sleep $(var play_delay); $0 $@'"

--- a/ouster-ros/src/impl/file_util.cpp
+++ b/ouster-ros/src/impl/file_util.cpp
@@ -21,7 +21,7 @@ bool write_text_to_file(const std::string& file_path,
     if (!ofs.is_open()) return false;
     ofs << text << std::endl;
     ofs.close();
-    return true;
+    return !ofs.fail();
 }
 
 } // namespace impl

--- a/ouster-ros/src/laser_scan_processor.h
+++ b/ouster-ros/src/laser_scan_processor.h
@@ -27,7 +27,9 @@ class LaserScanProcessor {
                        const std::string& frame_id, uint16_t ring,
                        PostProcessingFn func)
         : frame(frame_id),
-          ld_mode(info.config.lidar_mode.value()),
+          ld_mode(info.config.lidar_mode.value_or(
+              ouster::sdk::core::LidarMode(info.format.columns_per_frame,
+                                           info.format.fps))),
           ring_(ring),
           pixel_shift_by_row(info.format.pixel_shift_by_row),
           scan_msgs(info.num_returns()),

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -312,6 +312,14 @@ class LidarPacketHandler {
                           int scan_width) {
         assert(scan_width + curr_scan_first_nonzero_idx >
                last_scan_last_nonzero_idx);
+        if (scan_width + curr_scan_first_nonzero_idx <=
+            last_scan_last_nonzero_idx) {
+            // Precondition violated (corrupt column indices); the assert above
+            // is compiled out under NDEBUG and linear_interpolate would divide
+            // by zero. Fall back to extrapolating from the current scan alone.
+            return extrapolate_value(curr_scan_first_nonzero_idx,
+                                     curr_scan_first_nonzero_value);
+        }
         double interpolated_value = linear_interpolate(
             last_scan_last_nonzero_idx, last_scan_last_nonzero_value,
             scan_width + curr_scan_first_nonzero_idx,
@@ -327,12 +335,19 @@ class LidarPacketHandler {
         return impl::ulround(extrapolated_value);
     }
 
-    // compute_scan_ts_0 for first scan
-    uint64_t compute_scan_ts_0(
+    // compute_scan_ts_0 for first scan. Returns std::nullopt if the scan has
+    // no non-zero timestamp column at all (the caller must drop the scan);
+    // the asserts this replaces were compiled out under NDEBUG and an
+    // all-zero column would dereference an end iterator.
+    std::optional<uint64_t> compute_scan_ts_0(
         const ouster::sdk::core::LidarScan::Header<uint64_t>& ts_v) {
         auto idx = std::find_if(ts_v.data(), ts_v.data() + ts_v.size(),
                                 [](uint64_t h) { return h != 0; });
-        assert(idx != ts_v.data() + ts_v.size());  // should never happen
+        if (idx == ts_v.data() + ts_v.size()) {
+            RCLCPP_WARN(rclcpp::get_logger(getName()),
+                        "scan timestamp column is all zeros, dropping scan");
+            return std::nullopt;
+        }
         int curr_scan_first_nonzero_idx = idx - ts_v.data();
         uint64_t curr_scan_first_nonzero_value = *idx;
 
@@ -344,7 +359,11 @@ class LidarPacketHandler {
 
         last_scan_last_nonzero_idx =
             find_if_reverse(ts_v, [](uint64_t h) { return h != 0; });
-        assert(last_scan_last_nonzero_idx >= 0);  // should never happen
+        // Logically guaranteed to succeed since std::find_if above already
+        // located a non-zero element, but guard in Release: indexing ts_v
+        // with -1 would be UB. State is untouched, so the next scan
+        // re-anchors through compute_scan_ts_0 again.
+        if (last_scan_last_nonzero_idx < 0) return std::nullopt;
         last_scan_last_nonzero_value = ts_v(last_scan_last_nonzero_idx);
         compute_scan_ts = [this](const auto& ts_v) {
             return compute_scan_ts_n(ts_v);
@@ -353,12 +372,20 @@ class LidarPacketHandler {
         return scan_ns;
     }
 
-    // compute_scan_ts_n applied to all subsequent scans except first one
-    uint64_t compute_scan_ts_n(
+    // compute_scan_ts_n applied to all subsequent scans except first one.
+    // Same std::nullopt contract as compute_scan_ts_0; when a scan is
+    // dropped the estimator re-anchors on the next valid scan instead of
+    // imputing across the gap with stale last_scan_last_nonzero_* state.
+    std::optional<uint64_t> compute_scan_ts_n(
         const ouster::sdk::core::LidarScan::Header<uint64_t>& ts_v) {
         auto idx = std::find_if(ts_v.data(), ts_v.data() + ts_v.size(),
                                 [](uint64_t h) { return h != 0; });
-        assert(idx != ts_v.data() + ts_v.size());  // should never happen
+        if (idx == ts_v.data() + ts_v.size()) {
+            RCLCPP_WARN(rclcpp::get_logger(getName()),
+                        "scan timestamp column is all zeros, dropping scan");
+            reset_compute_scan_ts();
+            return std::nullopt;
+        }
         int curr_scan_first_nonzero_idx = idx - ts_v.data();
         uint64_t curr_scan_first_nonzero_value = *idx;
         uint64_t scan_ns = curr_scan_first_nonzero_idx == 0
@@ -370,9 +397,24 @@ class LidarPacketHandler {
                                               static_cast<int>(ts_v.size()));
         last_scan_last_nonzero_idx =
             find_if_reverse(ts_v, [](uint64_t h) { return h != 0; });
-        assert(last_scan_last_nonzero_idx >= 0);  // should never happen
+        // See compute_scan_ts_0: cannot fail after find_if succeeded, but
+        // guard in Release and re-anchor rather than keep stale state.
+        if (last_scan_last_nonzero_idx < 0) {
+            reset_compute_scan_ts();
+            return std::nullopt;
+        }
         last_scan_last_nonzero_value = ts_v(last_scan_last_nonzero_idx);
         return scan_ns;
+    }
+
+    // Forget the previous scan's trailing timestamp and anchor the estimator
+    // on the next valid scan via compute_scan_ts_0.
+    void reset_compute_scan_ts() {
+        last_scan_last_nonzero_idx = -1;
+        last_scan_last_nonzero_value = 0;
+        compute_scan_ts = [this](const auto& ts_v) {
+            return compute_scan_ts_0(ts_v);
+        };
     }
 
     uint16_t packet_col_index(const ouster::sdk::core::PacketFormat& pf,
@@ -394,9 +436,11 @@ class LidarPacketHandler {
                                    const ouster::sdk::core::LidarPacket& lidar_packet,
                                    ouster::sdk::core::LidarScan& lidar_scan) {
         if (!(*scan_batcher)(lidar_packet, lidar_scan)) return false;
+        const auto scan_ts = compute_scan_ts(lidar_scan.timestamp());
+        if (!scan_ts) return false;  // drop scans without a usable timestamp
         const auto slot = ring_buffer.write_head();
-        lidar_scan_slot_ts[slot] = compute_scan_ts(lidar_scan.timestamp());
-        lidar_scan_slot_msg_ts[slot] = rclcpp::Time(lidar_scan_slot_ts[slot]);
+        lidar_scan_slot_ts[slot] = *scan_ts;
+        lidar_scan_slot_msg_ts[slot] = rclcpp::Time(*scan_ts);
 
         return true;
     }
@@ -408,9 +452,11 @@ class LidarPacketHandler {
         auto ts_v = lidar_scan.timestamp();
         for (int i = 0; i < ts_v.rows(); ++i)
             ts_v[i] = impl::ts_safe_offset_add(ts_v[i], ptp_utc_tai_offset_);
+        const auto scan_ts = compute_scan_ts(ts_v);
+        if (!scan_ts) return false;  // drop scans without a usable timestamp
         const auto slot = ring_buffer.write_head();
-        lidar_scan_slot_ts[slot] = compute_scan_ts(ts_v);
-        lidar_scan_slot_msg_ts[slot] = rclcpp::Time(lidar_scan_slot_ts[slot]);
+        lidar_scan_slot_ts[slot] = *scan_ts;
+        lidar_scan_slot_msg_ts[slot] = rclcpp::Time(*scan_ts);
 
         return true;
     }
@@ -427,12 +473,16 @@ class LidarPacketHandler {
         }
 
         if (!(*scan_batcher)(lidar_packet, lidar_scan)) return false;
-        const auto slot = ring_buffer.write_head();
-        lidar_scan_slot_ts[slot] = compute_scan_ts(lidar_scan.timestamp());
-        lidar_scan_slot_msg_ts[slot] = lidar_handler_ros_time_frame_ts.value();
-        // set time for next point cloud msg
+        const auto scan_ts = compute_scan_ts(lidar_scan.timestamp());
+        const auto frame_ts = lidar_handler_ros_time_frame_ts.value();
+        // set time for next point cloud msg (even when this scan is dropped,
+        // so the next frame's ROS time stays anchored to packet arrival)
         lidar_handler_ros_time_frame_ts = extrapolate_frame_ts(
             pf, lidar_packet.buf.data(), packet_receive_time);
+        if (!scan_ts) return false;  // drop scans without a usable timestamp
+        const auto slot = ring_buffer.write_head();
+        lidar_scan_slot_ts[slot] = *scan_ts;
+        lidar_scan_slot_msg_ts[slot] = frame_ts;
         return true;
     }
 
@@ -465,7 +515,10 @@ class LidarPacketHandler {
     double scan_col_ts_spacing_ns;  // interval or spacing between columns of a
                                     // scan
 
-    std::function<uint64_t(const ouster::sdk::core::LidarScan::Header<uint64_t>&)>
+    // Returns std::nullopt when the scan carries no usable timestamp (the
+    // scan must then be dropped instead of published with a zero stamp).
+    std::function<std::optional<uint64_t>(
+        const ouster::sdk::core::LidarScan::Header<uint64_t>&)>
         compute_scan_ts;
 
     std::vector<LidarScanProcessor> lidar_scan_handlers;

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -104,6 +104,10 @@ class LidarPacketHandler {
 
         lidar_scans.resize(LIDAR_SCAN_COUNT);
         mutexes.resize(LIDAR_SCAN_COUNT);
+        // Per-slot scan-timestamp storage. Kept alongside lidar_scans so the
+        // existing per-slot mutex serialises writer/reader access.
+        lidar_scan_slot_ts.assign(LIDAR_SCAN_COUNT, 0);
+        lidar_scan_slot_msg_ts.assign(LIDAR_SCAN_COUNT, rclcpp::Time(0, 0));
 
         for (size_t i = 0; i < lidar_scans.size(); ++i) {
             // NOTE: must construct with SensorInfo (not the
@@ -240,11 +244,12 @@ class LidarPacketHandler {
             if (ring_buffer.empty()) return;
         }
 
-        std::unique_lock<std::mutex> lock(*mutexes[ring_buffer.read_head()]);
+        const auto slot = ring_buffer.read_head();
+        std::unique_lock<std::mutex> lock(*mutexes[slot]);
 
         // apply auto exposure to the rgb data only if the point cloud has rgb fields
         // NOTE[UN]: Don't copy the lidar scan to avoid modifying the original scan in the ring buffer
-        ouster::sdk::core::LidarScan& ls = *lidar_scans[ring_buffer.read_head()];
+        ouster::sdk::core::LidarScan& ls = *lidar_scans[slot];
 
         if (has_rgb_) {
             using ouster::sdk::core::img_t;
@@ -285,7 +290,7 @@ class LidarPacketHandler {
         }
 
         for (auto h : lidar_scan_handlers) {
-            h(ls, lidar_scan_estimated_ts, lidar_scan_estimated_msg_ts);
+            h(ls, lidar_scan_slot_ts[slot], lidar_scan_slot_msg_ts[slot]);
         }
 
         // when we hit percent amount of the ring_buffer capacity throttle
@@ -389,8 +394,9 @@ class LidarPacketHandler {
                                    const ouster::sdk::core::LidarPacket& lidar_packet,
                                    ouster::sdk::core::LidarScan& lidar_scan) {
         if (!(*scan_batcher)(lidar_packet, lidar_scan)) return false;
-        lidar_scan_estimated_ts = compute_scan_ts(lidar_scan.timestamp());
-        lidar_scan_estimated_msg_ts = rclcpp::Time(lidar_scan_estimated_ts);
+        const auto slot = ring_buffer.write_head();
+        lidar_scan_slot_ts[slot] = compute_scan_ts(lidar_scan.timestamp());
+        lidar_scan_slot_msg_ts[slot] = rclcpp::Time(lidar_scan_slot_ts[slot]);
 
         return true;
     }
@@ -402,9 +408,9 @@ class LidarPacketHandler {
         auto ts_v = lidar_scan.timestamp();
         for (int i = 0; i < ts_v.rows(); ++i)
             ts_v[i] = impl::ts_safe_offset_add(ts_v[i], ptp_utc_tai_offset_);
-        lidar_scan_estimated_ts = compute_scan_ts(ts_v);
-        lidar_scan_estimated_msg_ts =
-            rclcpp::Time(lidar_scan_estimated_ts);
+        const auto slot = ring_buffer.write_head();
+        lidar_scan_slot_ts[slot] = compute_scan_ts(ts_v);
+        lidar_scan_slot_msg_ts[slot] = rclcpp::Time(lidar_scan_slot_ts[slot]);
 
         return true;
     }
@@ -421,8 +427,9 @@ class LidarPacketHandler {
         }
 
         if (!(*scan_batcher)(lidar_packet, lidar_scan)) return false;
-        lidar_scan_estimated_ts = compute_scan_ts(lidar_scan.timestamp());
-        lidar_scan_estimated_msg_ts = lidar_handler_ros_time_frame_ts.value();
+        const auto slot = ring_buffer.write_head();
+        lidar_scan_slot_ts[slot] = compute_scan_ts(lidar_scan.timestamp());
+        lidar_scan_slot_msg_ts[slot] = lidar_handler_ros_time_frame_ts.value();
         // set time for next point cloud msg
         lidar_handler_ros_time_frame_ts = extrapolate_frame_ts(
             pf, lidar_packet.buf.data(), packet_receive_time);
@@ -444,9 +451,11 @@ class LidarPacketHandler {
     std::mutex ring_buffer_mutex;
     std::vector<std::unique_ptr<ouster::sdk::core::LidarScan>> lidar_scans;
     std::vector<std::unique_ptr<std::mutex>> mutexes;
-
-    uint64_t lidar_scan_estimated_ts;
-    rclcpp::Time lidar_scan_estimated_msg_ts;
+    // Per-slot scan timestamp, written by the lidar_handler_* methods inside
+    // the writer's per-slot mutex and read in process_scans() inside the same
+    // mutex for the slot at read_head().
+    std::vector<uint64_t> lidar_scan_slot_ts;
+    std::vector<rclcpp::Time> lidar_scan_slot_msg_ts;
 
     std::optional<rclcpp::Time> lidar_handler_ros_time_frame_ts;
 

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -18,18 +18,25 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "lock_free_ring_buffer.h"
-#include <optional>
-#include <chrono>
-#include <mutex>
-#include <condition_variable>
-#include <thread>
+
+#include <algorithm>
 #include <atomic>
-#include <vector>
+#include <cassert>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <ouster/image_processing.h>
-
-namespace ChanField = ouster::sdk::core::ChanField;
 
 namespace {
 
@@ -44,23 +51,31 @@ int find_if_reverse(const Eigen::Array<T, -1, 1>& array,
 }
 
 uint64_t linear_interpolate(int x0, uint64_t y0, int x1, uint64_t y1, int x) {
-    uint64_t min_v, max_v;
-    double sign;
-    if (y1 > y0) {
-        min_v = y0;
-        max_v = y1;
-        sign = +1;
-    } else {
-        min_v = y1;
-        max_v = y0;
-        sign = -1;
-    }
-    return y0 + (x - x0) * sign * (max_v - min_v) / (x1 - x0);
+    assert(x1 > x0 && x >= x0 && x <= x1);
+    if (x1 <= x0 || x <= x0) return y0;
+    if (x >= x1) return y1;
+
+    // Keep the epoch-sized base timestamp out of floating-point arithmetic.
+    // PTP/TAI nanoseconds are above 2^53, where double loses integer
+    // precision. Splitting delta * numerator / denominator into quotient and
+    // remainder also avoids an overflowing intermediate and stays portable
+    // to compilers without a 128-bit integer extension.
+    const uint64_t numerator = static_cast<uint64_t>(x - x0);
+    const uint64_t denominator = static_cast<uint64_t>(x1 - x0);
+    const uint64_t delta = y1 >= y0 ? y1 - y0 : y0 - y1;
+    const uint64_t scaled_delta =
+        (delta / denominator) * numerator +
+        ((delta % denominator) * numerator) / denominator;
+    return y1 >= y0 ? y0 + scaled_delta : y0 - scaled_delta;
 }
 
 // Fast float16 -> float32 conversion for normal-range values.
 inline float f16_bits_to_f32(uint16_t bits) {
-    if (bits == 0) return 0.0f;
+    // RGB samples are non-negative. Reject signed, subnormal, infinite and
+    // NaN encodings before they can poison the shared auto-exposure state.
+    if (bits & 0x8000u) return 0.0f;
+    const uint16_t exponent = bits & 0x7C00u;
+    if (exponent == 0 || exponent == 0x7C00u) return 0.0f;
     const uint32_t expanded = static_cast<uint32_t>(bits + 0x1C000u) << 13;
     float result;
     std::memcpy(&result, &expanded, sizeof(float));
@@ -76,6 +91,8 @@ inline uint8_t f32_to_u8(float v) {
 }  // namespace
 
 namespace ouster_ros {
+
+namespace ChanField = ouster::sdk::core::ChanField;
 
 using LidarScanProcessor =
     std::function<void(const ouster::sdk::core::LidarScan&, uint64_t, const rclcpp::Time&)>;
@@ -94,7 +111,8 @@ class LidarPacketHandler {
                        const std::vector<LidarScanProcessor>& handlers,
                        const std::string& timestamp_mode,
                        int64_t ptp_utc_tai_offset,
-                       float min_scan_valid_columns_ratio)
+                       float min_scan_valid_columns_ratio,
+                       bool process_rgb = true)
         : ring_buffer(LIDAR_SCAN_COUNT),
           lidar_scan_handlers{handlers},
           ptp_utc_tai_offset_(ptp_utc_tai_offset),
@@ -117,8 +135,12 @@ class LidarPacketHandler {
             mutexes[i] = std::make_unique<std::mutex>();
         }
 
-        if (info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
-            info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL) {
+        const bool profile_has_rgb =
+            info.format.udp_profile_lidar ==
+                ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+            info.format.udp_profile_lidar ==
+                ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
+        if (process_rgb && profile_has_rgb) {
             has_rgb_ = true;
             uint32_t H = info.format.pixels_per_column;
             uint32_t W = info.format.columns_per_frame;
@@ -134,16 +156,8 @@ class LidarPacketHandler {
             }
         }
 
-        lidar_scans_processing_thread = std::make_unique<std::thread>([this]() {
-            while (lidar_scans_processing_active) {
-                process_scans();
-            }
-            RCLCPP_DEBUG(rclcpp::get_logger(getName()),
-                         "lidar_scans_processing_thread done.");
-        });
-
         // initalize time handlers
-        scan_col_ts_spacing_ns = compute_scan_col_ts_spacing_ns(info.config.lidar_mode.value());
+        scan_col_ts_spacing_ns = compute_scan_col_ts_spacing_ns(info);
         compute_scan_ts = [this](const auto& ts_v) {
             return compute_scan_ts_0(ts_v);
         };
@@ -193,10 +207,33 @@ class LidarPacketHandler {
                     }
                 }
                 if (result) {
-                    ring_buffer.write();
+                    // Publish the predicate state under the same mutex used
+                    // by process_scans(). Without this synchronization a
+                    // notification can be lost between the consumer's empty
+                    // check and wait, stalling playback for the old 1 s
+                    // timeout and causing avoidable ring-buffer drops.
+                    std::lock_guard<std::mutex> index_lock(ring_buffer_mutex);
+                    if (!ring_buffer.write()) {
+                        RCLCPP_ERROR(rclcpp::get_logger(getName()),
+                                     "failed to enqueue completed lidar scan");
+                        return false;
+                    }
                 }
+                if (result) ring_buffer_has_elements.notify_one();
                 return result;
             }};
+
+        // Start the worker only after every object it touches is initialized
+        // and after all constructor operations that can throw. Otherwise a
+        // later exception can destroy a joinable std::thread and terminate
+        // the process.
+        lidar_scans_processing_thread = std::make_unique<std::thread>([this]() {
+            while (lidar_scans_processing_active) {
+                process_scans();
+            }
+            RCLCPP_DEBUG(rclcpp::get_logger(getName()),
+                         "lidar_scans_processing_thread done.");
+        });
     }
 
     LidarPacketHandler(const LidarPacketHandler&) = delete;
@@ -205,7 +242,11 @@ class LidarPacketHandler {
         RCLCPP_DEBUG(rclcpp::get_logger(getName()),
                      "LidarPacketHandler::~LidarPacketHandler()");
         if (lidar_scans_processing_thread->joinable()) {
-            lidar_scans_processing_active = false;
+            {
+                std::lock_guard<std::mutex> index_lock(ring_buffer_mutex);
+                lidar_scans_processing_active = false;
+            }
+            ring_buffer_has_elements.notify_all();
             lidar_scans_processing_thread->join();
         }
     }
@@ -221,30 +262,29 @@ class LidarPacketHandler {
         const ouster::sdk::core::SensorInfo& info,
         const std::vector<LidarScanProcessor>& handlers,
         const std::string& timestamp_mode, int64_t ptp_utc_tai_offset,
-        float min_scan_valid_columns_ratio) {
+        float min_scan_valid_columns_ratio, bool process_rgb = true) {
         auto handler = std::make_shared<LidarPacketHandler>(
             info, handlers, timestamp_mode, ptp_utc_tai_offset,
-            min_scan_valid_columns_ratio);
+            min_scan_valid_columns_ratio, process_rgb);
         return [handler](const ouster::sdk::core::LidarPacket& lidar_packet) {
-            if (handler->lidar_packet_accumlator(lidar_packet)) {
-                handler->ring_buffer_has_elements.notify_one();
-            }
+            handler->lidar_packet_accumlator(lidar_packet);
         };
     }
 
     const std::string getName() const { return "lidar_packet_hander"; }
 
     void process_scans() {
+        size_t slot;
         {
-            using namespace std::chrono;
             std::unique_lock<std::mutex> index_lock(ring_buffer_mutex);
-            ring_buffer_has_elements.wait_for(
-                index_lock, 1s, [this] { return !ring_buffer.empty(); });
+            ring_buffer_has_elements.wait(index_lock, [this] {
+                return !lidar_scans_processing_active || !ring_buffer.empty();
+            });
 
-            if (ring_buffer.empty()) return;
+            if (!lidar_scans_processing_active) return;
+            slot = ring_buffer.read_head();
         }
 
-        const auto slot = ring_buffer.read_head();
         std::unique_lock<std::mutex> lock(*mutexes[slot]);
 
         // apply auto exposure to the rgb data only if the point cloud has rgb fields
@@ -289,19 +329,21 @@ class LidarPacketHandler {
             }
         }
 
-        for (auto h : lidar_scan_handlers) {
+        for (const auto& h : lidar_scan_handlers) {
             h(ls, lidar_scan_slot_ts[slot], lidar_scan_slot_msg_ts[slot]);
         }
 
-        // when we hit percent amount of the ring_buffer capacity throttle
-        size_t read_step = 1;
-        if (ring_buffer.size() > THROTTLE_PERCENT * ring_buffer.capacity()) {
-            RCLCPP_WARN(rclcpp::get_logger(getName()),
-                               "lidar_scans %d%% full, THROTTLING",
-                               static_cast<int>(100* THROTTLE_PERCENT));
-            read_step = 2;
+        // Consume exactly the scan that was processed. Skipping a second scan
+        // to catch up silently decimates the effective sensor/bag rate and can
+        // pair downstream state with the wrong frame. If consumers cannot
+        // keep pace, the producer reports explicit full-ring packet drops.
+        {
+            std::lock_guard<std::mutex> index_lock(ring_buffer_mutex);
+            if (!ring_buffer.read()) {
+                RCLCPP_ERROR(rclcpp::get_logger(getName()),
+                             "failed to consume processed lidar scan");
+            }
         }
-        ring_buffer.read(read_step);
     }
 
     // time interpolation methods
@@ -320,19 +362,19 @@ class LidarPacketHandler {
             return extrapolate_value(curr_scan_first_nonzero_idx,
                                      curr_scan_first_nonzero_value);
         }
-        double interpolated_value = linear_interpolate(
+        return linear_interpolate(
             last_scan_last_nonzero_idx, last_scan_last_nonzero_value,
             scan_width + curr_scan_first_nonzero_idx,
             curr_scan_first_nonzero_value, scan_width);
-        return impl::ulround(interpolated_value);
     }
 
     uint64_t extrapolate_value(int curr_scan_first_nonzero_idx,
                                uint64_t curr_scan_first_nonzero_value) {
-        double extrapolated_value =
-            curr_scan_first_nonzero_value -
-            scan_col_ts_spacing_ns * curr_scan_first_nonzero_idx;
-        return impl::ulround(extrapolated_value);
+        const auto delta = static_cast<uint64_t>(std::llround(
+            scan_col_ts_spacing_ns * curr_scan_first_nonzero_idx));
+        return curr_scan_first_nonzero_value >= delta
+                   ? curr_scan_first_nonzero_value - delta
+                   : 0;
     }
 
     // compute_scan_ts_0 for first scan. Returns std::nullopt if the scan has
@@ -486,9 +528,18 @@ class LidarPacketHandler {
         return true;
     }
 
-    static double compute_scan_col_ts_spacing_ns(ouster::sdk::core::LidarMode ld_mode) {
-        const auto scan_width = ouster::sdk::core::n_cols_of_lidar_mode(ld_mode);
-        const auto scan_frequency = ouster::sdk::core::frequency_of_lidar_mode(ld_mode);
+    static double compute_scan_col_ts_spacing_ns(
+        const ouster::sdk::core::SensorInfo& info) {
+        // DataFormat carries the actual packet dimensions and frame rate even
+        // when older/partial metadata omits config.lidar_mode. Using it avoids
+        // std::bad_optional_access without inventing a 0x0 mode (which would
+        // divide by zero and corrupt every derived timestamp).
+        const auto scan_width = info.format.columns_per_frame;
+        const auto scan_frequency = info.format.fps;
+        if (scan_width == 0 || scan_frequency == 0) {
+            throw std::invalid_argument(
+                "sensor metadata has zero columns_per_frame or fps");
+        }
         const double one_sec_in_ns = 1e+9;
         return one_sec_in_ns / (scan_width * scan_frequency);
     }
@@ -496,7 +547,6 @@ class LidarPacketHandler {
    private:
     std::unique_ptr<ouster::sdk::core::ScanBatcher> scan_batcher;
     const int LIDAR_SCAN_COUNT = 10;
-    const float THROTTLE_PERCENT = 0.7f;
     LockFreeRingBuffer ring_buffer;
     std::mutex ring_buffer_mutex;
     std::vector<std::unique_ptr<ouster::sdk::core::LidarScan>> lidar_scans;

--- a/ouster-ros/src/lock_free_ring_buffer.h
+++ b/ouster-ros/src/lock_free_ring_buffer.h
@@ -15,8 +15,14 @@
 
 /**
  * @class LockFreeRingBuffer thread safe ring buffer.
- * 
+ *
  * @remarks current implementation has effective (capacity-1) when writing elements
+ *
+ * Single-producer / single-consumer only: write() / write_head() must be
+ * called from at most one thread, and read() / read_head() from at most one
+ * (possibly different) thread. size(), full() and empty() observe both
+ * indices non-atomically and may briefly return stale values; callers must
+ * be tolerant of that.
  */
 class LockFreeRingBuffer {
    public:

--- a/ouster-ros/src/lock_free_ring_buffer.h
+++ b/ouster-ros/src/lock_free_ring_buffer.h
@@ -46,9 +46,12 @@ class LockFreeRingBuffer {
      *  wouldn't cause the calling thread to be blocked.
      */
     size_t size() const {
-        return write_idx_ >= read_idx_ ?
-            write_idx_ - read_idx_ :
-            write_idx_ + capacity_ - read_idx_;
+        // Snapshot both atomics once. Reloading them for the comparison and
+        // branch lets a concurrent advance produce a torn observation and a
+        // size_t underflow in the wrap branch.
+        const size_t write = write_idx_.load();
+        const size_t read = read_idx_.load();
+        return write >= read ? write - read : write + capacity_ - read;
     }
 
     size_t available() const {

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -75,7 +75,8 @@ class OusterCloud : public OusterProcessingNodeBase {
 
     void metadata_handler(
         const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
-        if (metadata_msg->data == active_metadata_) {
+        if (!active_metadata_.empty() &&
+            metadata_msg->data == active_metadata_) {
             RCLCPP_DEBUG(get_logger(),
                          "OusterCloud: ignoring unchanged sensor metadata");
             return;

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -41,6 +41,8 @@ class OusterCloud : public OusterProcessingNodeBase {
         on_init();
     }
 
+    ~OusterCloud() override { stop_pipeline(); }
+
    private:
     bool is_arg_set(const std::string& arg) {
         return arg.find_first_not_of(' ') != std::string::npos;
@@ -73,15 +75,35 @@ class OusterCloud : public OusterProcessingNodeBase {
 
     void metadata_handler(
         const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
-        RCLCPP_INFO(get_logger(),
-                    "OusterCloud: retrieved new sensor metadata!");
-        info = ouster::sdk::core::SensorInfo(metadata_msg->data);
-        packet_format = std::make_shared<ouster::sdk::core::PacketFormat>(
-            ouster::sdk::core::get_format(info));
-        if (tf_bcast.publish_static_tf()) {
-            tf_bcast.broadcast_transforms(info);
+        if (metadata_msg->data == active_metadata_) {
+            RCLCPP_DEBUG(get_logger(),
+                         "OusterCloud: ignoring unchanged sensor metadata");
+            return;
         }
-        create_publishers_subscriptions(info);
+
+        try {
+            auto parsed_info =
+                ouster::sdk::core::SensorInfo(metadata_msg->data);
+            auto parsed_format =
+                std::make_shared<ouster::sdk::core::PacketFormat>(
+                    ouster::sdk::core::get_format(parsed_info));
+
+            stop_pipeline();
+            info = std::move(parsed_info);
+            packet_format = std::move(parsed_format);
+            if (tf_bcast.publish_static_tf()) {
+                tf_bcast.broadcast_transforms(info);
+            }
+            create_publishers_subscriptions(info);
+            active_metadata_ = metadata_msg->data;
+        } catch (const std::exception& e) {
+            stop_pipeline();
+            active_metadata_.clear();
+            RCLCPP_ERROR_STREAM(
+                get_logger(),
+                "OusterCloud: failed to activate sensor metadata: "
+                    << e.what());
+        }
     }
 
     void create_publishers_subscriptions(const ouster::sdk::core::SensorInfo& info) {
@@ -105,17 +127,27 @@ class OusterCloud : public OusterProcessingNodeBase {
             imu_packet_handler = ImuPacketHandler::create(
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
+            imu_packet_buffer =
+                std::make_unique<ImuPacket>(packet_format->imu_packet_size);
+            imu_packet_buffer->format = packet_format;
             imu_packet_sub = create_subscription<PacketMsg>(
                 "imu_packets",
                 rclcpp::QoS(selected_qos).keep_last(info.format.imu_packets_per_frame),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     if (imu_packet_handler) {
-                        // TODO[UN]: this is not ideal since we can't reuse the msg buffer
-                        // Need to redefine the Packet object and allow use of array_views
-                        ImuPacket imu_packet(msg->buf.size());
-                        imu_packet.format = packet_format;
-                        imu_packet.host_timestamp = static_cast<uint64_t>(now().nanoseconds());
-                        memcpy(imu_packet.buf.data(), msg->buf.data(), msg->buf.size());
+                        if (!packet_format ||
+                            msg->buf.size() < packet_format->imu_packet_size) {
+                            RCLCPP_WARN_STREAM_THROTTLE(
+                                get_logger(), *get_clock(), 1000,
+                                "dropping undersized imu_packets msg ("
+                                    << msg->buf.size() << " bytes)");
+                            return;
+                        }
+                        auto& imu_packet = *imu_packet_buffer;
+                        imu_packet.host_timestamp =
+                            static_cast<uint64_t>(now().nanoseconds());
+                        memcpy(imu_packet.buf.data(), msg->buf.data(),
+                               imu_packet.buf.size());
                         auto imu_msgs = imu_packet_handler(imu_packet);
                         for (const auto& imu_msg : imu_msgs) {
                             imu_pub->publish(imu_msg);
@@ -133,15 +165,22 @@ class OusterCloud : public OusterProcessingNodeBase {
         int num_returns = info.num_returns();
 
         std::vector<LidarScanProcessor> processors;
+        bool needs_rgb = false;
 
         if (impl::check_token(tokens, "PCL")) {
+            rclcpp::PublisherOptions point_cloud_pub_options;
+            point_cloud_pub_options.qos_overriding_options =
+                rclcpp::QosOverridingOptions::with_default_policies();
             lidar_pubs.resize(num_returns);
             for (int i = 0; i < num_returns; ++i) {
                 lidar_pubs[i] = create_publisher<sensor_msgs::msg::PointCloud2>(
-                    topic_for_return("points", i), selected_qos);
+                    topic_for_return("points", i), selected_qos,
+                    point_cloud_pub_options);
             }
 
             auto point_type = get_parameter("point_type").as_string();
+            needs_rgb =
+                PointCloudProcessorFactory::point_type_produces_color(point_type);
             auto organized = get_parameter("organized").as_bool();
             auto destagger = get_parameter("destagger").as_bool();
             auto min_range_m = get_parameter("min_range").as_double();
@@ -219,7 +258,7 @@ class OusterCloud : public OusterProcessingNodeBase {
             lidar_packet_handler = LidarPacketHandler::create(
                 info, processors, timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
-                min_scan_valid_columns_ratio);
+                min_scan_valid_columns_ratio, needs_rgb);
         }
 
         if (impl::check_token(tokens, "TLM")) {
@@ -234,16 +273,26 @@ class OusterCloud : public OusterProcessingNodeBase {
         if (impl::check_token(tokens, "PCL") ||
             impl::check_token(tokens, "SCAN") ||
             impl::check_token(tokens, "TLM")) {
+            lidar_packet_buffer =
+                std::make_unique<LidarPacket>(packet_format->lidar_packet_size);
+            lidar_packet_buffer->format = packet_format;
             lidar_packet_sub = create_subscription<PacketMsg>(
                 "lidar_packets",
                 rclcpp::QoS(selected_qos).keep_last(lidar_packets_per_frame(info)),
                 [this](const PacketMsg::ConstSharedPtr msg) {
-                    // TODO[UN]: this is not ideal since we can't reuse the msg buffer
-                    // Need to redefine the Packet object and allow use of array_views
-                    LidarPacket lidar_packet(msg->buf.size());
-                    lidar_packet.format = packet_format;
-                    lidar_packet.host_timestamp = static_cast<uint64_t>(now().nanoseconds());
-                    memcpy(lidar_packet.buf.data(), msg->buf.data(), msg->buf.size());
+                    if (!packet_format ||
+                        msg->buf.size() < packet_format->lidar_packet_size) {
+                        RCLCPP_WARN_STREAM_THROTTLE(
+                            get_logger(), *get_clock(), 1000,
+                            "dropping undersized lidar_packets msg ("
+                                << msg->buf.size() << " bytes)");
+                        return;
+                    }
+                    auto& lidar_packet = *lidar_packet_buffer;
+                    lidar_packet.host_timestamp =
+                        static_cast<uint64_t>(now().nanoseconds());
+                    memcpy(lidar_packet.buf.data(), msg->buf.data(),
+                           lidar_packet.buf.size());
 
                     if (telemetry_handler) {
                         auto telemetry = telemetry_handler(lidar_packet);
@@ -255,6 +304,20 @@ class OusterCloud : public OusterProcessingNodeBase {
                     }
                 });
         }
+    }
+
+    void stop_pipeline() {
+        lidar_packet_sub.reset();
+        imu_packet_sub.reset();
+        lidar_packet_handler = nullptr;
+        imu_packet_handler = nullptr;
+        telemetry_handler = nullptr;
+        lidar_packet_buffer.reset();
+        imu_packet_buffer.reset();
+        lidar_pubs.clear();
+        scan_pubs.clear();
+        imu_pub.reset();
+        telemetry_pub.reset();
     }
 
    private:
@@ -271,9 +334,12 @@ class OusterCloud : public OusterProcessingNodeBase {
 
     ImuPacketHandler::HandlerType imu_packet_handler;
     LidarPacketHandler::HandlerType lidar_packet_handler;
+    std::unique_ptr<ImuPacket> imu_packet_buffer;
+    std::unique_ptr<LidarPacket> lidar_packet_buffer;
 
     rclcpp::Publisher<ouster_sensor_msgs::msg::Telemetry>::SharedPtr telemetry_pub;
     TelemetryHandler::HandlerType telemetry_handler;
+    std::string active_metadata_;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -63,6 +63,15 @@ class OusterDriver : public OusterSensor {
     }
 
     virtual void create_publishers() override {
+        imu_packet_handler = nullptr;
+        lidar_packet_handler = nullptr;
+        telemetry_handler = nullptr;
+        imu_pub.reset();
+        telemetry_pub.reset();
+        lidar_pubs.clear();
+        scan_pubs.clear();
+        image_pubs.clear();
+
         auto proc_mask = get_parameter("proc_mask").as_string();
         auto tokens = impl::parse_tokens(proc_mask, '|');
 
@@ -96,14 +105,21 @@ class OusterDriver : public OusterSensor {
         int num_returns = info.num_returns();
 
         std::vector<LidarScanProcessor> processors;
+        bool needs_rgb = false;
         if (impl::check_token(tokens, "PCL")) {
+            rclcpp::PublisherOptions point_cloud_pub_options;
+            point_cloud_pub_options.qos_overriding_options =
+                rclcpp::QosOverridingOptions::with_default_policies();
             lidar_pubs.resize(num_returns);
             for (int i = 0; i < num_returns; ++i) {
                 lidar_pubs[i] = create_publisher<sensor_msgs::msg::PointCloud2>(
-                    topic_for_return("points", i), selected_qos);
+                    topic_for_return("points", i), selected_qos,
+                    point_cloud_pub_options);
             }
 
             auto point_type = get_parameter("point_type").as_string();
+            needs_rgb =
+                PointCloudProcessorFactory::point_type_produces_color(point_type);
             auto organized = get_parameter("organized").as_bool();
             auto destagger = get_parameter("destagger").as_bool();
             auto min_range_m = get_parameter("min_range").as_double();
@@ -182,15 +198,14 @@ class OusterDriver : public OusterSensor {
         }
 
         if (impl::check_token(tokens, "IMG")) {
-            const std::map<std::string, std::string>
+            std::map<std::string, std::string>
                 channel_field_topic_map_1{
                     {ChanField::RANGE, "range_image"},
                     {ChanField::SIGNAL, "signal_image"},
                     {ChanField::REFLECTIVITY, "reflec_image"},
-                    {ChanField::NEAR_IR, "nearir_image"},
-                    {ChanField::RGB, "rgb_image"}};
+                    {ChanField::NEAR_IR, "nearir_image"}};
 
-            const std::map<std::string, std::string>
+            std::map<std::string, std::string>
                 channel_field_topic_map_2{
                     {ChanField::RANGE, "range_image"},
                     {ChanField::SIGNAL, "signal_image"},
@@ -198,8 +213,18 @@ class OusterDriver : public OusterSensor {
                     {ChanField::NEAR_IR, "nearir_image"},
                     {ChanField::RANGE2, "range_image2"},
                     {ChanField::SIGNAL2, "signal_image2"},
-                    {ChanField::REFLECTIVITY2, "reflec_image2"},
-                    {ChanField::RGB, "rgb_image"}};
+                    {ChanField::REFLECTIVITY2, "reflec_image2"}};
+
+            const bool profile_has_rgb =
+                info.format.udp_profile_lidar ==
+                    ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+                info.format.udp_profile_lidar ==
+                    ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
+            if (profile_has_rgb) {
+                channel_field_topic_map_1[ChanField::RGB] = "rgb_image";
+                channel_field_topic_map_2[ChanField::RGB] = "rgb_image";
+            }
+            needs_rgb = needs_rgb || profile_has_rgb;
 
             auto which_map = num_returns == 1 ? &channel_field_topic_map_1
                                               : &channel_field_topic_map_2;
@@ -223,7 +248,7 @@ class OusterDriver : public OusterSensor {
             lidar_packet_handler = LidarPacketHandler::create(
                 info, processors, timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
-                min_scan_valid_columns_ratio);
+                min_scan_valid_columns_ratio, needs_rgb);
 
         if (impl::check_token(tokens, "TLM")) {
             telemetry_pub =
@@ -267,10 +292,15 @@ class OusterDriver : public OusterSensor {
     virtual void cleanup() override {
         imu_packet_handler = nullptr;
         lidar_packet_handler = nullptr;
+        telemetry_handler = nullptr;
         imu_pub.reset();
-        for (auto p : lidar_pubs) p.reset();
-        for (auto p : scan_pubs) p.reset();
-        for (auto p : image_pubs) p.second.reset();
+        telemetry_pub.reset();
+        for (auto& p : lidar_pubs) p.reset();
+        for (auto& p : scan_pubs) p.reset();
+        for (auto& p : image_pubs) p.second.reset();
+        lidar_pubs.clear();
+        scan_pubs.clear();
+        image_pubs.clear();
         OusterSensor::cleanup();
     }
 

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -149,8 +149,8 @@ class OusterPcap : public OusterSensorNodeBase {
 
     void declare_parameters() {
         declare_parameter("auto_start", true);
-        declare_parameter<std::string>("metadata");
-        declare_parameter<std::string>("pcap_file");
+        declare_parameter<std::string>("metadata", "");
+        declare_parameter<std::string>("pcap_file", "");
         declare_parameter("loop", false);
         declare_parameter("progress_update_freq", 1.0);
         declare_parameter("use_system_default_qos", false);

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -211,7 +211,7 @@ class OusterPcap : public OusterSensorNodeBase {
     }
 
     void open_pcap(const std::string& pcap_file) {
-        pcap.reset(new PcapReader(pcap_file));
+        pcap = std::make_unique<PcapReader>(pcap_file);
     }
 
     void start_packet_read_thread() {

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -128,6 +128,10 @@ class OusterPcap : public OusterSensorNodeBase {
             return LifecycleNodeInterface::CallbackReturn::SUCCESS;
         }
 
+        if (state.label() == "active") {
+            stop_packet_read_thread();
+        }
+
         // whether state was 'active' or 'inactive' do cleanup
         try {
             cleanup();

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -178,14 +178,26 @@ class OusterPcap : public OusterSensorNodeBase {
 
     void load_metadata_from_file(const std::string& meta_file) {
         try {
-            cached_metadata = impl::read_text_file(meta_file);
-            info = ouster::sdk::core::SensorInfo(cached_metadata);
+            const auto metadata = impl::read_text_file(meta_file);
+            if (metadata.empty()) {
+                throw std::runtime_error(
+                    "metadata file missing, unreadable, or empty: " + meta_file);
+            }
+            info = ouster::sdk::core::SensorInfo(metadata);
+            {
+                std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+                cached_metadata = metadata;
+            }
             display_lidar_info(info);
-        } catch (const std::runtime_error& e) {
-            cached_metadata.clear();
+        } catch (const std::exception& e) {
+            {
+                std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+                cached_metadata.clear();
+            }
             RCLCPP_ERROR_STREAM(
                 get_logger(),
                 "Error when running in replay mode: " << e.what());
+            throw;
         }
     }
 
@@ -219,12 +231,17 @@ class OusterPcap : public OusterSensorNodeBase {
         packet_read_thread = std::make_unique<std::thread>([this]() {
             auto& pf = ouster::sdk::core::get_format(info);
             do {
-                read_packets(*pcap, pf);
+                const size_t packet_count = read_packets(*pcap, pf);
                 pcap->reset();
+                if (packet_count == 0) {
+                    RCLCPP_WARN(get_logger(),
+                                "pcap yielded no packets; stopping replay");
+                    break;
+                }
             } while(rclcpp::ok() && packet_read_active && loop);
             RCLCPP_DEBUG(get_logger(),
                          "packet_read_thread done.");
-            rclcpp::shutdown();
+            if (packet_read_active && rclcpp::ok()) rclcpp::shutdown();
         });
     }
 
@@ -257,34 +274,59 @@ class OusterPcap : public OusterSensorNodeBase {
         imu_packet_pub->publish(imu_packet);
     }
 
-    void read_packets(PcapReader& pcap, const PacketFormat& pf) {
+    size_t read_packets(PcapReader& pcap, const PacketFormat& pf) {
         size_t payload_size = pcap.next_packet();
         auto packet_info = pcap.current_info();
         auto file_start = packet_info.timestamp;
         auto last_update = file_start;
         const auto UPDATE_PERIOD = duration_cast<microseconds>(1s / progress_update_freq);
 
+        size_t packet_count = 0;
         while (rclcpp::ok() && packet_read_active && payload_size) {
-            auto start = high_resolution_clock::now();
+            ++packet_count;
+            auto start = steady_clock::now();
             if (packet_info.dst_port == info.config.udp_port_imu) {
-                std::memcpy(imu_packet.buf.data(), pcap.current_data(),
-                            pf.imu_packet_size);
-                imu_packet_pub->publish(imu_packet);
+                if (payload_size >= pf.imu_packet_size) {
+                    std::memcpy(imu_packet.buf.data(), pcap.current_data(),
+                                pf.imu_packet_size);
+                    imu_packet_pub->publish(imu_packet);
+                } else {
+                    RCLCPP_WARN_STREAM_THROTTLE(
+                        get_logger(), *get_clock(), 1000,
+                        "skipping truncated imu packet: payload "
+                            << payload_size << " < expected "
+                            << pf.imu_packet_size);
+                }
             } else if (packet_info.dst_port == info.config.udp_port_lidar) {
-                std::memcpy(lidar_packet.buf.data(), pcap.current_data(),
-                            pf.lidar_packet_size);
-                lidar_packet_pub->publish(lidar_packet);
+                if (payload_size >= pf.lidar_packet_size) {
+                    std::memcpy(lidar_packet.buf.data(), pcap.current_data(),
+                                pf.lidar_packet_size);
+                    lidar_packet_pub->publish(lidar_packet);
+                } else {
+                    RCLCPP_WARN_STREAM_THROTTLE(
+                        get_logger(), *get_clock(), 1000,
+                        "skipping truncated lidar packet: payload "
+                            << payload_size << " < expected "
+                            << pf.lidar_packet_size);
+                }
             } else {
-                RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 1,
+                RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 1000,
                     "unknown packet /w port:" << packet_info.dst_port);
             }
             auto prev_packet_ts = packet_info.timestamp;
             payload_size = pcap.next_packet();
             packet_info = pcap.current_info();
             auto curr_packet_ts = packet_info.timestamp;
-            auto end = high_resolution_clock::now();
+            auto end = steady_clock::now();
             auto dt = (curr_packet_ts - prev_packet_ts) - (end - start);
-            std::this_thread::sleep_for(dt);  // pace packet generation
+            auto remaining = duration_cast<nanoseconds>(dt);
+            const auto slice = duration_cast<nanoseconds>(milliseconds(20));
+            while (remaining > nanoseconds::zero() && rclcpp::ok() &&
+                   packet_read_active) {
+                const auto chunk = remaining < slice ? remaining : slice;
+                std::this_thread::sleep_for(chunk);
+                remaining -= chunk;
+            }
 
             if (curr_packet_ts - last_update > UPDATE_PERIOD) {
                 last_update = curr_packet_ts;
@@ -295,6 +337,7 @@ class OusterPcap : public OusterSensorNodeBase {
                     << std::endl;   // This seem to be required for ROS2
             }
         }
+        return packet_count;
     }
 
    private:

--- a/ouster-ros/src/os_replay_node.cpp
+++ b/ouster-ros/src/os_replay_node.cpp
@@ -107,7 +107,7 @@ class OusterReplay : public OusterSensorNodeBase {
    private:
     void declare_parameters() {
         declare_parameter("auto_start", true);
-        declare_parameter<std::string>("metadata");
+        declare_parameter<std::string>("metadata", "");
     }
 
     std::string parse_parameters() {

--- a/ouster-ros/src/os_replay_node.cpp
+++ b/ouster-ros/src/os_replay_node.cpp
@@ -122,14 +122,26 @@ class OusterReplay : public OusterSensorNodeBase {
 
     void load_metadata_from_file(const std::string& meta_file) {
         try {
-            cached_metadata = impl::read_text_file(meta_file);
-            info = ouster::sdk::core::SensorInfo(cached_metadata);
+            const auto metadata = impl::read_text_file(meta_file);
+            if (metadata.empty()) {
+                throw std::runtime_error(
+                    "metadata file missing, unreadable, or empty: " + meta_file);
+            }
+            info = ouster::sdk::core::SensorInfo(metadata);
+            {
+                std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+                cached_metadata = metadata;
+            }
             display_lidar_info(info);
-        } catch (const std::runtime_error& e) {
-            cached_metadata.clear();
+        } catch (const std::exception& e) {
+            {
+                std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+                cached_metadata.clear();
+            }
             RCLCPP_ERROR_STREAM(
                 get_logger(),
                 "Error when running in replay mode: " << e.what());
+            throw;
         }
     }
 

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -70,13 +70,18 @@ std::vector<sensor_msgs::msg::Imu> packet_to_imu_msgs(
     auto& pf = *imu_packet.format;
     Eigen::ArrayX<uint64_t> imu_timestamps = imu_packet.timestamp();
     if (pf.imu_measurements_per_packet == 0) {  // Handle the LEGACY IMU profile (it would be better if the imu_packet handles this internally).
-        imu_timestamps[0] = pf.imu_gyro_ts(imu_packet.buf.data());
-    } else if ((imu_status[0] & 0x1) == 0) {    // HANDLE the case when the first imu_timestamp is unknown.
+        if (imu_timestamps.size() > 0)
+            imu_timestamps[0] = pf.imu_gyro_ts(imu_packet.buf.data());
+    } else if (imu_status.size() > 0 && (imu_status[0] & 0x1) == 0) {
         int imu_measurements_per_frame = pf.imu_measurements_per_packet * pf.imu_packets_per_frame;
-        double frame_ts_ns = 1e9 / sensor_info.format.fps;
-        double imu_measurement_interval = frame_ts_ns / imu_measurements_per_frame;
-        for (int i = 0; i < imu_timestamps.size(); ++i) {
-            imu_timestamps[i] = static_cast<uint64_t>(i * imu_measurement_interval);
+        if (sensor_info.format.fps > 0 && imu_measurements_per_frame > 0) {
+            double frame_ts_ns = 1e9 / sensor_info.format.fps;
+            double imu_measurement_interval =
+                frame_ts_ns / imu_measurements_per_frame;
+            for (int i = 0; i < imu_timestamps.size(); ++i) {
+                imu_timestamps[i] =
+                    static_cast<uint64_t>(i * imu_measurement_interval);
+            }
         }
     }
 
@@ -111,7 +116,14 @@ std::vector<sensor_msgs::msg::Imu> packet_to_imu_msgs(
         }
 
         m.header.frame_id = frame;
-        auto ts_offset = std::chrono::nanoseconds(imu_timestamps[i] - imu_timestamps[0]);
+        const auto base_ts = imu_timestamps[0];
+        const auto sample_ts = imu_timestamps[i];
+        const auto magnitude = sample_ts >= base_ts ? sample_ts - base_ts
+                                                    : base_ts - sample_ts;
+        const auto bounded = static_cast<int64_t>(std::min<uint64_t>(
+            magnitude, static_cast<uint64_t>(INT64_MAX)));
+        auto ts_offset = std::chrono::nanoseconds(
+            sample_ts >= base_ts ? bounded : -bounded);
         m.header.stamp = timestamp + rclcpp::Duration(ts_offset);
         m.linear_acceleration.x = accel(i, 0);
         m.linear_acceleration.y = accel(i, 1);
@@ -224,9 +236,17 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
 
     const auto scan_width = ouster::sdk::core::n_cols_of_lidar_mode(ld_mode);
     const auto scan_frequency = ouster::sdk::core::frequency_of_lidar_mode(ld_mode);
-    msg.scan_time = 1.0f / scan_frequency;
-    msg.time_increment = 1.0f / (scan_width * scan_frequency);
-    msg.angle_increment = 2 * M_PI / scan_width;
+    const double effective_width =
+        scan_width > 0 ? static_cast<double>(scan_width)
+                       : static_cast<double>(ls.w);
+    msg.scan_time = scan_frequency > 0 ? 1.0f / scan_frequency : 0.0f;
+    msg.time_increment =
+        (scan_width > 0 && scan_frequency > 0)
+            ? 1.0f /
+                  (static_cast<double>(scan_width) * scan_frequency)
+            : 0.0f;
+    msg.angle_increment =
+        effective_width > 0.0 ? 2 * M_PI / effective_width : 0.0f;
 
     auto which_range = return_index == 0 ? ChanField::RANGE
                                          : ChanField::RANGE2;
@@ -241,6 +261,10 @@ sensor_msgs::msg::LaserScan lidar_scan_to_laser_scan_msg(
     msg.intensities.resize(ls.w);
 
     uint16_t u = ring;
+    if (static_cast<size_t>(u) >= pixel_shift_by_row.size() ||
+        static_cast<size_t>(u) >= static_cast<size_t>(ls.h)) {
+        return msg;
+    }
     for (int v =  0; v < static_cast<int>(ls.w); ++v) {
         auto v_shift = (v + ls.w - pixel_shift_by_row[u] + ls.w / 2) % ls.w;
         auto src_idx = u * ls.w + v_shift;

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -637,14 +637,16 @@ void OusterSensor::parse_lidar_mode(SensorConfig& config) {
         return;
     }
 
-    try {
-        auto lidar_mode = ouster::sdk::core::lidar_mode_of_string(lidar_mode_arg);
-        config.lidar_mode = lidar_mode;
-    } catch (const std::exception& e) {
-        auto error_msg = "Invalid lidar mode: " + lidar_mode_arg + ", exception details: " + e.what();
+    // lidar_mode_of_string returns std::optional and does not throw; an
+    // invalid mode yields std::nullopt, so check explicitly instead of
+    // relying on a catch block that can never be reached.
+    auto lidar_mode = ouster::sdk::core::lidar_mode_of_string(lidar_mode_arg);
+    if (!lidar_mode) {
+        auto error_msg = "Invalid lidar mode: " + lidar_mode_arg;
         RCLCPP_FATAL_STREAM(get_logger(), error_msg);
         throw std::runtime_error(error_msg);
     }
+    config.lidar_mode = lidar_mode.value();
 }
 
 void OusterSensor::parse_timestamp_mode(SensorConfig& config) {

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -42,10 +42,25 @@ OusterSensor::OusterSensor(const std::string& name,
                            const rclcpp::NodeOptions& options)
     : OusterSensorNodeBase(name, options) {
     declare_parameters();
-    staged_config = parse_config_from_ros_parameters();
+    try {
+        staged_config = parse_config_from_ros_parameters();
+    } catch (const std::exception& e) {
+        config_parse_error = e.what();
+        RCLCPP_FATAL_STREAM(
+            get_logger(),
+            "Invalid sensor configuration parameters: " << e.what());
+    }
     attempt_reconnect = get_parameter("attempt_reconnect").as_bool();
     dormant_period_between_reconnects = 
         get_parameter("dormant_period_between_reconnects").as_double();
+    if (dormant_period_between_reconnects <= 0.0) {
+        RCLCPP_WARN(
+            get_logger(),
+            "dormant_period_between_reconnects (%f) must be > 0; "
+            "clamping to 1.0s",
+            dormant_period_between_reconnects);
+        dormant_period_between_reconnects = 1.0;
+    }
     reconnect_attempts_available =
         get_parameter("max_failed_reconnect_attempts").as_int();
 
@@ -155,6 +170,14 @@ LifecycleNodeInterface::CallbackReturn OusterSensor::on_configure(
     const rclcpp_lifecycle::State&) {
     RCLCPP_DEBUG(get_logger(), "on_configure() is called.");
 
+    if (config_parse_error) {
+        RCLCPP_FATAL_STREAM(
+            get_logger(),
+            "Cannot configure os_sensor: invalid parameters: "
+                << *config_parse_error);
+        return LifecycleNodeInterface::CallbackReturn::ERROR;
+    }
+
     try {
         if (!start()) {
             auto sleep_duration = std::chrono::duration<double>(dormant_period_between_reconnects);
@@ -192,7 +215,12 @@ LifecycleNodeInterface::CallbackReturn OusterSensor::on_activate(
     const rclcpp_lifecycle::State& state) {
     RCLCPP_DEBUG(get_logger(), "on_activate() is called.");
     LifecycleNode::on_activate(state);
-    if (cached_metadata.empty())
+    bool metadata_missing;
+    {
+        std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+        metadata_missing = cached_metadata.empty();
+    }
+    if (metadata_missing)
         update_metadata(*sensor_client);
     create_publishers();
     allocate_buffers();
@@ -273,21 +301,26 @@ std::string OusterSensor::get_sensor_hostname() {
 }
 
 void OusterSensor::update_metadata(ouster::sdk::sensor::Client& cli) {
+    std::string fetched;
     try {
-        cached_metadata = ouster::sdk::sensor::get_metadata(cli, 60);
+        fetched = ouster::sdk::sensor::get_metadata(cli, 60);
     } catch (const std::exception& e) {
         RCLCPP_ERROR_STREAM(get_logger(),
                             "ouster::sdk::sensor::get_metadata exception: " << e.what());
-        cached_metadata.clear();
+        fetched.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+        cached_metadata = fetched;
     }
 
-    if (cached_metadata.empty()) {
+    if (fetched.empty()) {
         const auto error_msg = "Failed to collect sensor metadata";
         RCLCPP_ERROR(get_logger(), error_msg);
         throw std::runtime_error(error_msg);
     }
 
-    info = ouster::sdk::core::SensorInfo(cached_metadata);
+    info = ouster::sdk::core::SensorInfo(fetched);
     // TODO: revist when *min_version* is changed
     populate_metadata_defaults(info);
 
@@ -308,7 +341,12 @@ void OusterSensor::save_metadata() {
 
     // write metadata file. If metadata_path is relative, will use cwd
     // (usually ~/.ros)
-    if (impl::write_text_to_file(meta_file, cached_metadata)) {
+    std::string metadata_copy;
+    {
+        std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+        metadata_copy = cached_metadata;
+    }
+    if (impl::write_text_to_file(meta_file, metadata_copy)) {
         RCLCPP_INFO_STREAM(get_logger(),
                            "Wrote sensor metadata to " << meta_file);
     } else {
@@ -352,7 +390,10 @@ void OusterSensor::reactivate_sensor(bool init_id_reset) {
     }
 
     reset_last_init_id = init_id_reset;
-    cached_metadata.clear();
+    {
+        std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+        cached_metadata.clear();
+    }
     auto request_transitions = std::vector<uint8_t>{
         lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE,
         lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE};
@@ -1139,6 +1180,8 @@ void OusterSensor::cleanup() {
     get_metadata_srv.reset();
     get_config_srv.reset();
     set_config_srv.reset();
+    reset_srv.reset();
+    metadata_pub.reset();
     sensor_connection_thread.reset();
     // Cancel and drop any pending reconnect timer; its lambda captures
     // `this` and could otherwise fire after cleanup if the node is

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -1140,6 +1140,13 @@ void OusterSensor::cleanup() {
     get_config_srv.reset();
     set_config_srv.reset();
     sensor_connection_thread.reset();
+    // Cancel and drop any pending reconnect timer; its lambda captures
+    // `this` and could otherwise fire after cleanup if the node is
+    // re-configured.
+    if (reconnect_timer) {
+        reconnect_timer->cancel();
+        reconnect_timer.reset();
+    }
 }
 
 void OusterSensor::connection_loop(ouster::sdk::sensor::Client& cli,

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -163,6 +163,7 @@ class OusterSensor : public OusterSensorNodeBase {
    private:
     std::string sensor_hostname;
     std::optional<ouster::sdk::core::SensorConfig> staged_config;
+    std::optional<std::string> config_parse_error;
     std::string mtp_dest;
     bool mtp_main = false;
     std::shared_ptr<ouster::sdk::sensor::Client> sensor_client;
@@ -186,9 +187,9 @@ class OusterSensor : public OusterSensorNodeBase {
     std::unique_ptr<std::thread> lidar_packets_processing_thread;
 
     bool persist_config = false;
-    bool force_sensor_reinit = false;
+    std::atomic<bool> force_sensor_reinit = {false};
     bool auto_udp_allowed = false;
-    bool reset_last_init_id = true;
+    std::atomic<bool> reset_last_init_id = {true};
     std::optional<uint32_t> last_init_id;
 
     // TODO: add as a ros parameter

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -32,6 +32,7 @@ void OusterSensorNodeBase::create_get_metadata_service() {
         "get_metadata",
         [this](const std::shared_ptr<GetMetadata::Request>,
                std::shared_ptr<GetMetadata::Response> response) {
+            std::lock_guard<std::mutex> lock(cached_metadata_mutex);
             response->metadata = cached_metadata;
             return cached_metadata.size() > 0;
         });
@@ -49,7 +50,10 @@ void OusterSensorNodeBase::create_metadata_pub() {
 
 void OusterSensorNodeBase::publish_metadata() {
     std_msgs::msg::String metadata_msg;
-    metadata_msg.data = cached_metadata;
+    {
+        std::lock_guard<std::mutex> lock(cached_metadata_mutex);
+        metadata_msg.data = cached_metadata;
+    }
     metadata_pub->publish(metadata_msg);
 }
 

--- a/ouster-ros/src/point_cloud_compose.h
+++ b/ouster-ros/src/point_cloud_compose.h
@@ -72,7 +72,9 @@ void map_lidar_scan_fields_to_tuple(Tuple& tp, const ouster::sdk::core::LidarSca
             std::remove_pointer_t<std::tuple_element_t<Index, Tuple>>>;
         static_assert(std::is_same_v<ElementType, FieldType>,
                       "tuple element, field element types mismatch!");
-        std::get<Index>(tp) = ls.field<FieldType>(Table[Index].first).data();
+        if (ls.has_field(Table[Index].first))
+            std::get<Index>(tp) =
+                ls.field<FieldType>(Table[Index].first).data();
         map_lidar_scan_fields_to_tuple<Index + 1, N, Table>(tp, ls);
     }
 }
@@ -103,7 +105,8 @@ constexpr auto make_lidar_scan_tuple(const ouster::sdk::core::LidarScan& ls) {
 template <std::size_t Index, typename PointT, typename Tuple>
 void copy_lidar_scan_fields_to_point(PointT& pt, const Tuple& tp, int idx) {
     if constexpr (Index < std::tuple_size_v<Tuple>) {
-        point::get<5 + Index>(pt) = std::get<Index>(tp)[idx];
+        const auto* src = std::get<Index>(tp);
+        point::get<5 + Index>(pt) = src ? src[idx] : 0;
         copy_lidar_scan_fields_to_point<Index + 1>(pt, tp, idx);
     } else {
         unused_variable(pt);
@@ -132,19 +135,29 @@ void scan_to_cloud_f(ouster_ros::Cloud<PointT>& cloud, PointS& staging_point,
 
     int h = static_cast<int>(ls.h);
     int w = static_cast<int>(ls.w);
+    if (h <= 0 || w <= 0 || rows_step <= 0) return;
 
     for (auto u = 0; u < h; u += rows_step) {
+        int next_source_col = 0;
+        if (destagger && u < static_cast<int>(pixel_shift_by_row.size())) {
+            int normalized_shift = pixel_shift_by_row[u] % w;
+            if (normalized_shift < 0) normalized_shift += w;
+            next_source_col =
+                normalized_shift == 0 ? 0 : w - normalized_shift;
+        }
         for (auto v = 0; v < w; ++v) {   // TODO[UN]: consider cols_step in future
-            const auto v_shift =
-                destagger ? (v + w - pixel_shift_by_row[u]) % w : v;
-            const auto src_idx = u * w + v_shift;
+            const int source_col = next_source_col;
+            if (++next_source_col == w) next_source_col = 0;
+            const auto src_idx = u * w + source_col;
             const auto xyz = points.row(src_idx);
             const auto tgt_idx =
                 organized ? (u / rows_step) * w + v : cloud.size();
 
             // copy the timestamp of associated point
             auto ts =
-                timestamp[v_shift] > scan_ts ? timestamp[v_shift] - scan_ts : 0UL;
+                timestamp[source_col] > scan_ts
+                    ? timestamp[source_col] - scan_ts
+                    : 0UL;
 
             if (organized) {
                 // set is_dense to false if any of the xyz coordinates is NaN

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -47,7 +47,7 @@ class PointCloudProcessor {
         : frame(frame_id),
           pixel_shift_by_row(info.format.pixel_shift_by_row),
           cloud{info.format.columns_per_frame,
-                info.format.pixels_per_column / rows_step},
+                (info.format.pixels_per_column + rows_step - 1) / rows_step},
           min_range_(min_range), max_range_(max_range),
           pc_msgs(info.num_returns()),
           scan_to_cloud_fn(scan_to_cloud_fn_),
@@ -73,6 +73,10 @@ class PointCloudProcessor {
                     mask_path,
                     info.format.pixels_per_column,
                     info.format.columns_per_frame);
+        if (mask.size() != 0) {
+            masked_range.resize(info.format.pixels_per_column,
+                                info.format.columns_per_frame);
+        }
     }
 
    private:
@@ -89,10 +93,17 @@ class PointCloudProcessor {
         for (int i = 0; i < static_cast<int>(pc_msgs.size()); ++i) {
             auto range_channel = i == 0 ? ChanField::RANGE : ChanField::RANGE2;
             auto range = lidar_scan.field<uint32_t>(range_channel);
-            auto range_masked = mask.size() != 0 ? range * mask : range;
-            ouster::cartesianT(points, range_masked, lut_direction, lut_offset,
-                               min_range_, max_range_,
-                               std::numeric_limits<float>::quiet_NaN());
+            if (mask.size() != 0) {
+                masked_range = range * mask;
+                ouster::cartesianT(
+                    points, masked_range, lut_direction, lut_offset,
+                    min_range_, max_range_,
+                    std::numeric_limits<float>::quiet_NaN());
+            } else {
+                ouster::cartesianT(
+                    points, range, lut_direction, lut_offset, min_range_,
+                    max_range_, std::numeric_limits<float>::quiet_NaN());
+            }
 
             scan_to_cloud_fn(cloud, points, scan_ts, lidar_scan,
                                         pixel_shift_by_row, i);
@@ -143,6 +154,7 @@ class PointCloudProcessor {
     PointCloudProcessor_PostProcessingFn post_processing_fn;
 
     ouster::sdk::core::img_t<uint32_t> mask;
+    ouster::sdk::core::img_t<uint32_t> masked_range;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/point_cloud_processor_factory.h
+++ b/ouster-ros/src/point_cloud_processor_factory.h
@@ -223,6 +223,11 @@ class PointCloudProcessorFactory {
                point_type == "color_point";
     }
 
+    static bool point_type_produces_color(const std::string& point_type) {
+        return point_type == "xyzrgb" || point_type == "xyzrgba" ||
+               point_type == "color_point";
+    }
+
     static bool profile_has_intensity(UDPProfileLidar profile) {
         return profile == UDPProfileLidar::LEGACY ||
                profile == UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_DUAL ||

--- a/ouster-ros/test/lidar_packet_handler_test.cpp
+++ b/ouster-ros/test/lidar_packet_handler_test.cpp
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2018-2026, Ouster, Inc.
+ * All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "../src/lidar_packet_handler.h"
+
+TEST(LidarPacketHandlerTimestampTest, InterpolatesEpochNanosecondsExactly) {
+    constexpr uint64_t base = 1700000000000000123ULL;
+
+    EXPECT_EQ(base + 1021000ULL,
+              linear_interpolate(3, base, 1027, base + 1024000ULL, 1024));
+}
+
+TEST(LidarPacketHandlerTimestampTest, InterpolatesDecreasingValuesExactly) {
+    constexpr uint64_t base = 1700000000001024123ULL;
+
+    EXPECT_EQ(base - 1021000ULL,
+              linear_interpolate(3, base, 1027, base - 1024000ULL, 1024));
+}
+
+TEST(OusterRosTimestampTest, AppliesSignedOffsetsWithoutOverflow) {
+    EXPECT_EQ(0U,
+              ouster_ros::impl::ts_safe_offset_add(
+                  1U, std::numeric_limits<int64_t>::min()));
+    EXPECT_EQ(std::numeric_limits<uint64_t>::max(),
+              ouster_ros::impl::ts_safe_offset_add(
+                  std::numeric_limits<uint64_t>::max(), 1));
+    EXPECT_EQ(42U, ouster_ros::impl::ts_safe_offset_add(79U, -37));
+}

--- a/ouster-ros/test/point_cloud_compose_test.cpp
+++ b/ouster-ros/test/point_cloud_compose_test.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 #include <ouster/lidar_scan.h>
 
+#include <limits>
+#include <vector>
+
 // prevent clang-format from altering the location of "ouster_ros/os_ros.h", the
 // header file needs to be the first include due to PCL_NO_PRECOMPILE flag
 // clang-format off
@@ -71,4 +74,56 @@ TEST_F(PointCloudComposeTest, MapLidarScanFields) {
         EXPECT_EQ(point::get<7>(pt), reflect(0, src_idx));
         EXPECT_EQ(point::get<8>(pt), near_ir(0, src_idx));
     }
+}
+
+TEST_F(PointCloudComposeTest, DestaggerNormalizesPositiveAndNegativeShifts) {
+    constexpr uint32_t WIDTH = 5;
+    constexpr uint32_t HEIGHT = 1;
+    LidarScan ls(WIDTH, HEIGHT,
+                 UDPProfileLidar::RNG19_RFL8_SIG16_NIR16);
+
+    PointCloudXYZf points(WIDTH * HEIGHT, 3);
+    points.setZero();
+    for (uint32_t i = 0; i < WIDTH; ++i) points(i, 0) = i;
+
+    auto compose = [&](int shift) {
+        Cloud<Point_RNG19_RFL8_SIG16_NIR16> cloud{WIDTH, HEIGHT};
+        Point_RNG19_RFL8_SIG16_NIR16 staging_point;
+        scan_to_cloud_f<Profile_RNG19_RFL8_SIG16_NIR16.size(),
+                        Profile_RNG19_RFL8_SIG16_NIR16>(
+            cloud, staging_point, points, 0, ls, {shift},
+            /*organized=*/true, /*destagger=*/true);
+        std::vector<float> x;
+        for (const auto& point : cloud.points) x.push_back(point.x);
+        return x;
+    };
+
+    EXPECT_EQ(compose(2), (std::vector<float>{3, 4, 0, 1, 2}));
+    EXPECT_EQ(compose(-1), (std::vector<float>{1, 2, 3, 4, 0}));
+    EXPECT_EQ(compose(7), (std::vector<float>{3, 4, 0, 1, 2}));
+}
+
+TEST_F(PointCloudComposeTest, UnorganizedDestaggerAdvancesPastInvalidPoints) {
+    constexpr uint32_t WIDTH = 5;
+    constexpr uint32_t HEIGHT = 1;
+    LidarScan ls(WIDTH, HEIGHT,
+                 UDPProfileLidar::RNG19_RFL8_SIG16_NIR16);
+
+    PointCloudXYZf points(WIDTH * HEIGHT, 3);
+    points.setZero();
+    for (uint32_t i = 0; i < WIDTH; ++i) points(i, 0) = i;
+    points(3, 0) = std::numeric_limits<float>::quiet_NaN();
+
+    Cloud<Point_RNG19_RFL8_SIG16_NIR16> cloud;
+    Point_RNG19_RFL8_SIG16_NIR16 staging_point;
+    scan_to_cloud_f<Profile_RNG19_RFL8_SIG16_NIR16.size(),
+                    Profile_RNG19_RFL8_SIG16_NIR16>(
+        cloud, staging_point, points, 0, ls, {2},
+        /*organized=*/false, /*destagger=*/true);
+
+    ASSERT_EQ(cloud.size(), 4U);
+    EXPECT_EQ(cloud.points[0].x, 4);
+    EXPECT_EQ(cloud.points[1].x, 0);
+    EXPECT_EQ(cloud.points[2].x, 1);
+    EXPECT_EQ(cloud.points[3].x, 2);
 }

--- a/ouster-ros/test/point_transform_test.cpp
+++ b/ouster-ros/test/point_transform_test.cpp
@@ -172,12 +172,12 @@ void verify_point_transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
         });
 
     // near_ir
-    CondBinaryOp<has_near_ir_v<PointTGT> && !has_near_ir_v<PointSRC>>::run(
+    CondBinaryOp<has_near_ir_v<PointTGT> && has_near_ir_v<PointSRC>>::run(
         tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
             EXPECT_EQ(tgt_pt.near_ir, src_pt.near_ir);
         });
 
-    CondBinaryOp<has_near_ir_v<PointTGT> && has_near_ir_v<PointSRC>>::run(
+    CondBinaryOp<has_near_ir_v<PointTGT> && !has_near_ir_v<PointSRC>>::run(
         tgt_pt, src_pt, [](const auto& tgt_pt, const auto&) {
             EXPECT_EQ(tgt_pt.near_ir, static_cast<decltype(tgt_pt.near_ir)>(0));
         });
@@ -378,6 +378,16 @@ TEST_F(PointTransformTest,
     point::transform(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16_dual);
     expect_points_xyz_equal(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16_dual);
     verify_point_transform(pt_os_point, pt_rg19_rf8_sg16_nr16_rgb16_dual);
+}
+
+TEST_F(PointTransformTest, TestTransformPreservesOrZerosNearIr) {
+    Point_RNG19_RFL8_SIG16_NIR16 target;
+
+    point::transform(target, pt_rg19_rf8_sg16_nr16);
+    verify_point_transform(target, pt_rg19_rf8_sg16_nr16);
+
+    point::transform(target, pt_xyz);
+    verify_point_transform(target, pt_xyz);
 }
 
 TEST_F(PointTransformTest, TestTransformReduce_RNG19_RFL8_SIG16_NIR16_RGB16) {

--- a/ouster-ros/test/point_transform_test.cpp
+++ b/ouster-ros/test/point_transform_test.cpp
@@ -172,7 +172,7 @@ void verify_point_transform(PointTGT& tgt_pt, const PointSRC& src_pt) {
         });
 
     // near_ir
-    CondBinaryOp<has_near_ir_v<PointTGT> && has_near_ir_v<PointSRC>>::run(
+    CondBinaryOp<has_near_ir_v<PointTGT> && !has_near_ir_v<PointSRC>>::run(
         tgt_pt, src_pt, [](const auto& tgt_pt, const auto& src_pt) {
             EXPECT_EQ(tgt_pt.near_ir, src_pt.near_ir);
         });


### PR DESCRIPTION
## Summary

This is the runtime-correctness and performance slice of the work developed and
exercised on the `cam_wip` integration branch, rebased onto the current `ros2`
branch. It deliberately preserves ROS time, simulated time, and bag playback
rate semantics: the live ROS processing path does not introduce wall-clock
throttling or silently decimate scans.

### Timing and scan correctness

- Make scan-timestamp interpolation epoch-safe and exact with integer
  arithmetic, checked offsets, and overflow-safe fallbacks.
- Derive scan spacing from the sensor `DataFormat`, rather than an assumed
  frequency.
- Store timestamps per ring-buffer slot under the same slot lock used for the
  scan, eliminating the timestamp/scan race.
- Drop all-zero-timestamp scans, reset the estimator after the discontinuity,
  and keep ROS-time anchoring correct across the drop.
- Accept missing scan fields and fix point-cloud field/cursor shifting bugs,
  with regression coverage.

### Packet path, concurrency, and performance

- Replace timeout polling with predicate-based wakeups that cannot lose a
  notification; start workers only after construction completes and make
  shutdown deterministic.
- Never silently decimate when consumers fall behind. A full ring produces an
  explicit drop instead, preserving the timing of every scan that is published.
- Reuse packet buffers, compute RGB only when a subscriber/output consumes it,
  and expose standard point-cloud QoS overrides.
- Snapshot lock-free ring indices once per operation and keep slot ownership
  consistent.

### Lifecycle, replay, and configuration

- Harden metadata parsing, reconnect behavior, lifecycle teardown, and
  publisher cleanup.
- Validate truncated PCAP packets, pace replay from a steady clock, make sleeps
  interruptible, avoid an empty-PCAP loop spin, and do not convert lifecycle
  deactivation into global ROS shutdown.
- Fix launch/config blockers, including bag filename selection and the
  `laser_frame`/`lidar_frame` mismatch.

## Validation

- Rebased on current `ouster-lidar/ouster-ros:ros2`.
- Combined with #553 (which repairs test discovery): clean ROS 2 Lyrical build;
  23 GoogleTests and 24 total test-result entries passed.
- Full #549 + #552 + #553 composition: 25 GoogleTests and 26 total test-result
  entries passed.
- PCAP smoke tests covered normal recorded pacing and empty-file looping; the
  empty loop exits without busy-spinning.

## Relationship to the other PRs

- #553 is the independent build/test modernization slice. It is only used above
  to ensure this PR's tests are actually compiled and run on Lyrical.
- #552 is the camera and pinhole slice and can be reviewed separately.
