### PR TITLE
Override system-default-qos with packet-qos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-ouster_ros v0.15.1
+ouster_ros v0.15.2
 ==================
 * [BUGFIX] fix improper scaling of mask image when row step is not 1.
 * [BUGFIX]: Add the missing ``ament_cmake_gtest`` to the dependencies.
@@ -23,6 +23,7 @@ ouster_ros v0.15.1
   - ``pcl::XYZRGBA``
   - ``ouster_ros::ColorPoint`` same as ``ouster_ros::Point`` but adds color info.
 * Enable tone mapping for RGB images.
+* Override the QoS Depth for packet topic whether when using System Defaults or not.
 
 ouster_ros v0.14.0
 ==================

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -54,23 +54,11 @@ size_t get_beams_count(const ouster::sdk::core::SensorInfo& info);
  */
 std::string topic_for_return(const std::string& topic_base, int return_idx);
 
-/**
- * Builds the QoS profile used for the raw lidar_packets/imu_packets topics.
- * A single lidar scan can span hundreds of packets, so neither
- * rclcpp::SensorDataQoS()'s default depth (5) nor
- * rclcpp::SystemDefaultsQoS() (which defers reliability/history entirely to
- * the RMW implementation, and on this RMW resolves to best-effort/depth 1 -
- * even shallower) are deep enough: any brief delay in servicing the
- * subscription callback overflows the reader's local queue and silently
- * drops packets, even though the publisher keeps up fine. This builds both
- * profiles explicitly instead of relying on SystemDefaultsQoS()'s
- * vendor-dependent fallback.
- * @param[in] use_system_default_qos if true, use a reliable profile;
- *            otherwise use a best-effort profile. Both get a queue deep
- *            enough to absorb a full scan's worth of packets
- * @return the QoS profile to use for the raw packet topics
- */
-rclcpp::QoS packet_qos(bool use_system_default_qos);
+/** Computes lidar packet count per LidarScan (per column_azimuth)
+ * @param[in] info sensor_info
+ * @return number of raw packets required to hold a LidarScan
+*/
+size_t lidar_packets_per_frame(const ouster::sdk::core::SensorInfo& info);
 
 /**
  * Parse an imu packet message into a ROS imu message

--- a/ouster-ros/include/ouster_ros/os_ros.h
+++ b/ouster-ros/include/ouster_ros/os_ros.h
@@ -55,6 +55,24 @@ size_t get_beams_count(const ouster::sdk::core::SensorInfo& info);
 std::string topic_for_return(const std::string& topic_base, int return_idx);
 
 /**
+ * Builds the QoS profile used for the raw lidar_packets/imu_packets topics.
+ * A single lidar scan can span hundreds of packets, so neither
+ * rclcpp::SensorDataQoS()'s default depth (5) nor
+ * rclcpp::SystemDefaultsQoS() (which defers reliability/history entirely to
+ * the RMW implementation, and on this RMW resolves to best-effort/depth 1 -
+ * even shallower) are deep enough: any brief delay in servicing the
+ * subscription callback overflows the reader's local queue and silently
+ * drops packets, even though the publisher keeps up fine. This builds both
+ * profiles explicitly instead of relying on SystemDefaultsQoS()'s
+ * vendor-dependent fallback.
+ * @param[in] use_system_default_qos if true, use a reliable profile;
+ *            otherwise use a best-effort profile. Both get a queue deep
+ *            enough to absorb a full scan's worth of packets
+ * @return the QoS profile to use for the raw packet topics
+ */
+rclcpp::QoS packet_qos(bool use_system_default_qos);
+
+/**
  * Parse an imu packet message into a ROS imu message
  * @param[in] imu_packet the raw IMU packet populated by read_imu_packet
  * @param[in] timestamp the timestamp to give the resulting ROS message

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_ros</name>
-  <version>0.15.1</version>
+  <version>0.15.2</version>
   <description>Ouster ROS2 driver</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license file="LICENSE">BSD</license>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -106,7 +106,8 @@ class OusterCloud : public OusterProcessingNodeBase {
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
             imu_packet_sub = create_subscription<PacketMsg>(
-                "imu_packets", selected_qos.keep_last(info.format.imu_packets_per_frame),
+                "imu_packets",
+                rclcpp::QoS(selected_qos).keep_last(info.format.imu_packets_per_frame),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     if (imu_packet_handler) {
                         // TODO[UN]: this is not ideal since we can't reuse the msg buffer
@@ -234,7 +235,8 @@ class OusterCloud : public OusterProcessingNodeBase {
             impl::check_token(tokens, "SCAN") ||
             impl::check_token(tokens, "TLM")) {
             lidar_packet_sub = create_subscription<PacketMsg>(
-                "lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)),
+                "lidar_packets",
+                rclcpp::QoS(selected_qos).keep_last(lidar_packets_per_frame(info)),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     // TODO[UN]: this is not ideal since we can't reuse the msg buffer
                     // Need to redefine the Packet object and allow use of array_views

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -95,6 +95,7 @@ class OusterCloud : public OusterProcessingNodeBase {
         rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
         auto selected_qos =
             use_system_default_qos ? system_default_qos : sensor_data_qos;
+        auto packet_sub_qos = packet_qos(use_system_default_qos);
 
         auto proc_mask = get_parameter("proc_mask").as_string();
         auto tokens = impl::parse_tokens(proc_mask, '|');
@@ -106,7 +107,7 @@ class OusterCloud : public OusterProcessingNodeBase {
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
             imu_packet_sub = create_subscription<PacketMsg>(
-                "imu_packets", selected_qos,
+                "imu_packets", packet_sub_qos,
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     if (imu_packet_handler) {
                         // TODO[UN]: this is not ideal since we can't reuse the msg buffer
@@ -234,7 +235,7 @@ class OusterCloud : public OusterProcessingNodeBase {
             impl::check_token(tokens, "SCAN") ||
             impl::check_token(tokens, "TLM")) {
             lidar_packet_sub = create_subscription<PacketMsg>(
-                "lidar_packets", selected_qos,
+                "lidar_packets", packet_sub_qos,
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     // TODO[UN]: this is not ideal since we can't reuse the msg buffer
                     // Need to redefine the Packet object and allow use of array_views

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -91,11 +91,10 @@ class OusterCloud : public OusterProcessingNodeBase {
 
         bool use_system_default_qos =
             get_parameter("use_system_default_qos").as_bool();
-        rclcpp::QoS system_default_qos = rclcpp::SystemDefaultsQoS();
-        rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
-        auto selected_qos =
-            use_system_default_qos ? system_default_qos : sensor_data_qos;
-        auto packet_sub_qos = packet_qos(use_system_default_qos);
+        rclcpp::QoS selected_qos =
+            use_system_default_qos ?
+                static_cast<rclcpp::QoS>(rclcpp::SystemDefaultsQoS()) :
+                static_cast<rclcpp::QoS>(rclcpp::SensorDataQoS());
 
         auto proc_mask = get_parameter("proc_mask").as_string();
         auto tokens = impl::parse_tokens(proc_mask, '|');
@@ -107,7 +106,7 @@ class OusterCloud : public OusterProcessingNodeBase {
                 info, tf_bcast.imu_frame_id(), timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9));
             imu_packet_sub = create_subscription<PacketMsg>(
-                "imu_packets", packet_sub_qos,
+                "imu_packets", selected_qos.keep_last(info.format.imu_packets_per_frame),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     if (imu_packet_handler) {
                         // TODO[UN]: this is not ideal since we can't reuse the msg buffer
@@ -235,7 +234,7 @@ class OusterCloud : public OusterProcessingNodeBase {
             impl::check_token(tokens, "SCAN") ||
             impl::check_token(tokens, "TLM")) {
             lidar_packet_sub = create_subscription<PacketMsg>(
-                "lidar_packets", packet_sub_qos,
+                "lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     // TODO[UN]: this is not ideal since we can't reuse the msg buffer
                     // Need to redefine the Packet object and allow use of array_views

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -50,7 +50,7 @@ class OusterImage : public OusterProcessingNodeBase {
         RCLCPP_INFO(get_logger(), "OusterImage: node initialized!");
     }
 
-    void metadata_handler(const std_msgs::msg::String::ConstPtr& metadata_msg) {
+    void metadata_handler(const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
         RCLCPP_INFO(get_logger(),
                     "OusterImage: retrieved new sensor metadata!");
         info = ouster::sdk::core::SensorInfo(metadata_msg->data);
@@ -69,11 +69,10 @@ class OusterImage : public OusterProcessingNodeBase {
             get_parameter("ptp_utc_tai_offset").as_double();
         bool use_system_default_qos =
             get_parameter("use_system_default_qos").as_bool();
-        rclcpp::QoS system_default_qos = rclcpp::SystemDefaultsQoS();
-        rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
-        auto selected_qos =
-            use_system_default_qos ? system_default_qos : sensor_data_qos;
-        auto packet_sub_qos = packet_qos(use_system_default_qos);
+        rclcpp::QoS selected_qos =
+            use_system_default_qos ?
+                static_cast<rclcpp::QoS>(rclcpp::SystemDefaultsQoS()) :
+                static_cast<rclcpp::QoS>(rclcpp::SensorDataQoS());
 
         const std::map<std::string, std::string>
             channel_field_topic_map_1 {
@@ -126,7 +125,7 @@ class OusterImage : public OusterProcessingNodeBase {
             static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
             min_scan_valid_columns_ratio);
         lidar_packet_sub = create_subscription<PacketMsg>(
-                "lidar_packets", packet_sub_qos,
+                "lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     if (lidar_packet_handler) {
                         // TODO[UN]: this is not ideal since we can't reuse the msg buffer

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -73,6 +73,7 @@ class OusterImage : public OusterProcessingNodeBase {
         rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
         auto selected_qos =
             use_system_default_qos ? system_default_qos : sensor_data_qos;
+        auto packet_sub_qos = packet_qos(use_system_default_qos);
 
         const std::map<std::string, std::string>
             channel_field_topic_map_1 {
@@ -125,7 +126,7 @@ class OusterImage : public OusterProcessingNodeBase {
             static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
             min_scan_valid_columns_ratio);
         lidar_packet_sub = create_subscription<PacketMsg>(
-                "lidar_packets", selected_qos,
+                "lidar_packets", packet_sub_qos,
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     if (lidar_packet_handler) {
                         // TODO[UN]: this is not ideal since we can't reuse the msg buffer

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -125,7 +125,8 @@ class OusterImage : public OusterProcessingNodeBase {
             static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
             min_scan_valid_columns_ratio);
         lidar_packet_sub = create_subscription<PacketMsg>(
-                "lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)),
+                "lidar_packets",
+                rclcpp::QoS(selected_qos).keep_last(lidar_packets_per_frame(info)),
                 [this](const PacketMsg::ConstSharedPtr msg) {
                     if (lidar_packet_handler) {
                         // TODO[UN]: this is not ideal since we can't reuse the msg buffer

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -198,10 +198,13 @@ class OusterPcap : public OusterSensorNodeBase {
     void create_publishers() {
         bool use_system_default_qos =
             get_parameter("use_system_default_qos").as_bool();
-        auto selected_qos = packet_qos(use_system_default_qos);
+        rclcpp::QoS selected_qos =
+            use_system_default_qos ?
+                static_cast<rclcpp::QoS>(rclcpp::SystemDefaultsQoS()) :
+                static_cast<rclcpp::QoS>(rclcpp::SensorDataQoS());
         lidar_packet_pub =
-            create_publisher<PacketMsg>("lidar_packets", selected_qos);
-        imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos);
+            create_publisher<PacketMsg>("lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)));
+        imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos.keep_last(info.format.imu_packets_per_frame));
     }
 
     void open_pcap(const std::string& pcap_file) {

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -198,10 +198,7 @@ class OusterPcap : public OusterSensorNodeBase {
     void create_publishers() {
         bool use_system_default_qos =
             get_parameter("use_system_default_qos").as_bool();
-        rclcpp::QoS system_default_qos = rclcpp::SystemDefaultsQoS();
-        rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
-        auto selected_qos =
-            use_system_default_qos ? system_default_qos : sensor_data_qos;
+        auto selected_qos = packet_qos(use_system_default_qos);
         lidar_packet_pub =
             create_publisher<PacketMsg>("lidar_packets", selected_qos);
         imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos);

--- a/ouster-ros/src/os_pcap_node.cpp
+++ b/ouster-ros/src/os_pcap_node.cpp
@@ -202,9 +202,12 @@ class OusterPcap : public OusterSensorNodeBase {
             use_system_default_qos ?
                 static_cast<rclcpp::QoS>(rclcpp::SystemDefaultsQoS()) :
                 static_cast<rclcpp::QoS>(rclcpp::SensorDataQoS());
-        lidar_packet_pub =
-            create_publisher<PacketMsg>("lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)));
-        imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos.keep_last(info.format.imu_packets_per_frame));
+        lidar_packet_pub = create_publisher<PacketMsg>(
+            "lidar_packets",
+            rclcpp::QoS(selected_qos).keep_last(lidar_packets_per_frame(info)));
+        imu_packet_pub = create_publisher<PacketMsg>(
+            "imu_packets",
+            rclcpp::QoS(selected_qos).keep_last(info.format.imu_packets_per_frame));
     }
 
     void open_pcap(const std::string& pcap_file) {

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -50,6 +50,15 @@ size_t get_beams_count(const SensorInfo& info) {
     return info.beam_azimuth_angles.size();
 }
 
+rclcpp::QoS packet_qos(bool use_system_default_qos) {
+    // large enough to hold a full scan's worth of packets so a brief
+    // stall servicing the subscription callback doesn't drop packets
+    constexpr size_t packet_queue_depth = 1024;
+    if (use_system_default_qos)
+        return rclcpp::QoS(rclcpp::KeepLast(packet_queue_depth)).reliable();
+    return rclcpp::SensorDataQoS().keep_last(packet_queue_depth);
+}
+
 std::string topic_for_return(const std::string& base, int idx) {
     return idx == 0 ? base : base + std::to_string(idx + 1);
 }

--- a/ouster-ros/src/os_ros.cpp
+++ b/ouster-ros/src/os_ros.cpp
@@ -50,13 +50,9 @@ size_t get_beams_count(const SensorInfo& info) {
     return info.beam_azimuth_angles.size();
 }
 
-rclcpp::QoS packet_qos(bool use_system_default_qos) {
-    // large enough to hold a full scan's worth of packets so a brief
-    // stall servicing the subscription callback doesn't drop packets
-    constexpr size_t packet_queue_depth = 1024;
-    if (use_system_default_qos)
-        return rclcpp::QoS(rclcpp::KeepLast(packet_queue_depth)).reliable();
-    return rclcpp::SensorDataQoS().keep_last(packet_queue_depth);
+size_t lidar_packets_per_frame(const ouster::sdk::core::SensorInfo& info) {
+    auto lidar_packets_per_frame = info.format.lidar_packets_per_frame();
+    return lidar_packets_per_frame > 0 ? lidar_packets_per_frame : 10;
 }
 
 std::string topic_for_return(const std::string& base, int idx) {

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -1030,10 +1030,13 @@ void OusterSensor::create_services() {
 void OusterSensor::create_publishers() {
     bool use_system_default_qos =
         get_parameter("use_system_default_qos").as_bool();
-    auto selected_qos = packet_qos(use_system_default_qos);
+    rclcpp::QoS selected_qos =
+        use_system_default_qos ?
+            static_cast<rclcpp::QoS>(rclcpp::SystemDefaultsQoS()) :
+            static_cast<rclcpp::QoS>(rclcpp::SensorDataQoS());
     lidar_packet_pub =
-        create_publisher<PacketMsg>("lidar_packets", selected_qos);
-    imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos);
+        create_publisher<PacketMsg>("lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)));
+    imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos.keep_last(info.format.imu_packets_per_frame));
 }
 
 void OusterSensor::allocate_buffers() {

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -1030,10 +1030,7 @@ void OusterSensor::create_services() {
 void OusterSensor::create_publishers() {
     bool use_system_default_qos =
         get_parameter("use_system_default_qos").as_bool();
-    rclcpp::QoS system_default_qos = rclcpp::SystemDefaultsQoS();
-    rclcpp::QoS sensor_data_qos = rclcpp::SensorDataQoS();
-    auto selected_qos =
-        use_system_default_qos ? system_default_qos : sensor_data_qos;
+    auto selected_qos = packet_qos(use_system_default_qos);
     lidar_packet_pub =
         create_publisher<PacketMsg>("lidar_packets", selected_qos);
     imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos);

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -1034,9 +1034,12 @@ void OusterSensor::create_publishers() {
         use_system_default_qos ?
             static_cast<rclcpp::QoS>(rclcpp::SystemDefaultsQoS()) :
             static_cast<rclcpp::QoS>(rclcpp::SensorDataQoS());
-    lidar_packet_pub =
-        create_publisher<PacketMsg>("lidar_packets", selected_qos.keep_last(lidar_packets_per_frame(info)));
-    imu_packet_pub = create_publisher<PacketMsg>("imu_packets", selected_qos.keep_last(info.format.imu_packets_per_frame));
+    lidar_packet_pub = create_publisher<PacketMsg>(
+        "lidar_packets",
+        rclcpp::QoS(selected_qos).keep_last(lidar_packets_per_frame(info)));
+    imu_packet_pub = create_publisher<PacketMsg>(
+        "imu_packets",
+        rclcpp::QoS(selected_qos).keep_last(info.format.imu_packets_per_frame));
 }
 
 void OusterSensor::allocate_buffers() {

--- a/ouster-sensor-msgs/package.xml
+++ b/ouster-sensor-msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ouster_sensor_msgs</name>
-  <version>0.15.1</version>
+  <version>0.15.2</version>
   <description>ouster_ros message and service definitions</description>
   <maintainer email="oss@ouster.io">ouster developers</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
## Related Issues & PRs
- Related #303

## Summary of Changes
* Override the QoS Depth for packet topic whether when using System Defaults (reliable) or when not using System Defaults (best effort)

### Notes to reviewers
* A better approach would be to use something similar to `driver.launch.xml` in which packets are parsed in the same node that produces them .. but this is an easier path to apply the fix than a whole refactor at this moment.

## Validation
Download a bag file and replay it via the command:

```bash
ros2 launch ouster_ros replay.launch.xml bag_file:=input.bag
```