### PR TITLE
[ROS2] Fix cropped scan when using both mask_path + v_reduction

### DIFF
--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -182,7 +182,7 @@ void warn_mask_resized(int image_cols, int image_rows,
                        int scan_height, int scan_width) {
     auto logger = rclcpp::get_logger("ouster_ros");
     RCLCPP_WARN_STREAM(logger, "Mask image has size (" << image_cols << "x" << image_rows << ")"
-                       << " but incoming scans has size (" << scan_height << "x" << scan_width << ")."
+                       << " but incoming scans has size (" << scan_width << "x" << scan_height << ")."
                        << " Resizing mask to match the scans size.");    
 }
 

--- a/ouster-ros/src/point_cloud_processor.h
+++ b/ouster-ros/src/point_cloud_processor.h
@@ -71,7 +71,7 @@ class PointCloudProcessor {
 
         mask = impl::load_mask<uint32_t>(
                     mask_path,
-                    info.format.pixels_per_column / rows_step,
+                    info.format.pixels_per_column,
                     info.format.columns_per_frame);
     }
 


### PR DESCRIPTION
## Related Issues & PRs
#462 introduced this bug when feature was implemented
#546 also modifies the image mask feature but does not address this fix

## Summary of Changes
Just fixing a super quick bug I encountered: when using both v_reduction and a mask, the mask is just applied to the first `height / v_reduction` rows, and the remaining fraction of the cloud is dropped. 

This is because the PointCloudProcessor resizes the mask to `pixels_per_column / row_step` height, but the mask is then applied to the whole (unreduced) scan data in the `scan_to_cloud_fn`, and then the reduction is finally applied.

This change fixes that, and also nitpicks the mask resize warning to report width x height as expected.

## Validation
With a fully white 1024x128 image as the mask and v_reduction set to 4, we now properly see the whole scan region. (below: before, after)
<img width="1773" height="1053" alt="cloud-reduced-before" src="https://github.com/user-attachments/assets/2d70547c-7ef6-475b-87d6-fed91fe2bea0" />
<img width="1773" height="1053" alt="cloud-reduced-after" src="https://github.com/user-attachments/assets/5f3c29bf-24f5-4723-844d-d65d732e332f" />

I also verified that more interesting masks (not fully white pixels) work as expected with v_reduction set to either 1 or 4.

Testing was performed on an OS0 128 rev 7, firmware 3.2.0.