### PR TITLE
Cast packet buffers before swapping

### DIFF
--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -1179,12 +1179,14 @@ void OusterSensor::stop_sensor_connection_thread() {
 }
 
 void OusterSensor::on_lidar_packet_msg(const LidarPacket&) {
-    lidar_packet_msg.buf.swap(lidar_packet.buf);
+    static_cast<std::vector<uint8_t>&>(lidar_packet_msg.buf)
+        .swap(lidar_packet.buf);
     lidar_packet_pub->publish(lidar_packet_msg);
 }
 
 void OusterSensor::on_imu_packet_msg(const ImuPacket&) {
-    imu_packet_msg.buf.swap(imu_packet.buf);
+    static_cast<std::vector<uint8_t>&>(imu_packet_msg.buf)
+        .swap(imu_packet.buf);
     imu_packet_pub->publish(imu_packet_msg);
 }
 


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack patch/ros-rolling-ouster-ros.patch, authored by Daisuke Nishimatsu.

The generated message buffer type may not expose std::vector swap directly on all supported builds. Casting the message buffer to its vector base before swapping keeps the existing transfer pattern while making the call portable.

I intentionally left out the CMake target-link modernization from the RoboStack patch because it overlaps existing upstream PR #553. The version.h major/minor macro part lives in the Ouster SDK submodule rather than in this ROS package source tree.