### PR TITLE
[ROS2] Add CameraInfo, optical frames, and cardinal pinhole views

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,6 +22,7 @@ jobs:
           - iron
           - jazzy
           - kilted
+          - lyrical
         rmw_imp:
           - rmw_fastrtps_cpp
           - rmw_cyclonedds_cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,7 @@ ARG ROS_DISTRO
 SHELL ["/bin/bash", "-c"]
 
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && colcon build \
-    --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations"
+    --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && colcon test \
     --ctest-args tests ouster_ros --rerun-failed --output-on-failure

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 3.14.0)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/ouster-sdk/cmake)
 include(DefaultBuildType)

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(ouster_sensor_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
@@ -321,8 +320,7 @@ install(
     share/${PROJECT_NAME}
 )
 
-ament_export_include_directories(include) 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_include_directories(include)
 ament_export_libraries(ouster_ros_library)
 ament_export_dependencies(${ouster_ros_library_deps})
 ament_package()

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
 # Use OpenCV libs variable (OpenCV::OpenCV target may not resolve on all systems)
 if(NOT OpenCV_LIBS)
@@ -183,6 +184,16 @@ rclcpp_components_register_node(os_image_component
   EXECUTABLE os_image
 )
 
+# ==== os_pinhole_component ====
+create_ros2_component(os_pinhole_component
+  "src/os_processing_node_base.cpp;src/os_pinhole_node.cpp"
+  "tf2;tf2_geometry_msgs;tf2_ros"
+)
+rclcpp_components_register_node(os_pinhole_component
+  PLUGIN "ouster_ros::OusterPinhole"
+  EXECUTABLE os_pinhole
+)
+
 # ==== os_driver_component ====
 create_ros2_component(os_driver_component
   "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/os_driver_node.cpp"
@@ -237,6 +248,7 @@ set(OUSTER_INSTALL_TARGETS
   os_replay_component
   os_cloud_component
   os_image_component
+  os_pinhole_component
   os_driver_component
 )
 if (BUILD_PCAP)

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -227,6 +227,7 @@ if(BUILD_TESTING)
     test/point_accessor_test.cpp
     test/point_transform_test.cpp
     test/point_cloud_compose_test.cpp
+    test/pinhole_processor_test.cpp
   )
   ament_target_dependencies(${PROJECT_NAME}_test
     rclcpp

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -98,6 +98,20 @@ option(BUILD_OSF "Turn off building OSF" OFF)
 option(BUILD_MAPPING "Turn off building MAPPING" OFF)
 find_package(OusterSDK REQUIRED)
 
+# The Ouster SDK is vendored via the ouster-sdk submodule. Silence
+# -Wpedantic / -Wdeprecated-declarations on its own compilation units so
+# pedantic workspace compile flags don't fail the build on third-party code
+# we don't own. Our wrapper (ouster_ros_library, os_*_node, etc.) is still
+# compiled with the full diagnostic set.
+foreach(_sdk_target ouster_client ouster_sensor ouster_pcap ouster_osf ouster_viz)
+  if(TARGET ${_sdk_target})
+    target_compile_options(${_sdk_target} PRIVATE
+      -Wno-pedantic
+      -Wno-deprecated-declarations
+    )
+  endif()
+endforeach()
+
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
 
 # catkin adds all include dirs to a single variable, don't try to use targets

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
+find_package(tf2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(OpenCV REQUIRED)
@@ -28,6 +29,37 @@ find_package(OpenCV REQUIRED)
 if(NOT OpenCV_LIBS)
   set(OpenCV_LIBS ${OpenCV_LIBRARIES})
 endif()
+
+# Link an ament package as a dependency. ament_cmake exposes packages in
+# three shapes across ROS 2 distros; we try each in turn:
+#   1. ${pkg}_TARGETS         - rosidl pkgs (msgs/srvs); library pkgs on
+#                               Lyrical+ (e.g. tf2).
+#   2. pkg::pkg imported tgt  - library pkgs on Humble/Jazzy/Kilted.
+#   3. ${pkg}_INCLUDE_DIRS /
+#      ${pkg}_LIBRARIES       - legacy header-only pkgs (pcl_conversions
+#                               on Humble/Jazzy/Kilted).
+function(_ouster_link_ament_deps target visibility)
+  foreach(_pkg IN LISTS ARGN)
+    if(DEFINED ${_pkg}_TARGETS)
+      target_link_libraries(${target} ${visibility} ${${_pkg}_TARGETS})
+    elseif(TARGET ${_pkg}::${_pkg})
+      target_link_libraries(${target} ${visibility} ${_pkg}::${_pkg})
+    elseif(DEFINED ${_pkg}_INCLUDE_DIRS OR DEFINED ${_pkg}_LIBRARIES)
+      if(${_pkg}_INCLUDE_DIRS)
+        target_include_directories(${target} SYSTEM ${visibility}
+          ${${_pkg}_INCLUDE_DIRS})
+      endif()
+      if(${_pkg}_LIBRARIES)
+        target_link_libraries(${target} ${visibility} ${${_pkg}_LIBRARIES})
+      endif()
+    else()
+      message(FATAL_ERROR
+        "_ouster_link_ament_deps: cannot resolve dependency '${_pkg}' "
+        "(none of ${_pkg}_TARGETS, target ${_pkg}::${_pkg}, or legacy "
+        "${_pkg}_INCLUDE_DIRS/${_pkg}_LIBRARIES are defined)")
+    endif()
+  endforeach()
+endfunction()
 
 # ==== Options ====
 if(MSVC)
@@ -97,18 +129,21 @@ set(ouster_ros_library_deps
   tf2_eigen
 )
 
-ament_target_dependencies(ouster_ros_library
+_ouster_link_ament_deps(ouster_ros_library PUBLIC
   ${ouster_ros_library_deps}
 )
 
 target_link_libraries(ouster_ros_library
-  # PUBLIC (unsupported)
+  PUBLIC
     ouster_build
     OusterSDK::ouster_sensor
     pcl_common
-  # PRIVATE (unsupported)
-  ${OUSTER_TARGET_LINKS}
-  ${OpenCV_LIBS}
+    # OpenCV must stay PUBLIC: impl::load_mask in the installed public header
+    # os_ros.h is a template calling cv:: functions, instantiated inside the
+    # component libraries that link only ouster_ros_library.
+    ${OpenCV_LIBS}
+  PRIVATE
+    ${OUSTER_TARGET_LINKS}
 )
 
 # helper method to construct ouster-ros components
@@ -125,7 +160,7 @@ function(create_ros2_component
       "OUSTER_ROS_BUILDING_DLL"
   )
 
-  ament_target_dependencies(${component_lib_name}
+  _ouster_link_ament_deps(${component_lib_name} PUBLIC
     rclcpp
     class_loader
     rclcpp_components
@@ -137,7 +172,8 @@ function(create_ros2_component
   )
 
   target_link_libraries(${component_lib_name}
-    ouster_ros_library
+    PUBLIC
+      ouster_ros_library
   )
 
 endfunction()
@@ -217,16 +253,21 @@ if(BUILD_TESTING)
     test/point_transform_test.cpp
     test/point_cloud_compose_test.cpp
   )
-  ament_target_dependencies(${PROJECT_NAME}_test
-    rclcpp
-    ouster_sensor_msgs
-  )
-  target_include_directories(${PROJECT_NAME}_test PUBLIC
-    ${_ouster_ros_INCLUDE_DIRS}
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-  )
-  target_link_libraries(${PROJECT_NAME}_test ouster_ros_library)
+  if(TARGET ${PROJECT_NAME}_test)
+    target_include_directories(${PROJECT_NAME}_test PRIVATE
+      ${_ouster_ros_INCLUDE_DIRS}
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    )
+    # ament_add_gtest links gtest into the target with the plain
+    # target_link_libraries signature on Humble/Jazzy/Kilted and the keyword
+    # signature on Lyrical; CMake forbids mixing the two on one target.
+    # Appending to LINK_LIBRARIES directly is signature-neutral and, for an
+    # executable, equivalent to PRIVATE linkage. The test's remaining deps
+    # (rclcpp, ouster_sensor_msgs, PCL, ...) propagate through
+    # ouster_ros_library's PUBLIC usage requirements.
+    set_property(TARGET ${PROJECT_NAME}_test APPEND PROPERTY
+      LINK_LIBRARIES ouster_ros_library)
+  endif()
 endif()
 
 

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -176,7 +176,7 @@ rclcpp_components_register_node(os_cloud_component
 # ==== os_image_component ====
 create_ros2_component(os_image_component
   "src/os_processing_node_base.cpp;src/os_image_node.cpp"
-  ""
+  "tf2_ros"
 )
 rclcpp_components_register_node(os_image_component
   PLUGIN "ouster_ros::OusterImage"

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -92,10 +92,13 @@ set(_ouster_ros_INCLUDE_DIRS
 set(_SAVE_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 
-option(BUILD_VIZ "Turn off building VIZ" OFF)
-option(BUILD_PCAP "Turn off building PCAP" OFF)
-option(BUILD_OSF "Turn off building OSF" OFF)
-option(BUILD_MAPPING "Turn off building MAPPING" OFF)
+option(BUILD_VIZ "Build the SDK visualizer" OFF)
+# The package ships os_pcap and replay_pcap.launch.xml, and its manifest
+# already declares the capture dependencies. Build that supported path by
+# default so binary/source installs do not silently omit the executable.
+option(BUILD_PCAP "Build the os_pcap node for pcap replay" ON)
+option(BUILD_OSF "Build SDK OSF support" OFF)
+option(BUILD_MAPPING "Build SDK mapping support" OFF)
 find_package(OusterSDK REQUIRED)
 
 # The Ouster SDK is vendored via the ouster-sdk submodule. Silence
@@ -249,6 +252,9 @@ create_ros2_component(os_pcap_component
   "src/os_sensor_node_base.cpp;src/os_pcap_node.cpp"
   ""
 )
+# os_pcap_node.cpp calls PcapReader directly. Do not rely on the private
+# ouster_ros_library link to retain these symbols in a shared component.
+target_link_libraries(os_pcap_component PRIVATE OusterSDK::ouster_pcap)
 rclcpp_components_register_node(os_pcap_component
   PLUGIN "ouster_ros::OusterPcap"
   EXECUTABLE os_pcap
@@ -257,6 +263,15 @@ endif()
 
 # ==== Test ====
 if(BUILD_TESTING)
+  # OusterSDK prepends its compatibility FindGTest.cmake to
+  # CMAKE_MODULE_PATH. On newer ament_cmake_gtest releases that module finds
+  # GTest inside a function without propagating GTest_FOUND, so
+  # ament_add_gtest() silently skips this package's test executable. SDK
+  # configuration is complete here; temporarily use CMake's system finder for
+  # the ROS test target, then restore the module path for downstream users.
+  set(_ouster_ros_saved_cmake_module_path "${CMAKE_MODULE_PATH}")
+  list(REMOVE_ITEM CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/ouster-sdk/cmake")
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(${PROJECT_NAME}_test
     src/os_ros.cpp
@@ -280,7 +295,12 @@ if(BUILD_TESTING)
     # ouster_ros_library's PUBLIC usage requirements.
     set_property(TARGET ${PROJECT_NAME}_test APPEND PROPERTY
       LINK_LIBRARIES ouster_ros_library)
+  else()
+    message(WARNING
+      "ouster_ros: ament_add_gtest did not create ${PROJECT_NAME}_test "
+      "even though ament_cmake_gtest is installed")
   endif()
+  set(CMAKE_MODULE_PATH "${_ouster_ros_saved_cmake_module_path}")
 endif()
 
 

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -50,4 +50,9 @@ ouster/os_image:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
     publish_camera_info: true # publish sensor_msgs/CameraInfo on os_image/camera_info
     frame_id: os_lidar # frame_id for the published image and camera_info messages
+    optical_frame: '' # empty (default) = off. When set (e.g. os_lidar_optical),
+                      # images/camera_info are stamped in that frame instead of
+                      # frame_id and a static TF frame_id -> optical_frame is
+                      # published (REP-103 optical convention: z forward along
+                      # the image center column, x right, y down)
     distortion_model: plumb_bob # advertised in camera_info; coefficients are all zero

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -46,4 +46,8 @@ ouster/os_cloud:
                   # value the range [0, sensor_beams_count)
     point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzrgb, xyzrgba}
 ouster/os_image:
+  ros__parameters:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
+    publish_camera_info: true # publish sensor_msgs/CameraInfo on os_image/camera_info
+    frame_id: os_lidar # frame_id for the published image and camera_info messages
+    distortion_model: plumb_bob # advertised in camera_info; coefficients are all zero

--- a/ouster-ros/config/os_sensor_cloud_image_params.yaml
+++ b/ouster-ros/config/os_sensor_cloud_image_params.yaml
@@ -37,6 +37,7 @@ ouster/os_cloud:
     lidar_frame: os_lidar
     imu_frame: os_imu
     point_cloud_frame: os_lidar
+    metadata: '' # optional path to sensor metadata JSON; useful for plain bag playback
     pub_static_tf: true
     timestamp_mode: ''  # this value needs to match os_sensor/timestamp_mode
     ptp_utc_tai_offset: -37.0 # UTC/TAI offset in seconds to apply when using TIME_FROM_PTP_1588
@@ -44,11 +45,13 @@ ouster/os_cloud:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
     scan_ring: 0  # Use this parameter in conjunction with the SCAN flag and choose a
                   # value the range [0, sensor_beams_count)
-    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzrgb, xyzrgba}
+    point_type: original # choose from: {original, native, xyz, xyzi, o_xyzi, xyzir, xyzrgb, xyzrgba, color_point}
 ouster/os_image:
   ros__parameters:
     use_system_default_qos: false # needs to match the value defined for os_sensor node
-    publish_camera_info: true # publish sensor_msgs/CameraInfo on os_image/camera_info
+    metadata: '' # optional path to sensor metadata JSON; useful for plain bag playback
+    publish_camera_info: false # display-only approximation for the equirectangular panorama;
+                               # use os_pinhole for pinhole geometry
     frame_id: os_lidar # frame_id for the published image and camera_info messages
     optical_frame: '' # empty (default) = off. When set (e.g. os_lidar_optical),
                       # images/camera_info are stamped in that frame instead of

--- a/ouster-ros/include/ouster_ros/common_point_types.h
+++ b/ouster-ros/include/ouster_ros/common_point_types.h
@@ -21,6 +21,12 @@ namespace ouster_ros {
  * @remark XYZIT point type is not compatible with RNG15_RFL8_NIR8/LOW_DATA
  * udp lidar profile.
  */
+// Anonymous struct inside a union is a GCC/Clang extension (not ISO C++), but it
+// is the canonical PCL point-type layout. Suppress the -Wpedantic complaint here.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 struct EIGEN_ALIGN16 _Ouster_PointXYZI {
     union EIGEN_ALIGN16 {
         float data[4];
@@ -33,6 +39,9 @@ struct EIGEN_ALIGN16 _Ouster_PointXYZI {
    };
    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 struct PointXYZI : public _Ouster_PointXYZI {
 

--- a/ouster-ros/include/ouster_ros/os_processing_node_base.h
+++ b/ouster-ros/include/ouster_ros/os_processing_node_base.h
@@ -10,8 +10,11 @@
 #include <ouster/types.h>
 
 #include <chrono>
+#include <cstdint>
+#include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <string>
 
 namespace ouster_ros {
 
@@ -25,10 +28,54 @@ class OusterProcessingNodeBase : public rclcpp::Node {
         std::function<void(const std_msgs::msg::String::ConstSharedPtr&)>
             on_sensor_metadata);
 
+    // Reads the optional "metadata" file-path parameter; when it is set, loads
+    // the file and invokes on_sensor_metadata with its contents. This lets the
+    // processing nodes obtain sensor metadata without the latched /metadata
+    // topic (e.g. a plain `ros2 bag play` of recorded packets, where the
+    // transient-local topic is not reliably re-delivered). Returns true if
+    // metadata was loaded from a file.
+    bool load_metadata_from_file(
+        const std::function<void(const std_msgs::msg::String::ConstSharedPtr&)>&
+            on_sensor_metadata);
+
+    // Metadata and packet subscriptions currently share the node's default
+    // mutually-exclusive callback group. Keep an explicit lock as well so a
+    // future callback-group change cannot race pipeline teardown against an
+    // in-flight packet callback.
+    std::mutex pipeline_mutex;
+
+    bool metadata_is_active(const std::string& metadata) const {
+        return has_active_metadata_ && metadata == active_metadata_;
+    }
+
+    void mark_metadata_active(const std::string& metadata) {
+        active_metadata_ = metadata;
+        has_active_metadata_ = true;
+    }
+
+    void invalidate_active_metadata() {
+        active_metadata_.clear();
+        has_active_metadata_ = false;
+    }
+
+    uint64_t begin_pipeline_update() {
+        invalidate_active_metadata();
+        return ++pipeline_generation_;
+    }
+
+    bool pipeline_is_current(uint64_t generation) const {
+        return generation == pipeline_generation_;
+    }
+
    protected:
     rclcpp::Subscription<std_msgs::msg::String>::SharedPtr metadata_sub;
     ouster::sdk::core::SensorInfo info;
     std::shared_ptr<ouster::sdk::core::PacketFormat> packet_format;
+
+   private:
+    std::string active_metadata_;
+    bool has_active_metadata_ = false;
+    uint64_t pipeline_generation_ = 0;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -193,6 +193,13 @@
   <arg name="mask_path" default="" description="path to an image file that will be used to
    mask parts of the pointcloud}"/>
 
+  <arg name="publish_camera_info" default="false"
+    description="publish a display-only equirectangular CameraInfo approximation"/>
+  <arg name="camera_optical_frame" default=""
+    description="optional REP-103 optical frame for os_image (empty = disabled)"/>
+  <arg name="distortion_model" default="plumb_bob"
+    description="distortion model advertised in os_image camera_info"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="os_container" output="screen" namespace="">
@@ -254,6 +261,10 @@
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
         <param name="proc_mask" value="$(var proc_mask)"/>
         <param name="mask_path" value="$(var mask_path)"/>
+        <param name="frame_id" value="$(var lidar_frame)"/>
+        <param name="publish_camera_info" value="$(var publish_camera_info)"/>
+        <param name="optical_frame" value="$(var camera_optical_frame)"/>
+        <param name="distortion_model" value="$(var distortion_model)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -89,6 +89,13 @@
   <arg name="mask_path" default="" description="path to an image file that will be used to
    mask parts of the pointcloud}"/>
 
+  <arg name="publish_camera_info" default="false"
+    description="publish a display-only equirectangular CameraInfo approximation"/>
+  <arg name="camera_optical_frame" default=""
+    description="optional REP-103 optical frame for os_image (empty = disabled)"/>
+  <arg name="distortion_model" default="plumb_bob"
+    description="distortion model advertised in os_image camera_info"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
@@ -115,11 +122,17 @@
         <param name="v_reduction" value="$(var v_reduction)"/>
         <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
+        <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
         <param name="proc_mask" value="$(var proc_mask)"/>
         <param name="mask_path" value="$(var mask_path)"/>
+        <param name="metadata" value="$(var metadata)"/>
+        <param name="frame_id" value="$(var lidar_frame)"/>
+        <param name="publish_camera_info" value="$(var publish_camera_info)"/>
+        <param name="optical_frame" value="$(var camera_optical_frame)"/>
+        <param name="distortion_model" value="$(var distortion_model)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -1,5 +1,7 @@
 <launch>
 
+  <!-- os_pcap is omitted only when the package is explicitly built with
+       -DBUILD_PCAP=OFF; BUILD_PCAP defaults to ON. -->
   <!-- NOTE: pcap replay node does not implement clock -->
   <set_parameter name="use_sim_time" value="false" />
 

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -85,6 +85,13 @@
   <arg name="mask_path" default="" description="path to an image file that will be used to
    mask parts of the pointcloud}"/>
 
+  <arg name="publish_camera_info" default="false"
+    description="publish a display-only equirectangular CameraInfo approximation"/>
+  <arg name="camera_optical_frame" default=""
+    description="optional REP-103 optical frame for os_image (empty = disabled)"/>
+  <arg name="distortion_model" default="plumb_bob"
+    description="distortion model advertised in os_image camera_info"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_pcap" name="os_pcap"
@@ -115,11 +122,17 @@
         <param name="v_reduction" value="$(var v_reduction)"/>
         <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
+        <param name="metadata" value="$(var metadata)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>
         <param name="proc_mask" value="$(var proc_mask)"/>
         <param name="mask_path" value="$(var mask_path)"/>
+        <param name="metadata" value="$(var metadata)"/>
+        <param name="frame_id" value="$(var lidar_frame)"/>
+        <param name="publish_camera_info" value="$(var publish_camera_info)"/>
+        <param name="optical_frame" value="$(var camera_optical_frame)"/>
+        <param name="distortion_model" value="$(var distortion_model)"/>
       </composable_node>
     </node_container>
   </group>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
   <version>0.15.0</version>
@@ -8,7 +8,6 @@
   <license file="LICENSE">BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
@@ -21,27 +20,24 @@
   <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
-  <depend>cv_bridge</depend>
+  <depend>libopencv-dev</depend>
   <depend>curl</depend>
   <depend>spdlog</depend>
+  <depend>libjsoncpp-dev</depend>
 
-  <build_depend>libjsoncpp-dev</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>tf2_eigen</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>libssl-dev</build_depend>
   <build_depend>libtins-dev</build_depend>
   <build_depend>libzip-dev</build_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>libjsoncpp</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>gtest</test_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -20,6 +20,7 @@
   <depend>geometry_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>cv_bridge</depend>
   <depend>curl</depend>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -19,6 +19,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>pcl_conversions</depend>
   <depend>cv_bridge</depend>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -18,9 +18,10 @@
   <depend>ouster_sensor_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
-  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
   <depend>cv_bridge</depend>
   <depend>curl</depend>

--- a/ouster-ros/src/lidar_packet_handler.h
+++ b/ouster-ros/src/lidar_packet_handler.h
@@ -94,7 +94,8 @@ class LidarPacketHandler {
                        const std::vector<LidarScanProcessor>& handlers,
                        const std::string& timestamp_mode,
                        int64_t ptp_utc_tai_offset,
-                       float min_scan_valid_columns_ratio)
+                       float min_scan_valid_columns_ratio,
+                       bool process_rgb = true)
         : ring_buffer(LIDAR_SCAN_COUNT),
           lidar_scan_handlers{handlers},
           ptp_utc_tai_offset_(ptp_utc_tai_offset),
@@ -113,8 +114,12 @@ class LidarPacketHandler {
             mutexes[i] = std::make_unique<std::mutex>();
         }
 
-        if (info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
-            info.format.udp_profile_lidar == ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL) {
+        const bool profile_has_rgb =
+            info.format.udp_profile_lidar ==
+                ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+            info.format.udp_profile_lidar ==
+                ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
+        if (process_rgb && profile_has_rgb) {
             has_rgb_ = true;
             uint32_t H = info.format.pixels_per_column;
             uint32_t W = info.format.columns_per_frame;
@@ -217,10 +222,10 @@ class LidarPacketHandler {
         const ouster::sdk::core::SensorInfo& info,
         const std::vector<LidarScanProcessor>& handlers,
         const std::string& timestamp_mode, int64_t ptp_utc_tai_offset,
-        float min_scan_valid_columns_ratio) {
+        float min_scan_valid_columns_ratio, bool process_rgb = true) {
         auto handler = std::make_shared<LidarPacketHandler>(
             info, handlers, timestamp_mode, ptp_utc_tai_offset,
-            min_scan_valid_columns_ratio);
+            min_scan_valid_columns_ratio, process_rgb);
         return [handler](const ouster::sdk::core::LidarPacket& lidar_packet) {
             if (handler->lidar_packet_accumlator(lidar_packet)) {
                 handler->ring_buffer_has_elements.notify_one();

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -51,6 +51,8 @@ class OusterCloud : public OusterProcessingNodeBase {
         tf_bcast.parse_parameters();
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
+        load_metadata_from_file(
+            [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterCloud: node initialized!");
     }
 

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -49,6 +49,8 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
         declare_parameter("mask_path", "");
         declare_parameter("distortion_model", "plumb_bob");
+        declare_parameter("sensor_frame", "os_lidar");
+        declare_parameter("publish_camera_info", true);
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
@@ -112,18 +114,24 @@ class OusterImage : public OusterProcessingNodeBase {
         }
 
         auto mask_path = get_parameter("mask_path").as_string();
+        auto sensor_frame = get_parameter("sensor_frame").as_string();
+        publish_camera_info_ = get_parameter("publish_camera_info").as_bool();
 
-        create_camera_info_publisher(info, selected_qos);
+        if (publish_camera_info_) {
+            create_camera_info_publisher(info, sensor_frame, selected_qos);
+        }
 
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
-                info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
+                info, sensor_frame,
                 mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
                         image_pubs[it->first]->publish(*it->second);
                     }
-                    publish_camera_info(msgs);
+                    if (publish_camera_info_) {
+                        publish_camera_info(msgs);
+                    }
                 })
         };
 
@@ -148,6 +156,7 @@ class OusterImage : public OusterProcessingNodeBase {
 
     void create_camera_info_publisher(
         const ouster::sdk::core::SensorInfo& sensor_info,
+        const std::string& frame_id,
         const rclcpp::QoS& qos) {
         uint32_t H = sensor_info.format.pixels_per_column;
         uint32_t W = sensor_info.format.columns_per_frame;
@@ -173,11 +182,19 @@ class OusterImage : public OusterProcessingNodeBase {
             double mean_alt_rad = 0.5 * (*max_it + *min_it) * M_PI / 180.0;
             cy = static_cast<double>(H) / 2.0 - mean_alt_rad * fy;
         } else {
+            // Degenerate fallback: assumes full 2π VFOV, which is wrong for any
+            // real Ouster sensor. Downstream rectification/projection will be
+            // garbage. Warn loudly so this isn't debugged in silence.
+            RCLCPP_WARN(get_logger(),
+                "CameraInfo: beam_altitude_angles has %zu element(s) "
+                "(need >=2). Falling back to a degenerate 2pi-VFOV calibration; "
+                "K matrix will not match real sensor geometry. Check sensor "
+                "metadata.", alts.size());
             fy = static_cast<double>(H) / (2.0 * M_PI);
             cy = static_cast<double>(H) / 2.0;
         }
 
-        camera_info_msg_.header.frame_id = "os_lidar";
+        camera_info_msg_.header.frame_id = frame_id;
         camera_info_msg_.height = H;
         camera_info_msg_.width = W;
         camera_info_msg_.distortion_model = get_parameter("distortion_model").as_string();
@@ -207,6 +224,7 @@ class OusterImage : public OusterProcessingNodeBase {
         image_pubs;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
     sensor_msgs::msg::CameraInfo camera_info_msg_;
+    bool publish_camera_info_{true};
 
     LidarPacketHandler::HandlerType lidar_packet_handler;
 };

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -23,6 +23,13 @@
 #include <algorithm>
 #include <sensor_msgs/msg/camera_info.hpp>
 
+#if __has_include(<tf2/LinearMath/Quaternion.hpp>)
+#include <tf2/LinearMath/Quaternion.hpp>
+#else
+#include <tf2/LinearMath/Quaternion.h>
+#endif
+#include <tf2_ros/static_transform_broadcaster.h>
+
 #include "lidar_packet_handler.h"
 #include "image_processor.h"
 
@@ -50,6 +57,7 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("mask_path", "");
         declare_parameter("distortion_model", "plumb_bob");
         declare_parameter("frame_id", "os_lidar");
+        declare_parameter("optical_frame", "");
         declare_parameter("publish_camera_info", true);
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
@@ -115,15 +123,26 @@ class OusterImage : public OusterProcessingNodeBase {
 
         auto mask_path = get_parameter("mask_path").as_string();
         auto frame_id = get_parameter("frame_id").as_string();
+        auto optical_frame = get_parameter("optical_frame").as_string();
         publish_camera_info_ = get_parameter("publish_camera_info").as_bool();
 
+        // When optical_frame is set, stamp images and camera_info in that
+        // frame and broadcast a static transform frame_id -> optical_frame.
+        // When empty (default) behavior is unchanged: messages are stamped
+        // with frame_id and no transform is published.
+        const auto& image_frame = optical_frame.empty() ? frame_id
+                                                        : optical_frame;
+        if (!optical_frame.empty()) {
+            broadcast_optical_transform(info, frame_id, optical_frame);
+        }
+
         if (publish_camera_info_) {
-            create_camera_info_publisher(info, frame_id, selected_qos);
+            create_camera_info_publisher(info, image_frame, selected_qos);
         }
 
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
-                info, frame_id,
+                info, image_frame,
                 mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
@@ -152,6 +171,49 @@ class OusterImage : public OusterProcessingNodeBase {
                         lidar_packet_handler(lidar_packet);
                     }
                 });
+    }
+
+    void broadcast_optical_transform(
+        const ouster::sdk::core::SensorInfo& sensor_info,
+        const std::string& frame_id,
+        const std::string& optical_frame) {
+        double W = static_cast<double>(sensor_info.format.columns_per_frame);
+
+        // Azimuth of the image center column (cx = W/2) in the lidar frame.
+        // Per the SDK xyz lut (ouster_client/src/xyzlut.cpp), raw column m has
+        // encoder angle theta_e = 2*pi - m*(2*pi/W) plus a per-beam azimuth
+        // theta_a = -beam_azimuth_angles[u]; destaggering shifts each row by
+        // pixel_shift_by_row[u] ~= beam_azimuth*W/360 which cancels theta_a,
+        // so destaggered image column v looks along azimuth
+        // theta(v) = 2*pi - v*(2*pi/W) for every row. For v = cx = W/2 this
+        // gives theta = pi, i.e. the image center looks along -X_lidar.
+        double az_center = 2.0 * M_PI - (W / 2.0) * (2.0 * M_PI / W);
+
+        // Rotate lidar axes to optical axes for a camera looking along
+        // +X_lidar (roll = -pi/2, yaw = -pi/2), then yaw the optical axis
+        // about Z_lidar to the center-column azimuth. With setRPY(r, p, y)
+        // composing as Rz(y)*Ry(p)*Rx(r) this collapses to:
+        tf2::Quaternion q;
+        q.setRPY(-M_PI_2, 0.0, az_center - M_PI_2);
+        // Resulting matrix (columns = optical axes in lidar coordinates):
+        //   [ 0  0 -1 ]
+        //   [ 1  0  0 ]   => Z_opt = -X_lidar (center column, forward),
+        //   [ 0 -1  0 ]      Y_opt = -Z_lidar (down), X_opt = +Y_lidar.
+
+        geometry_msgs::msg::TransformStamped tf_msg;
+        tf_msg.header.stamp = get_clock()->now();
+        tf_msg.header.frame_id = frame_id;
+        tf_msg.child_frame_id = optical_frame;
+        tf_msg.transform.rotation.x = q.x();
+        tf_msg.transform.rotation.y = q.y();
+        tf_msg.transform.rotation.z = q.z();
+        tf_msg.transform.rotation.w = q.w();
+
+        if (!tf_bcast_) {
+            tf_bcast_ =
+                std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+        }
+        tf_bcast_->sendTransform(tf_msg);
     }
 
     void create_camera_info_publisher(
@@ -276,6 +338,7 @@ class OusterImage : public OusterProcessingNodeBase {
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
     sensor_msgs::msg::CameraInfo camera_info_msg_;
     bool publish_camera_info_{true};
+    std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_bcast_;
 
     LidarPacketHandler::HandlerType lidar_packet_handler;
 };

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -162,34 +162,43 @@ class OusterImage : public OusterProcessingNodeBase {
         uint32_t W = sensor_info.format.columns_per_frame;
 
         // Equirectangular projection for the LiDAR range image.
-        // Horizontal: each column = 2π/W radians (full rotation, azimuth-window
-        // only affects data validity, not the column ↔ angle mapping).
+        // Horizontal: each column = 2pi/W radians (full rotation, azimuth
+        // window only affects data validity, not the column-to-angle mapping).
         double fx = static_cast<double>(W) / (2.0 * M_PI);
         double cx = static_cast<double>(W) / 2.0;
 
         // Vertical: use actual beam altitude angles for correct VFOV.
         // The beams are approximately uniformly spaced; per-beam non-uniformity
-        // cannot be represented in a single fy but this is far closer than 2π.
+        // cannot be represented in a single fy but this is far closer than 2pi.
         double fy;
         double cy;
         const auto& alts = sensor_info.beam_altitude_angles;
+        double vfov_rad = 0.0;
+        double max_alt_rad = 0.0;
         if (alts.size() >= 2) {
             auto [min_it, max_it] = std::minmax_element(alts.begin(), alts.end());
-            double vfov_rad = (*max_it - *min_it) * M_PI / 180.0;
-            fy = static_cast<double>(H) / vfov_rad;
-            // cy: row where elevation = 0°.  Beams are ordered top-to-bottom
-            // (highest altitude = row 0), so 0° maps to:
-            double mean_alt_rad = 0.5 * (*max_it + *min_it) * M_PI / 180.0;
-            cy = static_cast<double>(H) / 2.0 - mean_alt_rad * fy;
+            vfov_rad = (*max_it - *min_it) * M_PI / 180.0;
+            max_alt_rad = *max_it * M_PI / 180.0;
+        }
+        if (vfov_rad > 0.0) {
+            // The top and bottom beams sit at rows 0 and H-1, so the measured
+            // VFOV spans H-1 pixel pitches, not H.
+            fy = static_cast<double>(H - 1) / vfov_rad;
+            // cy: row where elevation = 0 deg. Beams are ordered top-to-bottom
+            // (highest altitude = row 0), so row(e) = (max_alt - e) * fy and
+            // the horizon lands at:
+            cy = max_alt_rad * fy;
         } else {
-            // Degenerate fallback: assumes full 2π VFOV, which is wrong for any
-            // real Ouster sensor. Downstream rectification/projection will be
+            // Degenerate fallback (fewer than 2 beams, or all altitudes
+            // equal): assumes full 2pi VFOV, which is wrong for any real
+            // Ouster sensor. Downstream rectification/projection will be
             // garbage. Warn loudly so this isn't debugged in silence.
             RCLCPP_WARN(get_logger(),
-                "CameraInfo: beam_altitude_angles has %zu element(s) "
-                "(need >=2). Falling back to a degenerate 2pi-VFOV calibration; "
-                "K matrix will not match real sensor geometry. Check sensor "
-                "metadata.", alts.size());
+                "CameraInfo: beam_altitude_angles has %zu element(s) spanning "
+                "%f rad (need >=2 distinct altitudes). Falling back to a "
+                "degenerate 2pi-VFOV calibration; K matrix will not match "
+                "real sensor geometry. Check sensor metadata.",
+                alts.size(), vfov_rad);
             fy = static_cast<double>(H) / (2.0 * M_PI);
             cy = static_cast<double>(H) / 2.0;
         }

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -20,6 +20,9 @@
 #include "ouster_ros/visibility_control.h"
 #include "ouster_ros/os_processing_node_base.h"
 
+#include <algorithm>
+#include <sensor_msgs/msg/camera_info.hpp>
+
 #include "lidar_packet_handler.h"
 #include "image_processor.h"
 
@@ -45,6 +48,7 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("use_system_default_qos", false);
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
         declare_parameter("mask_path", "");
+        declare_parameter("distortion_model", "plumb_bob");
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
@@ -109,6 +113,8 @@ class OusterImage : public OusterProcessingNodeBase {
 
         auto mask_path = get_parameter("mask_path").as_string();
 
+        create_camera_info_publisher(info, selected_qos);
+
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
                 info, "os_lidar", /*TODO: tf_bcast.point_cloud_frame_id()*/
@@ -117,6 +123,7 @@ class OusterImage : public OusterProcessingNodeBase {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {
                         image_pubs[it->first]->publish(*it->second);
                     }
+                    publish_camera_info(msgs);
                 })
         };
 
@@ -139,11 +146,67 @@ class OusterImage : public OusterProcessingNodeBase {
                 });
     }
 
+    void create_camera_info_publisher(
+        const ouster::sdk::core::SensorInfo& sensor_info,
+        const rclcpp::QoS& qos) {
+        uint32_t H = sensor_info.format.pixels_per_column;
+        uint32_t W = sensor_info.format.columns_per_frame;
+
+        // Equirectangular projection for the LiDAR range image.
+        // Horizontal: each column = 2π/W radians (full rotation, azimuth-window
+        // only affects data validity, not the column ↔ angle mapping).
+        double fx = static_cast<double>(W) / (2.0 * M_PI);
+        double cx = static_cast<double>(W) / 2.0;
+
+        // Vertical: use actual beam altitude angles for correct VFOV.
+        // The beams are approximately uniformly spaced; per-beam non-uniformity
+        // cannot be represented in a single fy but this is far closer than 2π.
+        double fy;
+        double cy;
+        const auto& alts = sensor_info.beam_altitude_angles;
+        if (alts.size() >= 2) {
+            auto [min_it, max_it] = std::minmax_element(alts.begin(), alts.end());
+            double vfov_rad = (*max_it - *min_it) * M_PI / 180.0;
+            fy = static_cast<double>(H) / vfov_rad;
+            // cy: row where elevation = 0°.  Beams are ordered top-to-bottom
+            // (highest altitude = row 0), so 0° maps to:
+            double mean_alt_rad = 0.5 * (*max_it + *min_it) * M_PI / 180.0;
+            cy = static_cast<double>(H) / 2.0 - mean_alt_rad * fy;
+        } else {
+            fy = static_cast<double>(H) / (2.0 * M_PI);
+            cy = static_cast<double>(H) / 2.0;
+        }
+
+        camera_info_msg_.header.frame_id = "os_lidar";
+        camera_info_msg_.height = H;
+        camera_info_msg_.width = W;
+        camera_info_msg_.distortion_model = get_parameter("distortion_model").as_string();
+        camera_info_msg_.k = {fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0};
+        camera_info_msg_.d = {0.0, 0.0, 0.0, 0.0, 0.0};
+        camera_info_msg_.r = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+        camera_info_msg_.p = {fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0,
+                              1.0, 0.0};
+
+        camera_info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
+            "camera_info", qos);
+    }
+
+    void publish_camera_info(const ImageProcessor::OutputType& msgs) {
+        // Use the timestamp from any image message for synchronization
+        auto it = msgs.begin();
+        if (it != msgs.end() && it->second) {
+            camera_info_msg_.header.stamp = it->second->header.stamp;
+        }
+        camera_info_pub_->publish(camera_info_msg_);
+    }
+
    private:
     rclcpp::Subscription<PacketMsg>::SharedPtr lidar_packet_sub;
     std::map<std::string,
              rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr>
         image_pubs;
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
+    sensor_msgs::msg::CameraInfo camera_info_msg_;
 
     LidarPacketHandler::HandlerType lidar_packet_handler;
 };

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -217,21 +217,35 @@ class OusterImage : public OusterProcessingNodeBase {
         // azimuth windowing (e.g. forward-only sector to suppress backplate
         // self-returns); the published image is still full-width (invalid
         // columns are zero-filled), but ROI tells consumers which columns
-        // hold real data. column_window is inclusive on both ends; if
-        // first > second the window wraps through column 0, which a single
-        // rectangle cannot represent — fall back to "no ROI" in that case.
+        // hold real data. column_window is inclusive on both ends and given
+        // in raw (staggered) columns, while the published images are
+        // destaggered: image column = raw column - pixel_shift_by_row[u]
+        // (mod W), so the valid region shifts per row. A CameraInfo ROI is a
+        // single rectangle, so publish the bounding box over all rows when
+        // it fits without wrapping; otherwise fall back to a full-size ROI.
         const auto& cw = sensor_info.format.column_window;
-        if (cw.first <= cw.second) {
-            camera_info_msg_.roi.x_offset = static_cast<uint32_t>(cw.first);
+        const auto& shifts = sensor_info.format.pixel_shift_by_row;
+        int min_shift = 0;
+        int max_shift = 0;
+        if (!shifts.empty()) {
+            auto [min_it, max_it] =
+                std::minmax_element(shifts.begin(), shifts.end());
+            min_shift = *min_it;
+            max_shift = *max_it;
+        }
+        const int x0 = cw.first - max_shift;   // leftmost valid image column
+        const int x1 = cw.second - min_shift;  // rightmost valid image column
+        if (cw.first <= cw.second && x0 >= 0 && x1 < static_cast<int>(W)) {
+            camera_info_msg_.roi.x_offset = static_cast<uint32_t>(x0);
             camera_info_msg_.roi.y_offset = 0;
-            camera_info_msg_.roi.width =
-                static_cast<uint32_t>(cw.second - cw.first + 1);
+            camera_info_msg_.roi.width = static_cast<uint32_t>(x1 - x0 + 1);
             camera_info_msg_.roi.height = H;
         } else {
             RCLCPP_INFO(get_logger(),
-                "CameraInfo: column_window=[%d,%d] wraps through column 0; "
-                "leaving ROI unset (consumers should treat the full %u-column "
-                "image as the ROI).", cw.first, cw.second, W);
+                "CameraInfo: column_window=[%d,%d] with destagger shifts "
+                "[%d,%d] wraps through column 0; publishing a full-size ROI "
+                "(equivalent to unset).", cw.first, cw.second, min_shift,
+                max_shift);
             camera_info_msg_.roi.x_offset = 0;
             camera_info_msg_.roi.y_offset = 0;
             camera_info_msg_.roi.width = W;

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -50,7 +50,7 @@ class OusterImage : public OusterProcessingNodeBase {
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
     }
 
-    void metadata_handler(const std_msgs::msg::String::ConstPtr& metadata_msg) {
+    void metadata_handler(const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
         RCLCPP_INFO(get_logger(),
                     "OusterImage: retrieved new sensor metadata!");
         info = ouster::sdk::core::SensorInfo(metadata_msg->data);

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -49,7 +49,7 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
         declare_parameter("mask_path", "");
         declare_parameter("distortion_model", "plumb_bob");
-        declare_parameter("sensor_frame", "os_lidar");
+        declare_parameter("frame_id", "os_lidar");
         declare_parameter("publish_camera_info", true);
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
@@ -114,16 +114,16 @@ class OusterImage : public OusterProcessingNodeBase {
         }
 
         auto mask_path = get_parameter("mask_path").as_string();
-        auto sensor_frame = get_parameter("sensor_frame").as_string();
+        auto frame_id = get_parameter("frame_id").as_string();
         publish_camera_info_ = get_parameter("publish_camera_info").as_bool();
 
         if (publish_camera_info_) {
-            create_camera_info_publisher(info, sensor_frame, selected_qos);
+            create_camera_info_publisher(info, frame_id, selected_qos);
         }
 
         std::vector<LidarScanProcessor> processors {
             ImageProcessor::create(
-                info, sensor_frame,
+                info, frame_id,
                 mask_path,
                 [this](ImageProcessor::OutputType msgs) {
                     for (auto it = msgs.begin(); it != msgs.end(); ++it) {

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -219,10 +219,12 @@ class OusterImage : public OusterProcessingNodeBase {
         // columns are zero-filled), but ROI tells consumers which columns
         // hold real data. column_window is inclusive on both ends and given
         // in raw (staggered) columns, while the published images are
-        // destaggered: image column = raw column - pixel_shift_by_row[u]
-        // (mod W), so the valid region shifts per row. A CameraInfo ROI is a
-        // single rectangle, so publish the bounding box over all rows when
-        // it fits without wrapping; otherwise fall back to a full-size ROI.
+        // destaggered. The SDK destagger maps a staggered column c to image
+        // column (c + pixel_shift_by_row[u]) mod W (see ouster::destagger:
+        // destaggered[k] = staggered[k - shift]), so the valid region shifts
+        // per row. A CameraInfo ROI is a single rectangle, so publish the
+        // bounding box over all rows when it fits without wrapping; otherwise
+        // fall back to a full-size ROI.
         const auto& cw = sensor_info.format.column_window;
         const auto& shifts = sensor_info.format.pixel_shift_by_row;
         int min_shift = 0;
@@ -233,8 +235,8 @@ class OusterImage : public OusterProcessingNodeBase {
             min_shift = *min_it;
             max_shift = *max_it;
         }
-        const int x0 = cw.first - max_shift;   // leftmost valid image column
-        const int x1 = cw.second - min_shift;  // rightmost valid image column
+        const int x0 = cw.first + min_shift;   // leftmost valid image column
+        const int x1 = cw.second + max_shift;  // rightmost valid image column
         if (cw.first <= cw.second && x0 >= 0 && x1 < static_cast<int>(W)) {
             camera_info_msg_.roi.x_offset = static_cast<uint32_t>(x0);
             camera_info_msg_.roi.y_offset = 0;
@@ -243,9 +245,9 @@ class OusterImage : public OusterProcessingNodeBase {
         } else {
             RCLCPP_INFO(get_logger(),
                 "CameraInfo: column_window=[%d,%d] with destagger shifts "
-                "[%d,%d] wraps through column 0; publishing a full-size ROI "
-                "(equivalent to unset).", cw.first, cw.second, min_shift,
-                max_shift);
+                "[%d,%d] makes the valid region wrap past the image bounds; "
+                "publishing a full-size ROI (equivalent to unset).",
+                cw.first, cw.second, min_shift, max_shift);
             camera_info_msg_.roi.x_offset = 0;
             camera_info_msg_.roi.y_offset = 0;
             camera_info_msg_.roi.width = W;

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -204,6 +204,32 @@ class OusterImage : public OusterProcessingNodeBase {
         camera_info_msg_.p = {fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0,
                               1.0, 0.0};
 
+        // ROI from sensor metadata column_window. Ouster sensors support
+        // azimuth windowing (e.g. forward-only sector to suppress backplate
+        // self-returns); the published image is still full-width (invalid
+        // columns are zero-filled), but ROI tells consumers which columns
+        // hold real data. column_window is inclusive on both ends; if
+        // first > second the window wraps through column 0, which a single
+        // rectangle cannot represent — fall back to "no ROI" in that case.
+        const auto& cw = sensor_info.format.column_window;
+        if (cw.first <= cw.second) {
+            camera_info_msg_.roi.x_offset = static_cast<uint32_t>(cw.first);
+            camera_info_msg_.roi.y_offset = 0;
+            camera_info_msg_.roi.width =
+                static_cast<uint32_t>(cw.second - cw.first + 1);
+            camera_info_msg_.roi.height = H;
+        } else {
+            RCLCPP_INFO(get_logger(),
+                "CameraInfo: column_window=[%d,%d] wraps through column 0; "
+                "leaving ROI unset (consumers should treat the full %u-column "
+                "image as the ROI).", cw.first, cw.second, W);
+            camera_info_msg_.roi.x_offset = 0;
+            camera_info_msg_.roi.y_offset = 0;
+            camera_info_msg_.roi.width = W;
+            camera_info_msg_.roi.height = H;
+        }
+        camera_info_msg_.roi.do_rectify = false;
+
         camera_info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(
             "camera_info", qos);
     }

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -21,14 +21,26 @@
 #include "ouster_ros/os_processing_node_base.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <map>
+#include <memory>
 #include <sensor_msgs/msg/camera_info.hpp>
+#include <stdexcept>
+#include <utility>
 
 #if __has_include(<tf2/LinearMath/Quaternion.hpp>)
 #include <tf2/LinearMath/Quaternion.hpp>
 #else
 #include <tf2/LinearMath/Quaternion.h>
 #endif
+#if __has_include(<tf2_ros/static_transform_broadcaster.hpp>)
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#else
 #include <tf2_ros/static_transform_broadcaster.h>
+#endif
+#include <geometry_msgs/msg/transform_stamped.hpp>
 
 #include "lidar_packet_handler.h"
 #include "image_processor.h"
@@ -48,6 +60,11 @@ class OusterImage : public OusterProcessingNodeBase {
         on_init();
     }
 
+    ~OusterImage() override {
+        lidar_packet_sub.reset();
+        lidar_packet_handler = nullptr;
+    }
+
    private:
     void on_init() {
         declare_parameter("timestamp_mode", "");
@@ -58,24 +75,51 @@ class OusterImage : public OusterProcessingNodeBase {
         declare_parameter("distortion_model", "plumb_bob");
         declare_parameter("frame_id", "os_lidar");
         declare_parameter("optical_frame", "");
-        declare_parameter("publish_camera_info", true);
+        // A full 360-degree panorama is not a pinhole image; publishing a
+        // plumb_bob CameraInfo by default invites invalid back-projection.
+        declare_parameter("publish_camera_info", false);
         create_metadata_subscriber(
+            [this](const auto& msg) { metadata_handler(msg); });
+        load_metadata_from_file(
             [this](const auto& msg) { metadata_handler(msg); });
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
     }
 
     void metadata_handler(const std_msgs::msg::String::ConstPtr& metadata_msg) {
-        RCLCPP_INFO(get_logger(),
-                    "OusterImage: retrieved new sensor metadata!");
-        info = ouster::sdk::core::SensorInfo(metadata_msg->data);
-        packet_format = std::make_shared<ouster::sdk::core::PacketFormat>(
-            ouster::sdk::core::get_format(info));
-        create_publishers_subscribers(info.num_returns());
+        std::lock_guard<std::mutex> pipeline_lock(pipeline_mutex);
+        if (metadata_is_active(metadata_msg->data)) {
+            RCLCPP_DEBUG(get_logger(),
+                         "OusterImage: ignoring unchanged sensor metadata");
+            return;
+        }
+
+        RCLCPP_INFO(get_logger(), "OusterImage: activating sensor metadata");
+        try {
+            auto parsed_info =
+                ouster::sdk::core::SensorInfo(metadata_msg->data);
+            auto parsed_format =
+                std::make_shared<ouster::sdk::core::PacketFormat>(
+                    ouster::sdk::core::get_format(parsed_info));
+            info = std::move(parsed_info);
+            packet_format = std::move(parsed_format);
+            create_publishers_subscribers(info.num_returns());
+            mark_metadata_active(metadata_msg->data);
+        } catch (const std::exception& e) {
+            invalidate_active_metadata();
+            RCLCPP_ERROR_STREAM(
+                get_logger(),
+                "OusterImage: failed to activate sensor metadata: "
+                    << e.what());
+        }
     }
 
     void create_publishers_subscribers(int n_returns) {
+        const uint64_t pipeline_generation = begin_pipeline_update();
+        lidar_packet_sub.reset();
+        lidar_packet_handler = nullptr;
+        lidar_packet_buffer.reset();
 
-        // TODO: avoid having to replicate the parameters: 
+        // TODO: avoid having to replicate the parameters:
         // timestamp_mode, ptp_utc_tai_offset, use_system_default_qos in yet
         // another node.
         auto timestamp_mode = get_parameter("timestamp_mode").as_string();
@@ -88,15 +132,14 @@ class OusterImage : public OusterProcessingNodeBase {
         auto selected_qos =
             use_system_default_qos ? system_default_qos : sensor_data_qos;
 
-        const std::map<std::string, std::string>
+        std::map<std::string, std::string>
             channel_field_topic_map_1 {
                 {ChanField::RANGE, "range_image"},
                 {ChanField::SIGNAL, "signal_image"},
                 {ChanField::REFLECTIVITY, "reflec_image"},
-                {ChanField::NEAR_IR, "nearir_image"},
-                {ChanField::RGB, "rgb_image"}};
+                {ChanField::NEAR_IR, "nearir_image"}};
 
-        const std::map<std::string, std::string>
+        std::map<std::string, std::string>
             channel_field_topic_map_2 {
                 {ChanField::RANGE, "range_image"},
                 {ChanField::SIGNAL, "signal_image"},
@@ -104,11 +147,21 @@ class OusterImage : public OusterProcessingNodeBase {
                 {ChanField::NEAR_IR, "nearir_image"},
                 {ChanField::RANGE2, "range_image2"},
                 {ChanField::SIGNAL2, "signal_image2"},
-                {ChanField::REFLECTIVITY2, "reflec_image2"},
-                {ChanField::RGB, "rgb_image"}};
+                {ChanField::REFLECTIVITY2, "reflec_image2"}};
+
+        const bool has_rgb =
+            info.format.udp_profile_lidar ==
+                ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16 ||
+            info.format.udp_profile_lidar ==
+                ouster::sdk::core::UDPProfileLidar::RNG19_RFL8_SIG16_NIR16_RGB16_DUAL;
+        if (has_rgb) {
+            channel_field_topic_map_1[ChanField::RGB] = "rgb_image";
+            channel_field_topic_map_2[ChanField::RGB] = "rgb_image";
+        }
 
         auto which_map = n_returns == 1 ? &channel_field_topic_map_1
                                         : &channel_field_topic_map_2;
+        image_pubs.clear();
         for (auto it = which_map->begin(); it != which_map->end(); ++it) {
             image_pubs[it->first] =
                 create_publisher<sensor_msgs::msg::Image>(it->second,
@@ -157,19 +210,33 @@ class OusterImage : public OusterProcessingNodeBase {
         lidar_packet_handler = LidarPacketHandler::create(
             info, processors, timestamp_mode,
             static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
-            min_scan_valid_columns_ratio);
+            min_scan_valid_columns_ratio, /*process_rgb=*/has_rgb);
+        lidar_packet_buffer =
+            std::make_unique<LidarPacket>(packet_format->lidar_packet_size);
+        lidar_packet_buffer->format = packet_format;
         lidar_packet_sub = create_subscription<PacketMsg>(
                 "lidar_packets", selected_qos,
-                [this](const PacketMsg::ConstSharedPtr msg) {
-                    if (lidar_packet_handler) {
-                        // TODO[UN]: this is not ideal since we can't reuse the msg buffer
-                        // Need to redefine the Packet object and allow use of array_views
-                        LidarPacket lidar_packet(msg->buf.size());
-                        lidar_packet.format = packet_format;
-                        lidar_packet.host_timestamp = static_cast<uint64_t>(now().nanoseconds());
-                        memcpy(lidar_packet.buf.data(), msg->buf.data(), msg->buf.size());
-                        lidar_packet_handler(lidar_packet);
+                [this, pipeline_generation](const PacketMsg::ConstSharedPtr msg) {
+                    std::lock_guard<std::mutex> pipeline_lock(pipeline_mutex);
+                    if (!pipeline_is_current(pipeline_generation) ||
+                        !lidar_packet_handler || !lidar_packet_buffer) {
+                        return;
                     }
+                    const size_t expected_size = packet_format->lidar_packet_size;
+                    if (msg->buf.size() < expected_size) {
+                        RCLCPP_WARN_STREAM_THROTTLE(
+                            get_logger(), *get_clock(), 1000,
+                            "dropping undersized lidar_packets msg ("
+                                << msg->buf.size() << " < " << expected_size
+                                << " bytes)");
+                        return;
+                    }
+                    auto& lidar_packet = *lidar_packet_buffer;
+                    lidar_packet.host_timestamp =
+                        static_cast<uint64_t>(now().nanoseconds());
+                    std::memcpy(lidar_packet.buf.data(), msg->buf.data(),
+                                expected_size);
+                    lidar_packet_handler(lidar_packet);
                 });
     }
 
@@ -220,6 +287,10 @@ class OusterImage : public OusterProcessingNodeBase {
         const ouster::sdk::core::SensorInfo& sensor_info,
         const std::string& frame_id,
         const rclcpp::QoS& qos) {
+        RCLCPP_WARN(get_logger(),
+            "os_image CameraInfo describes an equirectangular panorama, not "
+            "a pinhole camera. It is for display overlay only; use os_pinhole "
+            "for pinhole rectification or back-projection.");
         uint32_t H = sensor_info.format.pixels_per_column;
         uint32_t W = sensor_info.format.columns_per_frame;
 
@@ -331,16 +402,17 @@ class OusterImage : public OusterProcessingNodeBase {
     }
 
    private:
-    rclcpp::Subscription<PacketMsg>::SharedPtr lidar_packet_sub;
     std::map<std::string,
              rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr>
         image_pubs;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_pub_;
     sensor_msgs::msg::CameraInfo camera_info_msg_;
-    bool publish_camera_info_{true};
+    bool publish_camera_info_{false};
     std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_bcast_;
 
+    std::unique_ptr<LidarPacket> lidar_packet_buffer;
     LidarPacketHandler::HandlerType lidar_packet_handler;
+    rclcpp::Subscription<PacketMsg>::SharedPtr lidar_packet_sub;
 };
 }  // namespace ouster_ros
 

--- a/ouster-ros/src/os_pinhole_node.cpp
+++ b/ouster-ros/src/os_pinhole_node.cpp
@@ -1,0 +1,364 @@
+/**
+ * @file os_pinhole_node.cpp
+ * @brief Publishes N pinhole rectified panels (range/signal/reflec/nearir +
+ *        CameraInfo) re-sampled from the destaggered Ouster panorama. Each
+ *        panel has its own optical-convention frame, broadcast via
+ *        StaticTransformBroadcaster, so Foxglove/Trillium and standard
+ *        image pipelines see proper pinhole cameras.
+ *
+ * Built on the same LidarPacketHandler + LidarScan path as os_image_node;
+ * the resampling is implemented in PinholeProcessor.
+ */
+
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+
+#include "ouster_ros/visibility_control.h"
+#include "ouster_ros/os_processing_node_base.h"
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#if __has_include(<tf2/LinearMath/Quaternion.hpp>)
+#include <tf2/LinearMath/Quaternion.hpp>
+#else
+#include <tf2/LinearMath/Quaternion.h>
+#endif
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#if __has_include(<tf2_ros/static_transform_broadcaster.hpp>)
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#else
+#include <tf2_ros/static_transform_broadcaster.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lidar_packet_handler.h"
+#include "pinhole_processor.h"
+
+namespace ouster_ros {
+
+using ouster_sensor_msgs::msg::PacketMsg;
+using ouster::sdk::core::LidarPacket;
+
+class OusterPinhole : public OusterProcessingNodeBase {
+   public:
+    OUSTER_ROS_PUBLIC
+    explicit OusterPinhole(const rclcpp::NodeOptions& options)
+        : OusterProcessingNodeBase("os_pinhole", options) {
+        on_init();
+    }
+
+   private:
+    void on_init() {
+        // QoS / replay config — same shape as os_image.
+        declare_parameter("timestamp_mode", "");
+        declare_parameter("ptp_utc_tai_offset", -37.0);
+        declare_parameter("use_system_default_qos", false);
+        declare_parameter("min_scan_valid_columns_ratio", 0.0);
+
+        // Panel config (parallel arrays). panel_names is the source of
+        // truth for the panel count; the rest are sized to match (or
+        // broadcast a single scalar to all panels).
+        declare_parameter<std::vector<std::string>>(
+            "panel_names",
+            std::vector<std::string>{"front", "left", "rear", "right"});
+        declare_parameter<std::vector<double>>(
+            "panel_yaws_deg", std::vector<double>{0.0, 90.0, 180.0, 270.0});
+        declare_parameter<std::vector<double>>(
+            "panel_pitches_deg", std::vector<double>{0.0});
+        declare_parameter<std::vector<double>>(
+            "panel_hfovs_deg", std::vector<double>{90.0});
+        declare_parameter<std::vector<int64_t>>("panel_widths",
+                                                 std::vector<int64_t>{256});
+        declare_parameter<std::vector<int64_t>>("panel_heights",
+                                                 std::vector<int64_t>{0});
+        declare_parameter<std::vector<double>>("panel_vfovs_deg",
+                                                std::vector<double>{0.0});
+
+        // Frame configuration.
+        declare_parameter("parent_frame", "os_lidar");
+        declare_parameter("lidar_namespace", "lidar0");
+        declare_parameter("optical_frame_template",
+                          std::string("{ns}/panels/{name}_optical_frame"));
+
+        // Constant azimuth offset (degrees) of the destaggered image's
+        // column 0 relative to lidar_frame +X. If column 0 actually
+        // contains content from azimuth=φ in lidar_frame, set this to φ
+        // (positive = CCW). Per-platform empirical tune.
+        declare_parameter("azimuth_offset_deg", 0.0);
+
+        static_tf_broadcaster_ =
+            std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+
+        create_metadata_subscriber(
+            [this](const auto& msg) { metadata_handler(msg); });
+
+        RCLCPP_INFO(get_logger(), "OusterPinhole: node initialized!");
+    }
+
+    void metadata_handler(
+        const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
+        RCLCPP_INFO(get_logger(),
+                    "OusterPinhole: retrieved new sensor metadata!");
+        info = ouster::sdk::core::SensorInfo(metadata_msg->data);
+        packet_format = std::make_shared<ouster::sdk::core::PacketFormat>(
+            ouster::sdk::core::get_format(info));
+        create_publishers_subscribers();
+        broadcast_static_transforms();
+    }
+
+    std::vector<PinholeProcessor::PanelConfig> read_panel_configs() {
+        const auto names =
+            get_parameter("panel_names").as_string_array();
+        const auto yaws =
+            get_parameter("panel_yaws_deg").as_double_array();
+        const auto pitches =
+            get_parameter("panel_pitches_deg").as_double_array();
+        const auto hfovs =
+            get_parameter("panel_hfovs_deg").as_double_array();
+        const auto widths =
+            get_parameter("panel_widths").as_integer_array();
+        const auto heights =
+            get_parameter("panel_heights").as_integer_array();
+        const auto vfovs =
+            get_parameter("panel_vfovs_deg").as_double_array();
+
+        if (names.empty()) {
+            RCLCPP_FATAL(get_logger(),
+                         "OusterPinhole: panel_names is empty.");
+            throw std::runtime_error("panel_names is empty");
+        }
+        if (yaws.size() != names.size()) {
+            RCLCPP_FATAL(get_logger(),
+                "OusterPinhole: panel_yaws_deg length (%zu) must match "
+                "panel_names length (%zu).",
+                yaws.size(), names.size());
+            throw std::runtime_error("panel_yaws_deg length mismatch");
+        }
+
+        auto pick = [&](const auto& vec, size_t i, auto fallback) {
+            if (vec.empty()) return fallback;
+            // Singleton broadcasts to all panels; partial-length arrays
+            // wrap (caller should pass length 1 or length names.size()).
+            const size_t idx = (vec.size() == 1) ? 0 : (i % vec.size());
+            return static_cast<decltype(fallback)>(vec[idx]);
+        };
+
+        std::vector<PinholeProcessor::PanelConfig> out;
+        out.reserve(names.size());
+        for (size_t i = 0; i < names.size(); ++i) {
+            PinholeProcessor::PanelConfig cfg;
+            cfg.name = names[i];
+            cfg.yaw_rad = yaws[i] * M_PI / 180.0;
+            cfg.pitch_rad = pick(pitches, i, 0.0) * M_PI / 180.0;
+            cfg.hfov_rad = pick(hfovs, i, 90.0) * M_PI / 180.0;
+            cfg.width = static_cast<uint32_t>(pick(widths, i, int64_t{256}));
+            cfg.height = static_cast<uint32_t>(pick(heights, i, int64_t{0}));
+            cfg.vfov_rad = pick(vfovs, i, 0.0) * M_PI / 180.0;
+            out.push_back(cfg);
+        }
+        return out;
+    }
+
+    void create_publishers_subscribers() {
+        auto timestamp_mode = get_parameter("timestamp_mode").as_string();
+        auto ptp_utc_tai_offset =
+            get_parameter("ptp_utc_tai_offset").as_double();
+        bool use_system_default_qos =
+            get_parameter("use_system_default_qos").as_bool();
+        rclcpp::QoS selected_qos = use_system_default_qos
+                                       ? rclcpp::QoS(rclcpp::SystemDefaultsQoS())
+                                       : rclcpp::QoS(rclcpp::SensorDataQoS());
+
+        const auto min_ratio =
+            get_parameter("min_scan_valid_columns_ratio").as_double();
+        if (min_ratio < 0.0 || min_ratio > 1.0) {
+            RCLCPP_FATAL(get_logger(),
+                         "min_scan_valid_columns_ratio out of [0, 1]");
+            throw std::runtime_error("min_scan_valid_columns_ratio");
+        }
+
+        const auto lidar_namespace =
+            get_parameter("lidar_namespace").as_string();
+        const auto optical_frame_template =
+            get_parameter("optical_frame_template").as_string();
+        const auto azimuth_offset_deg =
+            get_parameter("azimuth_offset_deg").as_double();
+        const double W = static_cast<double>(info.format.columns_per_frame);
+        const double azimuth_offset_columns =
+            azimuth_offset_deg * W / 360.0;
+
+        const auto panel_configs = read_panel_configs();
+
+        // Build the processor + its panels.
+        std::vector<LidarScanProcessor> processors {
+            PinholeProcessor::create(
+                info, panel_configs,
+                optical_frame_template, lidar_namespace,
+                azimuth_offset_columns,
+                [this](PinholeProcessor::OutputType& panels) {
+                    publish_panels(panels);
+                })
+        };
+
+        // Build publishers from the constructed panel list. The processor
+        // already created PanelOutput entries with image buffers + ci, so
+        // we mirror those here as publishers.
+        // We need to query the processor for its panels — but
+        // PinholeProcessor::create returns just the lambda. Re-build a
+        // separate helper instance just to reach the panel list, OR
+        // build publishers from panel_configs directly + the channel set.
+        const auto channel_topics = pinhole_channel_topics(info.num_returns());
+        for (const auto& cfg : panel_configs) {
+            PanelPublishers pp;
+            pp.name = cfg.name;
+            for (const auto& kv : channel_topics) {
+                const std::string image_topic =
+                    "panels/" + cfg.name + "/" + kv.second;
+                pp.image_pubs[kv.first] =
+                    create_publisher<sensor_msgs::msg::Image>(
+                        image_topic, selected_qos);
+            }
+            const std::string ci_topic =
+                "panels/" + cfg.name + "/camera_info";
+            pp.camera_info_pub =
+                create_publisher<sensor_msgs::msg::CameraInfo>(ci_topic,
+                                                                selected_qos);
+            panel_pubs_.push_back(std::move(pp));
+        }
+
+        lidar_packet_handler_ = LidarPacketHandler::create(
+            info, processors, timestamp_mode,
+            static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
+            static_cast<float>(min_ratio));
+
+        lidar_packet_sub_ = create_subscription<PacketMsg>(
+            "lidar_packets", selected_qos,
+            [this](const PacketMsg::ConstSharedPtr msg) {
+                if (!lidar_packet_handler_) return;
+                LidarPacket packet(msg->buf.size());
+                packet.format = packet_format;
+                packet.host_timestamp =
+                    static_cast<uint64_t>(now().nanoseconds());
+                std::memcpy(packet.buf.data(), msg->buf.data(),
+                            msg->buf.size());
+                lidar_packet_handler_(packet);
+            });
+
+        // Cache panel configs for the static-TF broadcast (yaw → rpy).
+        panel_configs_for_tf_ = panel_configs;
+        lidar_namespace_for_tf_ = lidar_namespace;
+        optical_frame_template_for_tf_ = optical_frame_template;
+    }
+
+    void publish_panels(PinholeProcessor::OutputType& panels) {
+        for (size_t i = 0; i < panels.size() && i < panel_pubs_.size(); ++i) {
+            const auto& panel = panels[i];
+            auto& pp = panel_pubs_[i];
+            for (auto& kv : panel->images) {
+                auto it = pp.image_pubs.find(kv.first);
+                if (it != pp.image_pubs.end() && kv.second) {
+                    it->second->publish(*kv.second);
+                }
+            }
+            if (pp.camera_info_pub) {
+                pp.camera_info_pub->publish(panel->camera_info);
+            }
+        }
+    }
+
+    void broadcast_static_transforms() {
+        const auto parent_frame = get_parameter("parent_frame").as_string();
+        std::string ns = lidar_namespace_for_tf_;
+        while (!ns.empty() && ns.front() == '/') ns.erase(0, 1);
+
+        std::vector<geometry_msgs::msg::TransformStamped> transforms;
+        const auto stamp = now();
+        for (const auto& cfg : panel_configs_for_tf_) {
+            geometry_msgs::msg::TransformStamped tf;
+            tf.header.stamp = stamp;
+            tf.header.frame_id = parent_frame;
+            tf.child_frame_id =
+                substitute_template(optical_frame_template_for_tf_, ns,
+                                    cfg.name);
+            // Compose three rotations (applied right-to-left in the
+            // quaternion product, i.e. body→optical first, then pitch in
+            // post-b2o "panel-body" frame, then yaw in lidar_frame):
+            //   q = R_z(yaw) * R_y(-pitch) * R_b2o
+            //   R_b2o (rpy = -π/2, 0, -π/2): body axes → optical axes
+            //   pitch convention: positive pitch_rad → panel looks UP.
+            tf2::Quaternion q_b2o, q_pitch, q_yaw;
+            q_b2o.setRPY(-M_PI / 2.0, 0.0, -M_PI / 2.0);
+            q_pitch.setRPY(0.0, -cfg.pitch_rad, 0.0);
+            q_yaw.setRPY(0.0, 0.0, cfg.yaw_rad);
+            tf2::Quaternion q = q_yaw * q_pitch * q_b2o;
+            q.normalize();
+            tf.transform.translation.x = 0.0;
+            tf.transform.translation.y = 0.0;
+            tf.transform.translation.z = 0.0;
+            tf.transform.rotation = tf2::toMsg(q);
+            transforms.push_back(tf);
+        }
+        static_tf_broadcaster_->sendTransform(transforms);
+    }
+
+    static std::string substitute_template(const std::string& tmpl,
+                                           const std::string& ns,
+                                           const std::string& name) {
+        std::string out = tmpl;
+        for (auto& kv : std::map<std::string, std::string>{
+                 {"{ns}", ns}, {"{name}", name}}) {
+            size_t pos = 0;
+            while ((pos = out.find(kv.first, pos)) != std::string::npos) {
+                out.replace(pos, kv.first.size(), kv.second);
+                pos += kv.second.size();
+            }
+        }
+        return out;
+    }
+
+    static std::map<std::string, std::string> pinhole_channel_topics(
+        int n_returns) {
+        std::map<std::string, std::string> m{
+            {ouster::sdk::core::ChanField::RANGE, "range_image"},
+            {ouster::sdk::core::ChanField::SIGNAL, "signal_image"},
+            {ouster::sdk::core::ChanField::REFLECTIVITY, "reflec_image"},
+            {ouster::sdk::core::ChanField::NEAR_IR, "nearir_image"}};
+        if (n_returns == 2) {
+            m[ouster::sdk::core::ChanField::RANGE2] = "range_image2";
+            m[ouster::sdk::core::ChanField::SIGNAL2] = "signal_image2";
+            m[ouster::sdk::core::ChanField::REFLECTIVITY2] = "reflec_image2";
+        }
+        return m;
+    }
+
+    struct PanelPublishers {
+        std::string name;
+        std::map<std::string,
+                 rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr>
+            image_pubs;
+        rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr
+            camera_info_pub;
+    };
+
+    rclcpp::Subscription<PacketMsg>::SharedPtr lidar_packet_sub_;
+    LidarPacketHandler::HandlerType lidar_packet_handler_;
+    std::vector<PanelPublishers> panel_pubs_;
+    std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
+    std::vector<PinholeProcessor::PanelConfig> panel_configs_for_tf_;
+    std::string lidar_namespace_for_tf_;
+    std::string optical_frame_template_for_tf_;
+};
+
+}  // namespace ouster_ros
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(ouster_ros::OusterPinhole)

--- a/ouster-ros/src/os_pinhole_node.cpp
+++ b/ouster-ros/src/os_pinhole_node.cpp
@@ -34,8 +34,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
+#include <exception>
+#include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -54,6 +58,13 @@ class OusterPinhole : public OusterProcessingNodeBase {
     explicit OusterPinhole(const rclcpp::NodeOptions& options)
         : OusterProcessingNodeBase("os_pinhole", options) {
         on_init();
+    }
+
+    ~OusterPinhole() override {
+        // Stop incoming packets and join the packet-handler worker thread
+        // before the panel publishers it uses are destroyed.
+        lidar_packet_sub_.reset();
+        lidar_packet_handler_ = nullptr;
     }
 
    private:
@@ -83,7 +94,9 @@ class OusterPinhole : public OusterProcessingNodeBase {
         declare_parameter<std::vector<double>>("panel_vfovs_deg",
                                                 std::vector<double>{0.0});
 
-        // Frame configuration.
+        // parent_frame must use the lidar-frame convention (+X forward, +Z
+        // up, azimuth CCW about +Z). A renamed/namespaced lidar frame is fine;
+        // a differently-oriented frame would silently mis-orient every panel.
         declare_parameter("parent_frame", "os_lidar");
         declare_parameter("lidar_namespace", "lidar0");
         declare_parameter("optical_frame_template",
@@ -100,19 +113,40 @@ class OusterPinhole : public OusterProcessingNodeBase {
 
         create_metadata_subscriber(
             [this](const auto& msg) { metadata_handler(msg); });
+        load_metadata_from_file(
+            [this](const auto& msg) { metadata_handler(msg); });
 
         RCLCPP_INFO(get_logger(), "OusterPinhole: node initialized!");
     }
 
     void metadata_handler(
         const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
-        RCLCPP_INFO(get_logger(),
-                    "OusterPinhole: retrieved new sensor metadata!");
-        info = ouster::sdk::core::SensorInfo(metadata_msg->data);
-        packet_format = std::make_shared<ouster::sdk::core::PacketFormat>(
-            ouster::sdk::core::get_format(info));
-        create_publishers_subscribers();
-        broadcast_static_transforms();
+        std::lock_guard<std::mutex> pipeline_lock(pipeline_mutex);
+        if (metadata_is_active(metadata_msg->data)) {
+            RCLCPP_DEBUG(get_logger(),
+                         "OusterPinhole: ignoring unchanged sensor metadata");
+            return;
+        }
+
+        RCLCPP_INFO(get_logger(), "OusterPinhole: activating sensor metadata");
+        try {
+            auto parsed_info =
+                ouster::sdk::core::SensorInfo(metadata_msg->data);
+            auto parsed_format =
+                std::make_shared<ouster::sdk::core::PacketFormat>(
+                    ouster::sdk::core::get_format(parsed_info));
+            info = std::move(parsed_info);
+            packet_format = std::move(parsed_format);
+            create_publishers_subscribers();
+            broadcast_static_transforms();
+            mark_metadata_active(metadata_msg->data);
+        } catch (const std::exception& e) {
+            invalidate_active_metadata();
+            RCLCPP_ERROR_STREAM(
+                get_logger(),
+                "OusterPinhole: failed to activate sensor metadata: "
+                    << e.what());
+        }
     }
 
     std::vector<PinholeProcessor::PanelConfig> read_panel_configs() {
@@ -144,13 +178,28 @@ class OusterPinhole : public OusterProcessingNodeBase {
             throw std::runtime_error("panel_yaws_deg length mismatch");
         }
 
+        auto check_len = [&](const auto& vec, const char* name) {
+            if (!vec.empty() && vec.size() != 1 && vec.size() != names.size()) {
+                RCLCPP_FATAL(get_logger(),
+                    "OusterPinhole: %s length (%zu) must be 0, 1, or match "
+                    "panel_names length (%zu).",
+                    name, vec.size(), names.size());
+                throw std::runtime_error(std::string(name) + " length mismatch");
+            }
+        };
+        check_len(pitches, "panel_pitches_deg");
+        check_len(hfovs, "panel_hfovs_deg");
+        check_len(widths, "panel_widths");
+        check_len(heights, "panel_heights");
+        check_len(vfovs, "panel_vfovs_deg");
+
         auto pick = [&](const auto& vec, size_t i, auto fallback) {
             if (vec.empty()) return fallback;
-            // Singleton broadcasts to all panels; partial-length arrays
-            // wrap (caller should pass length 1 or length names.size()).
-            const size_t idx = (vec.size() == 1) ? 0 : (i % vec.size());
+            const size_t idx = (vec.size() == 1) ? 0 : i;
             return static_cast<decltype(fallback)>(vec[idx]);
         };
+
+        constexpr int64_t kMaxPanelDim = 8192;
 
         std::vector<PinholeProcessor::PanelConfig> out;
         out.reserve(names.size());
@@ -160,15 +209,52 @@ class OusterPinhole : public OusterProcessingNodeBase {
             cfg.yaw_rad = yaws[i] * M_PI / 180.0;
             cfg.pitch_rad = pick(pitches, i, 0.0) * M_PI / 180.0;
             cfg.hfov_rad = pick(hfovs, i, 90.0) * M_PI / 180.0;
-            cfg.width = static_cast<uint32_t>(pick(widths, i, int64_t{256}));
-            cfg.height = static_cast<uint32_t>(pick(heights, i, int64_t{0}));
-            cfg.vfov_rad = pick(vfovs, i, 0.0) * M_PI / 180.0;
+            if (cfg.hfov_rad <= 0.0 || cfg.hfov_rad >= M_PI) {
+                RCLCPP_FATAL(get_logger(),
+                    "OusterPinhole: panel '%s' hfov (%.3f deg) must be in "
+                    "the open interval (0, 180).",
+                    cfg.name.c_str(), cfg.hfov_rad * 180.0 / M_PI);
+                throw std::runtime_error("panel hfov out of range");
+            }
+            const int64_t width_i = pick(widths, i, int64_t{256});
+            if (width_i <= 0 || width_i > kMaxPanelDim) {
+                RCLCPP_FATAL(get_logger(),
+                    "OusterPinhole: panel '%s' width (%ld) must be in [1, %ld].",
+                    cfg.name.c_str(), static_cast<long>(width_i),
+                    static_cast<long>(kMaxPanelDim));
+                throw std::runtime_error("panel width out of range");
+            }
+            const int64_t height_i = pick(heights, i, int64_t{0});
+            if (height_i < 0 || height_i > kMaxPanelDim) {
+                RCLCPP_FATAL(get_logger(),
+                    "OusterPinhole: panel '%s' height (%ld) must be in "
+                    "[0, %ld] (0 = auto-fit).",
+                    cfg.name.c_str(), static_cast<long>(height_i),
+                    static_cast<long>(kMaxPanelDim));
+                throw std::runtime_error("panel height out of range");
+            }
+            const double vfov_deg = pick(vfovs, i, 0.0);
+            if (vfov_deg < 0.0 || vfov_deg >= 180.0) {
+                RCLCPP_FATAL(get_logger(),
+                    "OusterPinhole: panel '%s' vfov (%.3f deg) must be in "
+                    "[0, 180) (0 = auto).",
+                    cfg.name.c_str(), vfov_deg);
+                throw std::runtime_error("panel vfov out of range");
+            }
+            cfg.width = static_cast<uint32_t>(width_i);
+            cfg.height = static_cast<uint32_t>(height_i);
+            cfg.vfov_rad = vfov_deg * M_PI / 180.0;
             out.push_back(cfg);
         }
         return out;
     }
 
     void create_publishers_subscribers() {
+        const uint64_t pipeline_generation = begin_pipeline_update();
+        lidar_packet_sub_.reset();
+        lidar_packet_handler_ = nullptr;
+        lidar_packet_buffer_.reset();
+
         auto timestamp_mode = get_parameter("timestamp_mode").as_string();
         auto ptp_utc_tai_offset =
             get_parameter("ptp_utc_tai_offset").as_double();
@@ -216,6 +302,7 @@ class OusterPinhole : public OusterProcessingNodeBase {
         // PinholeProcessor::create returns just the lambda. Re-build a
         // separate helper instance just to reach the panel list, OR
         // build publishers from panel_configs directly + the channel set.
+        panel_pubs_.clear();
         const auto channel_topics = pinhole_channel_topics(info.num_returns());
         for (const auto& cfg : panel_configs) {
             PanelPublishers pp;
@@ -238,18 +325,33 @@ class OusterPinhole : public OusterProcessingNodeBase {
         lidar_packet_handler_ = LidarPacketHandler::create(
             info, processors, timestamp_mode,
             static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
-            static_cast<float>(min_ratio));
+            static_cast<float>(min_ratio), /*process_rgb=*/false);
+        lidar_packet_buffer_ =
+            std::make_unique<LidarPacket>(packet_format->lidar_packet_size);
+        lidar_packet_buffer_->format = packet_format;
 
         lidar_packet_sub_ = create_subscription<PacketMsg>(
             "lidar_packets", selected_qos,
-            [this](const PacketMsg::ConstSharedPtr msg) {
-                if (!lidar_packet_handler_) return;
-                LidarPacket packet(msg->buf.size());
-                packet.format = packet_format;
+            [this, pipeline_generation](const PacketMsg::ConstSharedPtr msg) {
+                std::lock_guard<std::mutex> pipeline_lock(pipeline_mutex);
+                if (!pipeline_is_current(pipeline_generation) ||
+                    !lidar_packet_handler_ || !lidar_packet_buffer_) {
+                    return;
+                }
+                const size_t expected_size = packet_format->lidar_packet_size;
+                if (msg->buf.size() < expected_size) {
+                    RCLCPP_WARN_STREAM_THROTTLE(
+                        get_logger(), *get_clock(), 1000,
+                        "dropping undersized lidar_packets msg ("
+                            << msg->buf.size() << " < " << expected_size
+                            << " bytes)");
+                    return;
+                }
+                auto& packet = *lidar_packet_buffer_;
                 packet.host_timestamp =
                     static_cast<uint64_t>(now().nanoseconds());
                 std::memcpy(packet.buf.data(), msg->buf.data(),
-                            msg->buf.size());
+                            expected_size);
                 lidar_packet_handler_(packet);
             });
 
@@ -349,13 +451,17 @@ class OusterPinhole : public OusterProcessingNodeBase {
             camera_info_pub;
     };
 
-    rclcpp::Subscription<PacketMsg>::SharedPtr lidar_packet_sub_;
-    LidarPacketHandler::HandlerType lidar_packet_handler_;
-    std::vector<PanelPublishers> panel_pubs_;
     std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
     std::vector<PinholeProcessor::PanelConfig> panel_configs_for_tf_;
     std::string lidar_namespace_for_tf_;
     std::string optical_frame_template_for_tf_;
+
+    // Reverse destruction order stops callbacks, joins the scan worker, then
+    // releases the buffer and publishers used by that worker.
+    std::vector<PanelPublishers> panel_pubs_;
+    std::unique_ptr<LidarPacket> lidar_packet_buffer_;
+    LidarPacketHandler::HandlerType lidar_packet_handler_;
+    rclcpp::Subscription<PacketMsg>::SharedPtr lidar_packet_sub_;
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_processing_node_base.cpp
+++ b/ouster-ros/src/os_processing_node_base.cpp
@@ -8,6 +8,11 @@
 
 #include "ouster_ros/os_processing_node_base.h"
 
+#include <memory>
+#include <string>
+
+#include "ouster_ros/impl/file_util.h"
+
 namespace ouster_ros {
 
 void OusterProcessingNodeBase::create_metadata_subscriber(
@@ -18,6 +23,32 @@ void OusterProcessingNodeBase::create_metadata_subscriber(
     latching_qos.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
     metadata_sub = create_subscription<std_msgs::msg::String>(
         "metadata", latching_qos, on_sensor_metadata);
+}
+
+bool OusterProcessingNodeBase::load_metadata_from_file(
+    const std::function<void(const std_msgs::msg::String::ConstSharedPtr&)>&
+        on_sensor_metadata) {
+    const std::string meta_file =
+        has_parameter("metadata")
+            ? get_parameter("metadata").as_string()
+            : declare_parameter<std::string>("metadata", "");
+    // Treat empty / whitespace-only as "not provided".
+    if (meta_file.find_first_not_of(' ') == std::string::npos) return false;
+
+    const std::string contents = impl::read_text_file(meta_file);
+    if (contents.empty()) {
+        RCLCPP_ERROR_STREAM(
+            get_logger(),
+            "metadata file could not be read or is empty: " << meta_file);
+        return false;
+    }
+
+    RCLCPP_INFO_STREAM(get_logger(),
+                       "loaded sensor metadata from file: " << meta_file);
+    auto msg = std::make_shared<std_msgs::msg::String>();
+    msg->data = contents;
+    on_sensor_metadata(msg);
+    return true;
 }
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_static_transforms_broadcaster.h
+++ b/ouster-ros/src/os_static_transforms_broadcaster.h
@@ -8,7 +8,11 @@
 
 #pragma once
 
+#if __has_include(<tf2_ros/static_transform_broadcaster.hpp>)
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#else
 #include <tf2_ros/static_transform_broadcaster.h>
+#endif
 
 namespace ouster_ros {
 

--- a/ouster-ros/src/pinhole_processor.h
+++ b/ouster-ros/src/pinhole_processor.h
@@ -1,0 +1,465 @@
+/**
+ * @file pinhole_processor.h
+ * @brief Resamples the destaggered Ouster panorama into N pinhole panels at
+ *        configurable cardinal yaws (front/left/rear/right). Each panel is a
+ *        rectified perspective view with optical-convention frame_id +
+ *        CameraInfo, suitable for direct rendering in Foxglove/Trillium and
+ *        for traditional image-pipeline consumers (image_proc, YOLO, etc.)
+ *        that expect a pinhole camera.
+ *
+ * Built once per metadata callback: a per-output-pixel LUT mapping
+ * (panel_row, panel_col) → (source_row, source_destaggered_col). Per-scan
+ * work is field-decode + auto-exposure (full panorama) + LUT-sample into
+ * the panel images. Auto-exposure runs on the full panorama so all panels
+ * share a consistent dynamic range.
+ */
+
+#pragma once
+
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+
+#include <Eigen/Core>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "ouster/lidar_scan.h"
+#include "ouster/image_processing.h"
+#include "lidar_packet_handler.h"
+
+namespace ouster_ros {
+
+namespace ChanField = ouster::sdk::core::ChanField;
+
+class PinholeProcessor {
+   public:
+    struct PanelConfig {
+        std::string name;
+        double yaw_rad = 0.0;       // CCW about lidar_frame +Z
+        double pitch_rad = 0.0;     // up positive (about panel-yawed +Y)
+        double hfov_rad = M_PI / 2.0;
+        uint32_t width = 256;
+        uint32_t height = 0;        // 0 → auto-fit lidar VFOV at square pixels
+        double vfov_rad = 0.0;      // override if both height==0 and vfov_rad>0
+    };
+
+    using pixel_type = uint16_t;
+
+    struct PanelOutput {
+        std::string name;
+        std::string optical_frame_id;
+        // Geometry of this panel relative to lidar_frame parent.
+        double yaw_rad = 0.0;
+        double pitch_rad = 0.0;
+        // Image messages (one per channel), reused across scans.
+        std::map<std::string, std::shared_ptr<sensor_msgs::msg::Image>> images;
+        // CameraInfo for this panel (optical convention pinhole).
+        sensor_msgs::msg::CameraInfo camera_info;
+        // LUT in destaggered space:
+        //   r_src(u, v) = source row (-1 → outside lidar VFOV; pixel zeroed)
+        //   v_src(u, v) = source destaggered column
+        Eigen::Array<int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> r_src;
+        Eigen::Array<int32_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> v_src;
+    };
+
+    using OutputType = std::vector<std::shared_ptr<PanelOutput>>;
+    using PostProcessingFn = std::function<void(OutputType&)>;
+
+    PinholeProcessor(const ouster::sdk::core::SensorInfo& info,
+                     const std::vector<PanelConfig>& panel_configs,
+                     const std::string& optical_frame_template,
+                     const std::string& lidar_namespace,
+                     double azimuth_offset_columns,
+                     PostProcessingFn func)
+        : info_(info),
+          azimuth_offset_columns_(azimuth_offset_columns),
+          post_processing_fn_(func) {
+        // Strip leading slash for {ns} substitution.
+        std::string ns = lidar_namespace;
+        while (!ns.empty() && ns.front() == '/') ns.erase(0, 1);
+
+        for (const auto& cfg : panel_configs) {
+            auto panel = build_panel(cfg, ns, optical_frame_template);
+            panels_.push_back(panel);
+        }
+    }
+
+    const std::vector<std::shared_ptr<PanelOutput>>& panels() const {
+        return panels_;
+    }
+
+    static LidarScanProcessor create(
+        const ouster::sdk::core::SensorInfo& info,
+        const std::vector<PanelConfig>& panel_configs,
+        const std::string& optical_frame_template,
+        const std::string& lidar_namespace,
+        double azimuth_offset_columns,
+        PostProcessingFn func) {
+        auto handler = std::make_shared<PinholeProcessor>(
+            info, panel_configs, optical_frame_template, lidar_namespace,
+            azimuth_offset_columns, func);
+        return [handler](const ouster::sdk::core::LidarScan& scan,
+                         uint64_t scan_ts,
+                         const rclcpp::Time& msg_ts) {
+            handler->process(scan, scan_ts, msg_ts);
+        };
+    }
+
+   private:
+    // ── Build helpers ────────────────────────────────────────────────────
+    std::shared_ptr<PanelOutput> build_panel(
+        const PanelConfig& cfg, const std::string& ns,
+        const std::string& optical_frame_template) {
+        auto out = std::make_shared<PanelOutput>();
+        out->name = cfg.name;
+        out->yaw_rad = cfg.yaw_rad;
+        out->pitch_rad = cfg.pitch_rad;
+        out->optical_frame_id =
+            substitute_template(optical_frame_template, ns, cfg.name);
+
+        const uint32_t pw = cfg.width;
+        // Pinhole intrinsics (square pixels). HFOV→fx, then height auto-fits.
+        const double half_hfov = 0.5 * cfg.hfov_rad;
+        const double fx = static_cast<double>(pw) / (2.0 * std::tan(half_hfov));
+        const double fy = fx;  // square pixels
+
+        // Auto-fit height from lidar VFOV unless caller forced one.
+        uint32_t ph = cfg.height;
+        if (ph == 0) {
+            const double vfov_rad = (cfg.vfov_rad > 0.0)
+                ? cfg.vfov_rad
+                : derive_lidar_vfov_rad();
+            ph = static_cast<uint32_t>(std::round(
+                2.0 * fy * std::tan(0.5 * vfov_rad)));
+            if (ph < 1) ph = 1;
+        }
+
+        const double cx = static_cast<double>(pw) / 2.0;
+        const double cy = static_cast<double>(ph) / 2.0;
+
+        // Build CameraInfo (pinhole, optical convention, no distortion).
+        out->camera_info.header.frame_id = out->optical_frame_id;
+        out->camera_info.width = pw;
+        out->camera_info.height = ph;
+        out->camera_info.distortion_model = "plumb_bob";
+        out->camera_info.k = {fx, 0.0, cx, 0.0, fy, cy, 0.0, 0.0, 1.0};
+        out->camera_info.d = {0.0, 0.0, 0.0, 0.0, 0.0};
+        out->camera_info.r = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+        out->camera_info.p = {fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0,
+                              0.0, 0.0, 1.0, 0.0};
+        out->camera_info.roi.x_offset = 0;
+        out->camera_info.roi.y_offset = 0;
+        out->camera_info.roi.width = pw;
+        out->camera_info.roi.height = ph;
+        out->camera_info.roi.do_rectify = false;
+
+        // Build channel image buffers (MONO16, reused across scans).
+        const auto channel_topic_map = channel_topic_map_for(info_.num_returns());
+        for (const auto& kv : channel_topic_map) {
+            auto img = std::make_shared<sensor_msgs::msg::Image>();
+            img->header.frame_id = out->optical_frame_id;
+            img->width = pw;
+            img->height = ph;
+            img->encoding = sensor_msgs::image_encodings::MONO16;
+            img->is_bigendian = 0;
+            img->step = pw * sizeof(pixel_type);
+            img->data.assign(static_cast<size_t>(img->step) * ph, 0);
+            out->images[kv.first] = img;
+        }
+
+        compute_lut(*out, fx, fy, cx, cy, pw, ph);
+        return out;
+    }
+
+    void compute_lut(PanelOutput& out, double fx, double fy, double cx,
+                     double cy, uint32_t pw, uint32_t ph) const {
+        out.r_src.resize(ph, pw);
+        out.v_src.resize(ph, pw);
+
+        const auto& alts = info_.beam_altitude_angles;  // degrees, top→bottom
+        const uint32_t H = info_.format.pixels_per_column;
+        const uint32_t W = info_.format.columns_per_frame;
+
+        const double cosy = std::cos(out.yaw_rad);
+        const double siny = std::sin(out.yaw_rad);
+        // Pitch convention: positive pitch_rad → panel looks UP. In
+        // panel-body coords (post-b2o, pre-yaw) this is a rotation that
+        // tilts the +X (forward) axis toward +Z (up):
+        //   pb' = R_y(-pitch) * pb
+        //       = (cos·pb_x - sin·pb_z,  pb_y,  sin·pb_x + cos·pb_z)
+        const double cosp = std::cos(out.pitch_rad);
+        const double sinp = std::sin(out.pitch_rad);
+
+        // Tolerance for "elevation outside lidar VFOV" check, in degrees.
+        // One beam spacing (~ vfov / (H-1)) seems generous enough to allow
+        // the outermost rows to sample safely without snapping wildly.
+        double beam_spacing_deg = 0.0;
+        if (alts.size() >= 2) {
+            auto [min_it, max_it] =
+                std::minmax_element(alts.begin(), alts.end());
+            beam_spacing_deg = (*max_it - *min_it) /
+                               static_cast<double>(alts.size() - 1);
+        }
+        const double snap_tol_deg = std::max(beam_spacing_deg, 0.5);
+
+        for (uint32_t u = 0; u < ph; ++u) {
+            for (uint32_t v = 0; v < pw; ++v) {
+                // Direction in panel optical frame.
+                const double x_o = (static_cast<double>(v) - cx) / fx;
+                const double y_o = (static_cast<double>(u) - cy) / fy;
+                const double z_o = 1.0;
+
+                // Optical → panel-body (rpy=-π/2,0,-π/2 is body→optical).
+                //   body_x =  z_o ;  body_y = -x_o ;  body_z = -y_o.
+                const double pb_x = z_o;
+                const double pb_y = -x_o;
+                const double pb_z = -y_o;
+
+                // Pitch: rotate panel-body about +Y by -pitch (so positive
+                // pitch tilts the +X "forward" axis toward +Z "up").
+                const double pp_x = cosp * pb_x - sinp * pb_z;
+                const double pp_y = pb_y;
+                const double pp_z = sinp * pb_x + cosp * pb_z;
+
+                // Pitched panel-body → lidar_frame: yaw φ about +Z (CCW).
+                const double lx = cosy * pp_x - siny * pp_y;
+                const double ly = siny * pp_x + cosy * pp_y;
+                const double lz = pp_z;
+
+                // Spherical in lidar_frame.
+                const double azimuth = std::atan2(ly, lx);
+                const double horiz = std::sqrt(lx * lx + ly * ly);
+                const double elev_rad = std::atan2(lz, horiz);
+                const double elev_deg = elev_rad * 180.0 / M_PI;
+
+                // Elevation → nearest beam row.
+                int32_t r_src = -1;
+                double best_diff = std::numeric_limits<double>::infinity();
+                for (size_t r = 0; r < alts.size(); ++r) {
+                    const double diff = std::abs(alts[r] - elev_deg);
+                    if (diff < best_diff) {
+                        best_diff = diff;
+                        r_src = static_cast<int32_t>(r);
+                    }
+                }
+                if (best_diff > snap_tol_deg) r_src = -1;
+
+                // Azimuth → destaggered column.
+                // Ouster destagger advances columns with the firmware encoder.
+                // The encoder rotates CCW about sensor +Z, but the URDF puts
+                // lidar_frame as a 180° yaw of sensor_frame (lidar +X = cable
+                // end), which flips the rotation sense in lidar_frame to CW.
+                // So as col index k increases, lidar azimuth DECREASES:
+                //     col k  ↔  lidar azimuth = col_0_az - k * 2π / W
+                // For a target azimuth θ, the column whose content is at θ:
+                //     col = (col_0_az - θ) * W / (2π)
+                // azimuth_offset_columns_ is col_0_az converted to columns.
+                double az_norm = azimuth;
+                while (az_norm < 0.0) az_norm += 2.0 * M_PI;
+                while (az_norm >= 2.0 * M_PI) az_norm -= 2.0 * M_PI;
+                double v_dest = azimuth_offset_columns_ -
+                                az_norm * static_cast<double>(W) /
+                                (2.0 * M_PI);
+                while (v_dest < 0.0) v_dest += static_cast<double>(W);
+                while (v_dest >= static_cast<double>(W)) {
+                    v_dest -= static_cast<double>(W);
+                }
+                int32_t v_src = static_cast<int32_t>(std::lround(v_dest));
+                if (v_src < 0) v_src = 0;
+                if (v_src >= static_cast<int32_t>(W)) v_src = W - 1;
+
+                out.r_src(u, v) = (r_src >= 0 && r_src < static_cast<int32_t>(H))
+                                      ? r_src
+                                      : -1;
+                out.v_src(u, v) = v_src;
+            }
+        }
+    }
+
+    double derive_lidar_vfov_rad() const {
+        const auto& alts = info_.beam_altitude_angles;
+        if (alts.size() < 2) return M_PI / 2.0;  // 90° fallback
+        auto [min_it, max_it] = std::minmax_element(alts.begin(), alts.end());
+        return (*max_it - *min_it) * M_PI / 180.0;
+    }
+
+    static std::string substitute_template(const std::string& tmpl,
+                                           const std::string& ns,
+                                           const std::string& name) {
+        std::string out = tmpl;
+        for (auto& [key, value] :
+             std::map<std::string, std::string>{{"{ns}", ns}, {"{name}", name}}) {
+            size_t pos = 0;
+            while ((pos = out.find(key, pos)) != std::string::npos) {
+                out.replace(pos, key.size(), value);
+                pos += value.size();
+            }
+        }
+        return out;
+    }
+
+    static std::map<std::string, std::string> channel_topic_map_for(
+        int n_returns) {
+        std::map<std::string, std::string> m {
+            {ChanField::RANGE, "range_image"},
+            {ChanField::SIGNAL, "signal_image"},
+            {ChanField::REFLECTIVITY, "reflec_image"},
+            {ChanField::NEAR_IR, "nearir_image"}};
+        if (n_returns == 2) {
+            m[ChanField::RANGE2] = "range_image2";
+            m[ChanField::SIGNAL2] = "signal_image2";
+            m[ChanField::REFLECTIVITY2] = "reflec_image2";
+        }
+        return m;
+    }
+
+    // ── Per-scan processing ──────────────────────────────────────────────
+    void process(const ouster::sdk::core::LidarScan& scan, uint64_t,
+                 const rclcpp::Time& msg_ts) {
+        process_return(scan, /*return_index=*/0);
+        if (info_.num_returns() == 2) process_return(scan, /*return_index=*/1);
+
+        for (auto& panel : panels_) {
+            for (auto& kv : panel->images) kv.second->header.stamp = msg_ts;
+            panel->camera_info.header.stamp = msg_ts;
+        }
+        if (post_processing_fn_) post_processing_fn_(panels_);
+    }
+
+    void process_return(const ouster::sdk::core::LidarScan& lidar_scan,
+                        int return_index) {
+        const bool first = return_index == 0;
+        const uint32_t H = info_.format.pixels_per_column;
+        const uint32_t W = info_.format.columns_per_frame;
+        const auto& px_offset = info_.format.pixel_shift_by_row;
+
+        // Channel field IDs (mirror image_processor.h).
+        const auto range_ch =
+            first ? ChanField::RANGE : ChanField::RANGE2;
+        const auto signal_ch =
+            impl::scan_return(ChanField::SIGNAL, !first);
+        const auto reflec_ch =
+            impl::scan_return(ChanField::REFLECTIVITY, !first);
+        const auto nearir_ch = ChanField::NEAR_IR;
+
+        // Decode raw fields (staggered).
+        ouster::sdk::core::img_t<uint32_t> range =
+            lidar_scan.field<uint32_t>(range_ch);
+        ouster::sdk::core::img_t<uint32_t> signal =
+            impl::get_or_fill_zero<uint32_t>(signal_ch, lidar_scan);
+        ouster::sdk::core::img_t<uint16_t> reflec =
+            impl::get_or_fill_zero<uint16_t>(reflec_ch, lidar_scan);
+        ouster::sdk::core::img_t<uint16_t> nearir =
+            (return_index == 0)
+                ? impl::get_or_fill_zero<uint16_t>(nearir_ch, lidar_scan)
+                : ouster::sdk::core::img_t<uint16_t>::Zero(H, W);
+
+        // Build full destaggered 16-bit panoramas (auto-exposed for the
+        // signal/reflec/nearir channels). Auto-exposure runs on float
+        // images, then we sample with the LUT into pinhole panels.
+        ouster::sdk::core::img_t<float> signal_f(H, W);
+        ouster::sdk::core::img_t<float> reflec_f(H, W);
+        ouster::sdk::core::img_t<float> nearir_f(H, W);
+        ouster::sdk::core::img_t<pixel_type> range_dest(H, W);
+        range_dest.setZero();
+
+        // First pass: destagger + cast/scale to float (for AE) and 16-bit
+        // for range. Range conversion mirrors image_processor.h: 4mm
+        // resolution, throw out > 260m (>= 65535).
+        const auto rg = range.data();
+        const auto sg = signal.data();
+        const auto rf = reflec.data();
+        const auto nr = nearir.data();
+        constexpr size_t pixel_value_max =
+            std::numeric_limits<pixel_type>::max();
+
+        for (size_t u = 0; u < H; ++u) {
+            for (size_t v = 0; v < W; ++v) {
+                const size_t vv = (v + W - px_offset[u]) % W;
+                const size_t idx = u * W + vv;
+                auto r = (rg[idx] + 0b10) >> 2;
+                range_dest(u, v) = r > pixel_value_max ? 0 : r;
+                signal_f(u, v) = static_cast<float>(sg[idx]);
+                reflec_f(u, v) = static_cast<float>(rf[idx]);
+                nearir_f(u, v) = static_cast<float>(nr[idx]);
+            }
+        }
+
+        signal_ae_.update(signal_f, first);
+        reflec_ae_.update(reflec_f, first);
+        nearir_buc_.update(nearir_f);
+        nearir_ae_.update(nearir_f, first);
+        nearir_f = nearir_f.sqrt();
+        signal_f = signal_f.sqrt();
+
+        // Cast to 16-bit destaggered images (full panorama).
+        ouster::sdk::core::img_t<pixel_type> signal_dest =
+            (signal_f * pixel_value_max).cast<pixel_type>();
+        ouster::sdk::core::img_t<pixel_type> reflec_dest =
+            (reflec_f * pixel_value_max).cast<pixel_type>();
+        ouster::sdk::core::img_t<pixel_type> nearir_dest =
+            (nearir_f * pixel_value_max).cast<pixel_type>();
+
+        // Sample each panel for each channel.
+        const std::map<std::string, const ouster::sdk::core::img_t<pixel_type>*>
+            channel_to_image{
+                {range_ch, &range_dest},
+                {signal_ch, &signal_dest},
+                {reflec_ch, &reflec_dest},
+                {nearir_ch, &nearir_dest}};
+
+        for (auto& panel : panels_) {
+            for (const auto& chan_img : channel_to_image) {
+                const std::string& chan = chan_img.first;
+                auto img_it = panel->images.find(chan);
+                if (img_it == panel->images.end()) continue;
+                sample_panel(*img_it->second, *chan_img.second, *panel);
+            }
+        }
+    }
+
+    void sample_panel(sensor_msgs::msg::Image& out,
+                      const ouster::sdk::core::img_t<pixel_type>& src,
+                      const PanelOutput& panel) const {
+        const uint32_t pw = out.width;
+        const uint32_t ph = out.height;
+        pixel_type* dst = reinterpret_cast<pixel_type*>(out.data.data());
+        for (uint32_t u = 0; u < ph; ++u) {
+            for (uint32_t v = 0; v < pw; ++v) {
+                const int32_t r = panel.r_src(u, v);
+                const int32_t c = panel.v_src(u, v);
+                pixel_type val = 0;
+                if (r >= 0) {
+                    val = src(r, c);
+                }
+                dst[u * pw + v] = val;
+            }
+        }
+    }
+
+   private:
+    ouster::sdk::core::SensorInfo info_;
+    double azimuth_offset_columns_;
+    PostProcessingFn post_processing_fn_;
+    std::vector<std::shared_ptr<PanelOutput>> panels_;
+
+    ouster::sdk::core::image::AutoExposure signal_ae_;
+    ouster::sdk::core::image::AutoExposure reflec_ae_;
+    ouster::sdk::core::image::AutoExposure nearir_ae_;
+    ouster::sdk::core::image::BeamUniformityCorrector nearir_buc_;
+};
+
+}  // namespace ouster_ros

--- a/ouster-ros/src/pinhole_processor.h
+++ b/ouster-ros/src/pinhole_processor.h
@@ -142,9 +142,14 @@ class PinholeProcessor {
             const double vfov_rad = (cfg.vfov_rad > 0.0)
                 ? cfg.vfov_rad
                 : derive_lidar_vfov_rad();
-            ph = static_cast<uint32_t>(std::round(
-                2.0 * fy * std::tan(0.5 * vfov_rad)));
-            if (ph < 1) ph = 1;
+            double ph_d = std::round(2.0 * fy * std::tan(0.5 * vfov_rad));
+            // A very small HFOV inflates fy (hence the auto-fit height)
+            // without bound, and a degenerate vfov could be non-finite; clamp
+            // to a sane range so we never attempt a runaway image allocation.
+            if (!std::isfinite(ph_d) || ph_d < 1.0) ph_d = 1.0;
+            constexpr double kMaxPanelDim = 8192.0;
+            if (ph_d > kMaxPanelDim) ph_d = kMaxPanelDim;
+            ph = static_cast<uint32_t>(ph_d);
         }
 
         const double cx = static_cast<double>(pw) / 2.0;
@@ -277,9 +282,11 @@ class PinholeProcessor {
                 while (v_dest >= static_cast<double>(W)) {
                     v_dest -= static_cast<double>(W);
                 }
+                // v_dest is in [0, W) but rounding can land exactly on W;
+                // wrap around the panorama seam instead of clamping to W-1.
                 int32_t v_src = static_cast<int32_t>(std::lround(v_dest));
-                if (v_src < 0) v_src = 0;
-                if (v_src >= static_cast<int32_t>(W)) v_src = W - 1;
+                v_src %= static_cast<int32_t>(W);
+                if (v_src < 0) v_src += static_cast<int32_t>(W);
 
                 out.r_src(u, v) = (r_src >= 0 && r_src < static_cast<int32_t>(H))
                                       ? r_src
@@ -400,9 +407,14 @@ class PinholeProcessor {
 
         signal_ae_.update(signal_f, first);
         reflec_ae_.update(reflec_f, first);
-        nearir_buc_.update(nearir_f);
-        nearir_ae_.update(nearir_f, first);
-        nearir_f = nearir_f.sqrt();
+        // NEAR_IR is not duplicated for the 2nd return; only decode/expose it
+        // on the first return so the zero-filled 2nd-return image doesn't
+        // pollute the BUC/AE state or overwrite the panel (see sampling below).
+        if (first) {
+            nearir_buc_.update(nearir_f);
+            nearir_ae_.update(nearir_f, first);
+            nearir_f = nearir_f.sqrt();
+        }
         signal_f = signal_f.sqrt();
 
         // Cast to 16-bit destaggered images (full panorama).
@@ -413,13 +425,15 @@ class PinholeProcessor {
         ouster::sdk::core::img_t<pixel_type> nearir_dest =
             (nearir_f * pixel_value_max).cast<pixel_type>();
 
-        // Sample each panel for each channel.
-        const std::map<std::string, const ouster::sdk::core::img_t<pixel_type>*>
+        // Sample each panel for each channel. NEAR_IR is only produced on the
+        // first return; skip it for the 2nd return so its (zeroed) buffer does
+        // not overwrite the first return's near-IR panel.
+        std::map<std::string, const ouster::sdk::core::img_t<pixel_type>*>
             channel_to_image{
                 {range_ch, &range_dest},
                 {signal_ch, &signal_dest},
-                {reflec_ch, &reflec_dest},
-                {nearir_ch, &nearir_dest}};
+                {reflec_ch, &reflec_dest}};
+        if (first) channel_to_image[nearir_ch] = &nearir_dest;
 
         for (auto& panel : panels_) {
             for (const auto& chan_img : channel_to_image) {

--- a/ouster-ros/test/pinhole_processor_test.cpp
+++ b/ouster-ros/test/pinhole_processor_test.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "ouster_ros/impl/file_util.h"
+#include "../src/pinhole_processor.h"
+
+namespace ouster_ros {
+namespace {
+
+ouster::sdk::core::SensorInfo load_test_info() {
+    const auto metadata =
+        std::filesystem::path(__FILE__).parent_path().parent_path() /
+        "ouster-sdk/tests/metadata/3_0_1_os-122246000293-128.json";
+    return ouster::sdk::core::SensorInfo(
+        impl::read_text_file(metadata.string()));
+}
+
+TEST(PinholeProcessorTest, WrapsRoundedColumnAtPanoramaSeam) {
+    const auto info = load_test_info();
+    const double quarter_column_azimuth =
+        0.25 * 2.0 * M_PI /
+        static_cast<double>(info.format.columns_per_frame);
+
+    PinholeProcessor::PanelConfig config;
+    config.name = "seam";
+    config.yaw_rad = quarter_column_azimuth;
+    config.width = 2;
+    config.height = 1;
+
+    PinholeProcessor processor(info, {config}, "{ns}/{name}", "/lidar0",
+                               0.0, nullptr);
+    const auto& panel = *processor.panels().at(0);
+
+    // The center ray maps to W - 0.25 columns. Rounding lands on W, which
+    // must wrap to column zero rather than clamp to the last column.
+    EXPECT_EQ(panel.v_src(0, 1), 0);
+    EXPECT_EQ(panel.optical_frame_id, "lidar0/seam");
+    EXPECT_EQ(panel.camera_info.width, 2u);
+    EXPECT_EQ(panel.camera_info.height, 1u);
+}
+
+TEST(PinholeProcessorTest, ClampsAutoHeightBeforeAllocating) {
+    const auto info = load_test_info();
+
+    PinholeProcessor::PanelConfig config;
+    config.name = "narrow";
+    config.hfov_rad = 1e-12;
+    config.width = 1;
+    config.height = 0;
+
+    PinholeProcessor processor(info, {config}, "{name}", "", 0.0, nullptr);
+    const auto& panel = *processor.panels().at(0);
+
+    EXPECT_EQ(panel.camera_info.height, 8192u);
+    EXPECT_EQ(panel.r_src.rows(), 8192);
+    EXPECT_EQ(panel.r_src.cols(), 1);
+}
+
+}  // namespace
+}  // namespace ouster_ros


### PR DESCRIPTION
## Status / dependency

This PR remains closed/parked while #553 is reviewed. Its branch has been
rebuilt as a clean linear stack directly on the current #553 head (`baa2c3c`),
so it no longer contains the old merge commit or duplicate copies of the #553
history.

The stack intentionally excludes the separate packet-field experiment and does
not add or change a license file.

## Changes

### `os_image` CameraInfo and optical frame

- Add opt-in panorama `CameraInfo` publication (`publish_camera_info` defaults
  to `false`) with corrected horizontal/vertical intrinsics and a destagger-aware
  `column_window` ROI.
- Warn clearly that the equirectangular panorama is not a true pinhole camera.
- Add an optional REP-103 optical frame and static transform shared by images
  and CameraInfo.

### Rectified cardinal pinhole views

- Add `os_pinhole`, which resamples the panorama into configurable rectified
  pinhole panels (front/left/rear/right by default), each with matching
  `CameraInfo` and optical-frame semantics.
- Validate projection parameters, bound auto-derived output height before
  allocation, wrap rounded columns at the panorama seam, and handle dual-return
  NIR correctly.
- Add focused regression tests for seam wrapping, allocation bounds, and the
  cardinal panels' center rays.

### Playback, lifecycle, and portability hardening

- Allow `OusterCloud`, `OusterImage`, and `OusterPinhole` to initialize from a
  metadata file for packet-only bag playback workflows, while ignoring an
  unchanged copy later delivered on the latched metadata topic.
- Reuse packet buffers, avoid RGB work unless consumed, reject undersized data,
  and make image/pinhole metadata reconfiguration and teardown safe.
- Construct static TF broadcasters through the interface-based API on
  `tf2_ros >= 0.44`, while retaining the older ROS 2 API fallback.
- Plumb the new `os_image` options through the composite, PCAP, and bag replay
  launches.

## Validation

- Exact rebuilt branch on #553 (`baa2c3c`), ROS 2 Lyrical / `tf2_ros 0.45.9`,
  Release, `BUILD_TESTING=ON`, `BUILD_PCAP=ON`: clean build.
- 21 GoogleTests across five suites passed; `colcon test-result` reports 22
  tests, 0 errors, 0 failures, and 0 skipped.
- Standalone `OusterCloud`, `OusterImage` (CameraInfo + optical frame enabled),
  and `OusterPinhole` smoke tests loaded real OS metadata and initialized.
- All modified XML launch files parse successfully.

## Review guidance

Review/merge #553 first. Once it lands, rebase this branch on `ros2`; the
remaining diff will be the camera, pinhole, metadata-file, and launch/config
work described above.
