### PR TITLE
Add Windows CMake options for ouster_ros

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -30,7 +30,14 @@ if(NOT OpenCV_LIBS)
 endif()
 
 # ==== Options ====
-add_compile_options(-Wall -Wextra)
+if(MSVC)
+  add_compile_options(/W2)
+  add_compile_definitions(NOMINMAX _USE_MATH_DEFINES WIN32_LEAN_AND_MEAN)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+else()
+  add_compile_options(-Wall -Wextra)
+endif()
+
 if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -32,10 +32,15 @@ endif()
 # ==== Options ====
 if(MSVC)
   add_compile_options(/W2)
-  add_compile_definitions(NOMINMAX _USE_MATH_DEFINES WIN32_LEAN_AND_MEAN)
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 else()
   add_compile_options(-Wall -Wextra)
+endif()
+
+if(WIN32)
+  add_compile_definitions(NOMINMAX _USE_MATH_DEFINES WIN32_LEAN_AND_MEAN)
+  if(NOT DEFINED CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON CACHE BOOL "Export all symbols on Windows by default")
+  endif()
 endif()
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack patch/ros-rolling-ouster-ros.win.patch, authored by Daisuke Nishimatsu.

Use MSVC warning options instead of GCC warning flags, define common Windows portability macros, and enable CMake Windows symbol export generation for ouster_ros builds on Windows.

This touches the same CMakeLists.txt as upstream PR #553, so it may need a small rebase depending on which PR lands first.