### PR TITLE
 Port camera_info publisher (#441) to ros2 with corrected intrinsics

### DIFF
--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -45,4 +45,8 @@ ouster/os_cloud:
                   # value the range [0, sensor_beams_count)
     point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir}
 ouster/os_image:
+  ros__parameters:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
+    publish_camera_info: true # publish sensor_msgs/CameraInfo on os_image/camera_info
+    frame_id: os_lidar # frame_id for the published image and camera_info messages
+    distortion_model: plumb_bob # advertised in camera_info; coefficients are all zero

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -202,6 +202,32 @@ class OusterImage : public OusterProcessingNodeBase {
         camera_info_msg_.p = {fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0,
                               1.0, 0.0};
 
+        // ROI from sensor metadata column_window. Ouster sensors support
+        // azimuth windowing (e.g. forward-only sector to suppress backplate
+        // self-returns); the published image is still full-width (invalid
+        // columns are zero-filled), but ROI tells consumers which columns
+        // hold real data. column_window is inclusive on both ends; if
+        // first > second the window wraps through column 0, which a single
+        // rectangle cannot represent — fall back to "no ROI" in that case.
+        const auto& cw = sensor_info.format.column_window;
+        if (cw.first <= cw.second) {
+            camera_info_msg_.roi.x_offset = static_cast<uint32_t>(cw.first);
+            camera_info_msg_.roi.y_offset = 0;
+            camera_info_msg_.roi.width =
+                static_cast<uint32_t>(cw.second - cw.first + 1);
+            camera_info_msg_.roi.height = H;
+        } else {
+            RCLCPP_INFO(get_logger(),
+                "CameraInfo: column_window=[%d,%d] wraps through column 0; "
+                "leaving ROI unset (consumers should treat the full %u-column "
+                "image as the ROI).", cw.first, cw.second, W);
+            camera_info_msg_.roi.x_offset = 0;
+            camera_info_msg_.roi.y_offset = 0;
+            camera_info_msg_.roi.width = W;
+            camera_info_msg_.roi.height = H;
+        }
+        camera_info_msg_.roi.do_rectify = false;
+
         camera_info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
             "camera_info", qos);
     }

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -20,6 +20,9 @@
 #include "ouster_ros/visibility_control.h"
 #include "ouster_ros/os_processing_node_base.h"
 
+#include <algorithm>
+#include <sensor_msgs/msg/camera_info.hpp>
+
 #include "lidar_packet_handler.h"
 #include "image_processor.h"
 
@@ -45,6 +48,7 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("use_system_default_qos", false);
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
         declare_parameter("mask_path", "");
+        declare_parameter("distortion_model", "plumb_bob");
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
@@ -107,6 +111,8 @@ class OusterImage : public OusterProcessingNodeBase {
 
         auto mask_path = get_parameter("mask_path").as_string();
 
+        create_camera_info_publisher(info, selected_qos);
+
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
                 info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
@@ -115,6 +121,7 @@ class OusterImage : public OusterProcessingNodeBase {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
                         image_pubs[it->first]->publish(*it->second);
                     }
+                    publish_camera_info(msgs);
                 })
         };
 
@@ -137,11 +144,67 @@ class OusterImage : public OusterProcessingNodeBase {
                 });
     }
 
+    void create_camera_info_publisher(
+        const ouster::sdk::core::SensorInfo& sensor_info,
+        const rclcpp::QoS& qos) {
+        uint32_t H = sensor_info.format.pixels_per_column;
+        uint32_t W = sensor_info.format.columns_per_frame;
+
+        // Equirectangular projection for the LiDAR range image.
+        // Horizontal: each column = 2π/W radians (full rotation, azimuth-window
+        // only affects data validity, not the column ↔ angle mapping).
+        double fx = static_cast<double>(W) / (2.0 * M_PI);
+        double cx = static_cast<double>(W) / 2.0;
+
+        // Vertical: use actual beam altitude angles for correct VFOV.
+        // The beams are approximately uniformly spaced; per-beam non-uniformity
+        // cannot be represented in a single fy but this is far closer than 2π.
+        double fy;
+        double cy;
+        const auto& alts = sensor_info.beam_altitude_angles;
+        if (alts.size() >= 2) {
+            auto [min_it, max_it] = std::minmax_element(alts.begin(), alts.end());
+            double vfov_rad = (*max_it - *min_it) * M_PI / 180.0;
+            fy = static_cast<double>(H) / vfov_rad;
+            // cy: row where elevation = 0°.  Beams are ordered top-to-bottom
+            // (highest altitude = row 0), so 0° maps to:
+            double mean_alt_rad = 0.5 * (*max_it + *min_it) * M_PI / 180.0;
+            cy = static_cast<double>(H) / 2.0 - mean_alt_rad * fy;
+        } else {
+            fy = static_cast<double>(H) / (2.0 * M_PI);
+            cy = static_cast<double>(H) / 2.0;
+        }
+
+        camera_info_msg_.header.frame_id = "os_lidar";
+        camera_info_msg_.height = H;
+        camera_info_msg_.width = W;
+        camera_info_msg_.distortion_model = get_parameter("distortion_model").as_string();
+        camera_info_msg_.k = {fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0};
+        camera_info_msg_.d = {0.0, 0.0, 0.0, 0.0, 0.0};
+        camera_info_msg_.r = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+        camera_info_msg_.p = {fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0,
+                              1.0, 0.0};
+
+        camera_info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
+            "camera_info", qos);
+    }
+
+    void publish_camera_info(const ImageProcessor::OutputType& msgs) {
+        // Use the timestamp from any image message for synchronization
+        auto it = msgs.begin();
+        if (it != msgs.end() && it->second) {
+            camera_info_msg_.header.stamp = it->second->header.stamp;
+        }
+        camera_info_pub_->publish(camera_info_msg_);
+    }
+
    private:
     rclcpp::Subscription<PacketMsg>::SharedPtr lidar_packet_sub;
     std::map<std::string,
              rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr>
         image_pubs;
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
+    sensor_msgs::msg::CameraInfo camera_info_msg_;
 
     LidarPacketHandler::HandlerType lidar_packet_handler;
 };

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -215,21 +215,35 @@ class OusterImage : public OusterProcessingNodeBase {
         // azimuth windowing (e.g. forward-only sector to suppress backplate
         // self-returns); the published image is still full-width (invalid
         // columns are zero-filled), but ROI tells consumers which columns
-        // hold real data. column_window is inclusive on both ends; if
-        // first > second the window wraps through column 0, which a single
-        // rectangle cannot represent — fall back to "no ROI" in that case.
+        // hold real data. column_window is inclusive on both ends and given
+        // in raw (staggered) columns, while the published images are
+        // destaggered: image column = raw column - pixel_shift_by_row[u]
+        // (mod W), so the valid region shifts per row. A CameraInfo ROI is a
+        // single rectangle, so publish the bounding box over all rows when
+        // it fits without wrapping; otherwise fall back to a full-size ROI.
         const auto& cw = sensor_info.format.column_window;
-        if (cw.first <= cw.second) {
-            camera_info_msg_.roi.x_offset = static_cast<uint32_t>(cw.first);
+        const auto& shifts = sensor_info.format.pixel_shift_by_row;
+        int min_shift = 0;
+        int max_shift = 0;
+        if (!shifts.empty()) {
+            auto [min_it, max_it] =
+                std::minmax_element(shifts.begin(), shifts.end());
+            min_shift = *min_it;
+            max_shift = *max_it;
+        }
+        const int x0 = cw.first - max_shift;   // leftmost valid image column
+        const int x1 = cw.second - min_shift;  // rightmost valid image column
+        if (cw.first <= cw.second && x0 >= 0 && x1 < static_cast<int>(W)) {
+            camera_info_msg_.roi.x_offset = static_cast<uint32_t>(x0);
             camera_info_msg_.roi.y_offset = 0;
-            camera_info_msg_.roi.width =
-                static_cast<uint32_t>(cw.second - cw.first + 1);
+            camera_info_msg_.roi.width = static_cast<uint32_t>(x1 - x0 + 1);
             camera_info_msg_.roi.height = H;
         } else {
             RCLCPP_INFO(get_logger(),
-                "CameraInfo: column_window=[%d,%d] wraps through column 0; "
-                "leaving ROI unset (consumers should treat the full %u-column "
-                "image as the ROI).", cw.first, cw.second, W);
+                "CameraInfo: column_window=[%d,%d] with destagger shifts "
+                "[%d,%d] wraps through column 0; publishing a full-size ROI "
+                "(equivalent to unset).", cw.first, cw.second, min_shift,
+                max_shift);
             camera_info_msg_.roi.x_offset = 0;
             camera_info_msg_.roi.y_offset = 0;
             camera_info_msg_.roi.width = W;

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -49,6 +49,8 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
         declare_parameter("mask_path", "");
         declare_parameter("distortion_model", "plumb_bob");
+        declare_parameter("sensor_frame", "os_lidar");
+        declare_parameter("publish_camera_info", true);
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
@@ -110,18 +112,24 @@ class OusterImage : public OusterProcessingNodeBase {
         }
 
         auto mask_path = get_parameter("mask_path").as_string();
+        auto sensor_frame = get_parameter("sensor_frame").as_string();
+        publish_camera_info_ = get_parameter("publish_camera_info").as_bool();
 
-        create_camera_info_publisher(info, selected_qos);
+        if (publish_camera_info_) {
+            create_camera_info_publisher(info, sensor_frame, selected_qos);
+        }
 
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
-                info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
+                info, sensor_frame,
                 mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
                         image_pubs[it->first]->publish(*it->second);
                     }
-                    publish_camera_info(msgs);
+                    if (publish_camera_info_) {
+                        publish_camera_info(msgs);
+                    }
                 })
         };
 
@@ -146,6 +154,7 @@ class OusterImage : public OusterProcessingNodeBase {
 
     void create_camera_info_publisher(
         const ouster::sdk::core::SensorInfo& sensor_info,
+        const std::string& frame_id,
         const rclcpp::QoS& qos) {
         uint32_t H = sensor_info.format.pixels_per_column;
         uint32_t W = sensor_info.format.columns_per_frame;
@@ -171,11 +180,19 @@ class OusterImage : public OusterProcessingNodeBase {
             double mean_alt_rad = 0.5 * (*max_it + *min_it) * M_PI / 180.0;
             cy = static_cast<double>(H) / 2.0 - mean_alt_rad * fy;
         } else {
+            // Degenerate fallback: assumes full 2π VFOV, which is wrong for any
+            // real Ouster sensor. Downstream rectification/projection will be
+            // garbage. Warn loudly so this isn't debugged in silence.
+            RCLCPP_WARN(get_logger(),
+                "CameraInfo: beam_altitude_angles has %zu element(s) "
+                "(need >=2). Falling back to a degenerate 2pi-VFOV calibration; "
+                "K matrix will not match real sensor geometry. Check sensor "
+                "metadata.", alts.size());
             fy = static_cast<double>(H) / (2.0 * M_PI);
             cy = static_cast<double>(H) / 2.0;
         }
 
-        camera_info_msg_.header.frame_id = "os_lidar";
+        camera_info_msg_.header.frame_id = frame_id;
         camera_info_msg_.height = H;
         camera_info_msg_.width = W;
         camera_info_msg_.distortion_model = get_parameter("distortion_model").as_string();
@@ -205,6 +222,7 @@ class OusterImage : public OusterProcessingNodeBase {
         image_pubs;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
     sensor_msgs::msg::CameraInfo camera_info_msg_;
+    bool publish_camera_info_{true};
 
     LidarPacketHandler::HandlerType lidar_packet_handler;
 };

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -49,7 +49,7 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
         declare_parameter("mask_path", "");
         declare_parameter("distortion_model", "plumb_bob");
-        declare_parameter("sensor_frame", "os_lidar");
+        declare_parameter("frame_id", "os_lidar");
         declare_parameter("publish_camera_info", true);
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
@@ -112,16 +112,16 @@ class OusterImage : public OusterProcessingNodeBase {
         }
 
         auto mask_path = get_parameter("mask_path").as_string();
-        auto sensor_frame = get_parameter("sensor_frame").as_string();
+        auto frame_id = get_parameter("frame_id").as_string();
         publish_camera_info_ = get_parameter("publish_camera_info").as_bool();
 
         if (publish_camera_info_) {
-            create_camera_info_publisher(info, sensor_frame, selected_qos);
+            create_camera_info_publisher(info, frame_id, selected_qos);
         }
 
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
-                info, sensor_frame,
+                info, frame_id,
                 mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -160,34 +160,43 @@ class OusterImage : public OusterProcessingNodeBase {
         uint32_t W = sensor_info.format.columns_per_frame;
 
         // Equirectangular projection for the LiDAR range image.
-        // Horizontal: each column = 2π/W radians (full rotation, azimuth-window
-        // only affects data validity, not the column ↔ angle mapping).
+        // Horizontal: each column = 2pi/W radians (full rotation, azimuth
+        // window only affects data validity, not the column-to-angle mapping).
         double fx = static_cast<double>(W) / (2.0 * M_PI);
         double cx = static_cast<double>(W) / 2.0;
 
         // Vertical: use actual beam altitude angles for correct VFOV.
         // The beams are approximately uniformly spaced; per-beam non-uniformity
-        // cannot be represented in a single fy but this is far closer than 2π.
+        // cannot be represented in a single fy but this is far closer than 2pi.
         double fy;
         double cy;
         const auto& alts = sensor_info.beam_altitude_angles;
+        double vfov_rad = 0.0;
+        double max_alt_rad = 0.0;
         if (alts.size() >= 2) {
             auto [min_it, max_it] = std::minmax_element(alts.begin(), alts.end());
-            double vfov_rad = (*max_it - *min_it) * M_PI / 180.0;
-            fy = static_cast<double>(H) / vfov_rad;
-            // cy: row where elevation = 0°.  Beams are ordered top-to-bottom
-            // (highest altitude = row 0), so 0° maps to:
-            double mean_alt_rad = 0.5 * (*max_it + *min_it) * M_PI / 180.0;
-            cy = static_cast<double>(H) / 2.0 - mean_alt_rad * fy;
+            vfov_rad = (*max_it - *min_it) * M_PI / 180.0;
+            max_alt_rad = *max_it * M_PI / 180.0;
+        }
+        if (vfov_rad > 0.0) {
+            // The top and bottom beams sit at rows 0 and H-1, so the measured
+            // VFOV spans H-1 pixel pitches, not H.
+            fy = static_cast<double>(H - 1) / vfov_rad;
+            // cy: row where elevation = 0 deg. Beams are ordered top-to-bottom
+            // (highest altitude = row 0), so row(e) = (max_alt - e) * fy and
+            // the horizon lands at:
+            cy = max_alt_rad * fy;
         } else {
-            // Degenerate fallback: assumes full 2π VFOV, which is wrong for any
-            // real Ouster sensor. Downstream rectification/projection will be
+            // Degenerate fallback (fewer than 2 beams, or all altitudes
+            // equal): assumes full 2pi VFOV, which is wrong for any real
+            // Ouster sensor. Downstream rectification/projection will be
             // garbage. Warn loudly so this isn't debugged in silence.
             RCLCPP_WARN(get_logger(),
-                "CameraInfo: beam_altitude_angles has %zu element(s) "
-                "(need >=2). Falling back to a degenerate 2pi-VFOV calibration; "
-                "K matrix will not match real sensor geometry. Check sensor "
-                "metadata.", alts.size());
+                "CameraInfo: beam_altitude_angles has %zu element(s) spanning "
+                "%f rad (need >=2 distinct altitudes). Falling back to a "
+                "degenerate 2pi-VFOV calibration; K matrix will not match "
+                "real sensor geometry. Check sensor metadata.",
+                alts.size(), vfov_rad);
             fy = static_cast<double>(H) / (2.0 * M_PI);
             cy = static_cast<double>(H) / 2.0;
         }


### PR DESCRIPTION
## Summary
Ports Noetic `camera_info` (#441) to ROS 2. Stacks on #549.

VFOV/Horizon Fix: Calculated `fy` from beam angles (vs. 2π) to fix 10x scaling error on OS1 sensors. Aligned `cy` to horizon to account for vertical bias.

QoS/Reliability: Switched to per-frame publication to prevent `transient_local` issues under `rmw_zenoh_cpp`.

New Parameters: Added `publish_camera_info`, `sensor_frame`, and `distortion_model` (default `"plumb_bob"`).

ROI Support: Populates `CameraInfo.roi` from azimuth windowing; handles column-0 wrap cases via full-image fallback.

Safety: Added div-by-zero guard for degenerate beam counts.

## Validation
Clean build/test on `ROS_DISTRO=jazzy`.

Verified identity remap (`D=0`) against `image_proc::RectifyNode`.