### PR TITLE
Fixed ability to remap name of sensor nodes

### DIFF
--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -23,7 +23,7 @@ namespace ouster_ros {
 OusterSensorNodeBase::OusterSensorNodeBase(
     const std::string& name, const rclcpp::NodeOptions& options)
 : rclcpp_lifecycle::LifecycleNode(name, options),
-  change_state_client{create_client<ChangeState>(std::string{get_name()} + "/change_state")} {
+  change_state_client{create_client<ChangeState>("~/change_state")} {
 }
 
 

--- a/ouster-ros/src/os_sensor_node_base.cpp
+++ b/ouster-ros/src/os_sensor_node_base.cpp
@@ -23,7 +23,7 @@ namespace ouster_ros {
 OusterSensorNodeBase::OusterSensorNodeBase(
     const std::string& name, const rclcpp::NodeOptions& options)
 : rclcpp_lifecycle::LifecycleNode(name, options),
-  change_state_client{create_client<ChangeState>(name + "/change_state"s)} {
+  change_state_client{create_client<ChangeState>(std::string{get_name()} + "/change_state")} {
 }
 
 


### PR DESCRIPTION
## Related Issues & PRs

None

## Summary of Changes

Query the resolved and remapped name instead of hard-coding the default name passed to constructor.

## Validation

Without this fix, this fail:

```
$ ros2 run ouster_ros os_driver --ros-args -p sensor_hostname:=169.254.39.27 -p lidar_mode:=1024x10 -p auto_start:=true -r __node:=os_remapped

[WARN] [1784654490.291295280] [os_sensor]: lidar port set to zero, the client will assign a random port number!
[WARN] [1784654490.291412525] [os_sensor]: imu port set to zero, the client will assign a random port number!
[INFO] [1784654490.291565096] [os_sensor]: auto start requested
[ERROR] [1784654494.291857213] [os_sensor]: Service /os_driver/change_stateis not available.
[INFO] [1784654494.292017132] [os_sensor]: auto start initiated
```

With this fix, the node starts successfully even with the remapped name.