### PR TITLE
WIP - Add configurable multi-rule point filtering (direct + sparse)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,10 @@ target_link_libraries(ouster_ros
     ${OpenCV_LIBS}
 )
 
+if(APPLE AND BUILD_PCAP)
+  target_link_libraries(ouster_ros PRIVATE ouster_pcap)
+endif()
+
 add_dependencies(ouster_ros ${PROJECT_NAME}_gencpp)
 
 # ==== Executables ====

--- a/README.md
+++ b/README.md
@@ -224,6 +224,30 @@ New launch file parameter:
           this type is same as Velodyne point cloud type
           this type is not compatible with the low data profile.
 
+### Multiple point-filter rules
+
+Use `filter_rules_file` to apply multiple range and field conditions in one
+filter pass:
+
+```bash
+roslaunch ouster_ros sensor.launch \
+  sensor_hostname:=192.168.1.10 \
+  filter_rules_file:=$(rospack find ouster_ros)/config/multi_rule_filter.yaml
+```
+
+The example file applies direct removal below 2 m and sparse-neighbor culling
+from 2 m to 25 m. Rule masks are combined, and point field thresholds use raw
+`PointCloud2` values. The `signal` name works with both the `intensity` field in
+original clouds and the `signal` field in native clouds.
+
+Each named rule uses exactly one `any` (OR) or `all` (AND) list. Conditions
+accept only `reflectivity` or `signal` with `<`, `<=`, `>`, `>=`, `==`, or
+`!=`. A `direct` rule removes matching points immediately. A `sparse` rule
+also requires `min_neighbors`, `kernel: [height, width]`, and
+`neighbor_distance_m`. Unknown settings are rejected.
+
+When `filter_rules_file` is omitted, point filtering is disabled.
+
 ### Invoking Services
 To execute any of the following service, first you need to open a new terminal
 and source the castkin workspace again by running the command:

--- a/config/multi_rule_filter.yaml
+++ b/config/multi_rule_filter.yaml
@@ -14,7 +14,7 @@ filter_rules:
     range_m: [0.0, 2.0]
     culling: direct
     any:
-      - "reflectivity <= 2"
+      - "reflectivity < 2"
       - "reflectivity > 100"
 
   condition_B:

--- a/config/multi_rule_filter.yaml
+++ b/config/multi_rule_filter.yaml
@@ -1,0 +1,28 @@
+# HOW TO USE:
+# - Give each rule a unique name under filter_rules.
+# - range_m is [minimum inclusive, maximum exclusive].
+# - culling must be direct or sparse.
+# - Use exactly one condition list: any (OR) or all (AND).
+# - Conditions allow only reflectivity or signal with <, <=, >, >=, ==, !=.
+# - Sparse rules require min_neighbors, kernel [height, width],
+#   and neighbor_distance_m.
+# - Thresholds are raw sensor values, not percentages.
+# - Unknown or misspelled settings stop the node with an error.
+
+filter_rules:
+  condition_A:
+    range_m: [0.0, 2.0]
+    culling: direct
+    any:
+      - "reflectivity <= 2"
+      - "reflectivity > 100"
+
+  condition_B:
+    range_m: [2.0, 25.0]
+    culling: sparse
+    all:
+      - "reflectivity < 2"
+      - "signal < 100"
+    min_neighbors: 6
+    kernel: [3, 3]
+    neighbor_distance_m: 0.8

--- a/config/multi_rule_filter.yaml
+++ b/config/multi_rule_filter.yaml
@@ -22,7 +22,7 @@ filter_rules:
     culling: sparse
     all:
       - "reflectivity < 2"
-      - "signal < 100"
+      - "signal < 150"
     min_neighbors: 6
     kernel: [3, 3]
-    neighbor_distance_m: 0.8
+    neighbor_distance_m: 0.05

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -62,6 +62,17 @@
 
   <arg name="mask_path" doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
+  <arg name="sparse_noise_culling_enable" doc="enable sparse-neighbor point cloud culling"/>
+  <arg name="spatial_min_neighbors"/>
+  <arg name="spatial_kernel_height"/>
+  <arg name="spatial_kernel_width"/>
+  <arg name="max_culling_range_m"/>
+  <arg name="neighbor_distance_m"/>
+  <arg name="use_filter_field"/>
+  <arg name="filter_field"/>
+  <arg name="filter_threshold"/>
+  <arg name="keep_organized"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
       output="screen" required="true"
@@ -89,6 +100,17 @@
       <param name="~/mask_path" value="$(arg mask_path)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
+      <param name="~/sparse_noise_culling_enable"
+        value="$(arg sparse_noise_culling_enable)"/>
+      <param name="~/spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
+      <param name="~/spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
+      <param name="~/spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
+      <param name="~/max_culling_range_m" value="$(arg max_culling_range_m)"/>
+      <param name="~/neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
+      <param name="~/use_filter_field" value="$(arg use_filter_field)"/>
+      <param name="~/filter_field" value="$(arg filter_field)"/>
+      <param name="~/filter_threshold" value="$(arg filter_threshold)"/>
+      <param name="~/keep_organized" value="$(arg keep_organized)"/>
     </node>
   </group>
 

--- a/launch/common.launch
+++ b/launch/common.launch
@@ -62,16 +62,7 @@
 
   <arg name="mask_path" doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
-  <arg name="sparse_noise_culling_enable" doc="enable sparse-neighbor point cloud culling"/>
-  <arg name="spatial_min_neighbors"/>
-  <arg name="spatial_kernel_height"/>
-  <arg name="spatial_kernel_width"/>
-  <arg name="max_culling_range_m"/>
-  <arg name="neighbor_distance_m"/>
-  <arg name="use_filter_field"/>
-  <arg name="filter_field"/>
-  <arg name="filter_threshold"/>
-  <arg name="keep_organized"/>
+  <arg name="filter_rules_file"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
@@ -100,17 +91,9 @@
       <param name="~/mask_path" value="$(arg mask_path)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
-      <param name="~/sparse_noise_culling_enable"
-        value="$(arg sparse_noise_culling_enable)"/>
-      <param name="~/spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
-      <param name="~/spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
-      <param name="~/spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
-      <param name="~/max_culling_range_m" value="$(arg max_culling_range_m)"/>
-      <param name="~/neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
-      <param name="~/use_filter_field" value="$(arg use_filter_field)"/>
-      <param name="~/filter_field" value="$(arg filter_field)"/>
-      <param name="~/filter_threshold" value="$(arg filter_threshold)"/>
-      <param name="~/keep_organized" value="$(arg keep_organized)"/>
+      <rosparam command="load" file="$(arg filter_rules_file)"
+        param="point_filter_config"
+        if="$(eval arg('filter_rules_file') != '')"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -246,7 +246,7 @@
   <arg name="spatial_min_neighbors" default="6"/>
   <arg name="spatial_kernel_height" default="3"/>
   <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="max_culling_range_m" default="5.0"/>
   <arg name="neighbor_distance_m" default="0.02"/>
   <arg name="use_filter_field" default="true"/>
   <arg name="filter_field" default="reflectivity"/>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -241,6 +241,18 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
+  <arg name="sparse_noise_culling_enable" default="true"
+    doc="enable sparse-neighbor point cloud culling"/>
+  <arg name="spatial_min_neighbors" default="6"/>
+  <arg name="spatial_kernel_height" default="3"/>
+  <arg name="spatial_kernel_width" default="3"/>
+  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="neighbor_distance_m" default="0.02"/>
+  <arg name="use_filter_field" default="true"/>
+  <arg name="filter_field" default="reflectivity"/>
+  <arg name="filter_threshold" default="2.0"/>
+  <arg name="keep_organized" default="true"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -307,6 +319,17 @@
       <param name="~/mask_path" value="$(arg mask_path)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
+      <param name="~/sparse_noise_culling_enable"
+        value="$(arg sparse_noise_culling_enable)"/>
+      <param name="~/spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
+      <param name="~/spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
+      <param name="~/spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
+      <param name="~/max_culling_range_m" value="$(arg max_culling_range_m)"/>
+      <param name="~/neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
+      <param name="~/use_filter_field" value="$(arg use_filter_field)"/>
+      <param name="~/filter_field" value="$(arg filter_field)"/>
+      <param name="~/filter_threshold" value="$(arg filter_threshold)"/>
+      <param name="~/keep_organized" value="$(arg keep_organized)"/>
     </node>
   </group>
 

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -241,17 +241,8 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
-  <arg name="sparse_noise_culling_enable" default="true"
-    doc="enable sparse-neighbor point cloud culling"/>
-  <arg name="spatial_min_neighbors" default="6"/>
-  <arg name="spatial_kernel_height" default="3"/>
-  <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="5.0"/>
-  <arg name="neighbor_distance_m" default="0.02"/>
-  <arg name="use_filter_field" default="true"/>
-  <arg name="filter_field" default="reflectivity"/>
-  <arg name="filter_threshold" default="2.0"/>
-  <arg name="keep_organized" default="true"/>
+  <arg name="filter_rules_file" default=""
+    doc="optional YAML file containing point filter rules; empty disables filtering"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -319,17 +310,9 @@
       <param name="~/mask_path" value="$(arg mask_path)"/>
       <param name="~/min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
-      <param name="~/sparse_noise_culling_enable"
-        value="$(arg sparse_noise_culling_enable)"/>
-      <param name="~/spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
-      <param name="~/spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
-      <param name="~/spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
-      <param name="~/max_culling_range_m" value="$(arg max_culling_range_m)"/>
-      <param name="~/neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
-      <param name="~/use_filter_field" value="$(arg use_filter_field)"/>
-      <param name="~/filter_field" value="$(arg filter_field)"/>
-      <param name="~/filter_threshold" value="$(arg filter_threshold)"/>
-      <param name="~/keep_organized" value="$(arg keep_organized)"/>
+      <rosparam command="load" file="$(arg filter_rules_file)"
+        param="point_filter_config"
+        if="$(eval arg('filter_rules_file') != '')"/>
     </node>
   </group>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -177,16 +177,8 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
-  <arg name="sparse_noise_culling_enable" default="true"/>
-  <arg name="spatial_min_neighbors" default="6"/>
-  <arg name="spatial_kernel_height" default="3"/>
-  <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="5.0"/>
-  <arg name="neighbor_distance_m" default="0.02"/>
-  <arg name="use_filter_field" default="true"/>
-  <arg name="filter_field" default="reflectivity"/>
-  <arg name="filter_threshold" default="2.0"/>
-  <arg name="keep_organized" default="true"/>
+  <arg name="filter_rules_file" default=""
+    doc="optional YAML file containing point filter rules; empty disables filtering"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -259,16 +251,7 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
-    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
-    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
-    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
-    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
-    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
-    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
-    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
-    <arg name="filter_field" value="$(arg filter_field)"/>
-    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
-    <arg name="keep_organized" value="$(arg keep_organized)"/>
+    <arg name="filter_rules_file" value="$(arg filter_rules_file)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -177,6 +177,17 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
+  <arg name="sparse_noise_culling_enable" default="true"/>
+  <arg name="spatial_min_neighbors" default="6"/>
+  <arg name="spatial_kernel_height" default="3"/>
+  <arg name="spatial_kernel_width" default="3"/>
+  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="neighbor_distance_m" default="0.02"/>
+  <arg name="use_filter_field" default="true"/>
+  <arg name="filter_field" default="reflectivity"/>
+  <arg name="filter_threshold" default="2.0"/>
+  <arg name="keep_organized" default="true"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -248,6 +259,16 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
+    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
+    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
+    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
+    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
+    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
+    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
+    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
+    <arg name="filter_field" value="$(arg filter_field)"/>
+    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
+    <arg name="keep_organized" value="$(arg keep_organized)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -181,7 +181,7 @@
   <arg name="spatial_min_neighbors" default="6"/>
   <arg name="spatial_kernel_height" default="3"/>
   <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="max_culling_range_m" default="5.0"/>
   <arg name="neighbor_distance_m" default="0.02"/>
   <arg name="use_filter_field" default="true"/>
   <arg name="filter_field" default="reflectivity"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -90,16 +90,8 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
-  <arg name="sparse_noise_culling_enable" default="true"/>
-  <arg name="spatial_min_neighbors" default="6"/>
-  <arg name="spatial_kernel_height" default="3"/>
-  <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="5.0"/>
-  <arg name="neighbor_distance_m" default="0.02"/>
-  <arg name="use_filter_field" default="true"/>
-  <arg name="filter_field" default="reflectivity"/>
-  <arg name="filter_threshold" default="2.0"/>
-  <arg name="keep_organized" default="true"/>
+  <arg name="filter_rules_file" default=""
+    doc="optional YAML file containing point filter rules; empty disables filtering"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -144,16 +136,7 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
-    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
-    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
-    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
-    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
-    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
-    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
-    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
-    <arg name="filter_field" value="$(arg filter_field)"/>
-    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
-    <arg name="keep_organized" value="$(arg keep_organized)"/>
+    <arg name="filter_rules_file" value="$(arg filter_rules_file)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -94,7 +94,7 @@
   <arg name="spatial_min_neighbors" default="6"/>
   <arg name="spatial_kernel_height" default="3"/>
   <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="max_culling_range_m" default="5.0"/>
   <arg name="neighbor_distance_m" default="0.02"/>
   <arg name="use_filter_field" default="true"/>
   <arg name="filter_field" default="reflectivity"/>

--- a/launch/replay.launch
+++ b/launch/replay.launch
@@ -90,6 +90,17 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
+  <arg name="sparse_noise_culling_enable" default="true"/>
+  <arg name="spatial_min_neighbors" default="6"/>
+  <arg name="spatial_kernel_height" default="3"/>
+  <arg name="spatial_kernel_width" default="3"/>
+  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="neighbor_distance_m" default="0.02"/>
+  <arg name="use_filter_field" default="true"/>
+  <arg name="filter_field" default="reflectivity"/>
+  <arg name="filter_threshold" default="2.0"/>
+  <arg name="keep_organized" default="true"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -133,6 +144,16 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
+    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
+    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
+    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
+    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
+    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
+    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
+    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
+    <arg name="filter_field" value="$(arg filter_field)"/>
+    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
+    <arg name="keep_organized" value="$(arg keep_organized)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -87,7 +87,7 @@
   <arg name="sparse_noise_culling_enable" default="true"/>
   <arg name="spatial_min_neighbors" default="6"/>
   <arg name="spatial_kernel_height" default="3"/>
-  <arg name="spatial_kernel_width" default="3"/>
+  <arg name="spatial_kernel_width" default="5"/>
   <arg name="max_culling_range_m" default="2.0"/>
   <arg name="neighbor_distance_m" default="0.02"/>
   <arg name="use_filter_field" default="true"/>

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -84,16 +84,8 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
-  <arg name="sparse_noise_culling_enable" default="true"/>
-  <arg name="spatial_min_neighbors" default="6"/>
-  <arg name="spatial_kernel_height" default="3"/>
-  <arg name="spatial_kernel_width" default="5"/>
-  <arg name="max_culling_range_m" default="2.0"/>
-  <arg name="neighbor_distance_m" default="0.02"/>
-  <arg name="use_filter_field" default="true"/>
-  <arg name="filter_field" default="reflectivity"/>
-  <arg name="filter_threshold" default="2.0"/>
-  <arg name="keep_organized" default="true"/>
+  <arg name="filter_rules_file" default="$(find ouster_ros)/config/multi_rule_filter.yaml"
+    doc="optional YAML file containing point filter rules; empty disables filtering"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -139,16 +131,7 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
-    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
-    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
-    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
-    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
-    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
-    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
-    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
-    <arg name="filter_field" value="$(arg filter_field)"/>
-    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
-    <arg name="keep_organized" value="$(arg keep_organized)"/>
+    <arg name="filter_rules_file" value="$(arg filter_rules_file)"/>
   </include>
 
 

--- a/launch/replay_pcap.launch
+++ b/launch/replay_pcap.launch
@@ -84,6 +84,17 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
+  <arg name="sparse_noise_culling_enable" default="true"/>
+  <arg name="spatial_min_neighbors" default="6"/>
+  <arg name="spatial_kernel_height" default="3"/>
+  <arg name="spatial_kernel_width" default="3"/>
+  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="neighbor_distance_m" default="0.02"/>
+  <arg name="use_filter_field" default="true"/>
+  <arg name="filter_field" default="reflectivity"/>
+  <arg name="filter_threshold" default="2.0"/>
+  <arg name="keep_organized" default="true"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -128,6 +139,16 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
+    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
+    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
+    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
+    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
+    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
+    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
+    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
+    <arg name="filter_field" value="$(arg filter_field)"/>
+    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
+    <arg name="keep_organized" value="$(arg keep_organized)"/>
   </include>
 
 

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -191,6 +191,17 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
+  <arg name="sparse_noise_culling_enable" default="true"/>
+  <arg name="spatial_min_neighbors" default="6"/>
+  <arg name="spatial_kernel_height" default="3"/>
+  <arg name="spatial_kernel_width" default="3"/>
+  <arg name="max_culling_range_m" default="3.0"/>
+  <arg name="neighbor_distance_m" default="0.02"/>
+  <arg name="use_filter_field" default="true"/>
+  <arg name="filter_field" default="reflectivity"/>
+  <arg name="filter_threshold" default="2.0"/>
+  <arg name="keep_organized" default="true"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -263,6 +274,16 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
+    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
+    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
+    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
+    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
+    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
+    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
+    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
+    <arg name="filter_field" value="$(arg filter_field)"/>
+    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
+    <arg name="keep_organized" value="$(arg keep_organized)"/>
   </include>
 
 </launch>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -195,7 +195,7 @@
   <arg name="spatial_min_neighbors" default="6"/>
   <arg name="spatial_kernel_height" default="3"/>
   <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="3.0"/>
+  <arg name="max_culling_range_m" default="5.0"/>
   <arg name="neighbor_distance_m" default="0.02"/>
   <arg name="use_filter_field" default="true"/>
   <arg name="filter_field" default="reflectivity"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -191,16 +191,8 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
-  <arg name="sparse_noise_culling_enable" default="true"/>
-  <arg name="spatial_min_neighbors" default="6"/>
-  <arg name="spatial_kernel_height" default="3"/>
-  <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="5.0"/>
-  <arg name="neighbor_distance_m" default="0.02"/>
-  <arg name="use_filter_field" default="true"/>
-  <arg name="filter_field" default="reflectivity"/>
-  <arg name="filter_threshold" default="2.0"/>
-  <arg name="keep_organized" default="true"/>
+  <arg name="filter_rules_file" default="$(find ouster_ros)/config/multi_rule_filter.yaml"
+    doc="optional YAML file containing point filter rules; empty disables filtering"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -274,16 +266,7 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
-    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
-    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
-    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
-    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
-    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
-    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
-    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
-    <arg name="filter_field" value="$(arg filter_field)"/>
-    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
-    <arg name="keep_organized" value="$(arg keep_organized)"/>
+    <arg name="filter_rules_file" value="$(arg filter_rules_file)"/>
   </include>
 
 </launch>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -121,16 +121,8 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
-  <arg name="sparse_noise_culling_enable" default="true"/>
-  <arg name="spatial_min_neighbors" default="6"/>
-  <arg name="spatial_kernel_height" default="3"/>
-  <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="5.0"/>
-  <arg name="neighbor_distance_m" default="0.02"/>
-  <arg name="use_filter_field" default="true"/>
-  <arg name="filter_field" default="reflectivity"/>
-  <arg name="filter_threshold" default="2.0"/>
-  <arg name="keep_organized" default="true"/>
+  <arg name="filter_rules_file" default=""
+    doc="optional YAML file containing point filter rules; empty disables filtering"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
@@ -193,16 +185,7 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
-    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
-    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
-    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
-    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
-    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
-    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
-    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
-    <arg name="filter_field" value="$(arg filter_field)"/>
-    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
-    <arg name="keep_organized" value="$(arg keep_organized)"/>
+    <arg name="filter_rules_file" value="$(arg filter_rules_file)"/>
   </include>
 
 </launch>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -125,7 +125,7 @@
   <arg name="spatial_min_neighbors" default="6"/>
   <arg name="spatial_kernel_height" default="3"/>
   <arg name="spatial_kernel_width" default="3"/>
-  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="max_culling_range_m" default="5.0"/>
   <arg name="neighbor_distance_m" default="0.02"/>
   <arg name="use_filter_field" default="true"/>
   <arg name="filter_field" default="reflectivity"/>

--- a/launch/sensor_mtp.launch
+++ b/launch/sensor_mtp.launch
@@ -121,6 +121,17 @@
   <arg name="mask_path" default=""
     doc="path to an image file that will be used to mask parts of the pointcloud"/>
 
+  <arg name="sparse_noise_culling_enable" default="true"/>
+  <arg name="spatial_min_neighbors" default="6"/>
+  <arg name="spatial_kernel_height" default="3"/>
+  <arg name="spatial_kernel_width" default="3"/>
+  <arg name="max_culling_range_m" default="2.0"/>
+  <arg name="neighbor_distance_m" default="0.02"/>
+  <arg name="use_filter_field" default="true"/>
+  <arg name="filter_field" default="reflectivity"/>
+  <arg name="filter_threshold" default="2.0"/>
+  <arg name="keep_organized" default="true"/>
+
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_nodelet_mgr"
       output="screen" required="true" args="manager"/>
@@ -182,6 +193,16 @@
     <arg name="mask_path" value="$(arg mask_path)"/>
     <arg name="min_scan_valid_columns_ratio"
         value="$(arg min_scan_valid_columns_ratio)"/>
+    <arg name="sparse_noise_culling_enable" value="$(arg sparse_noise_culling_enable)"/>
+    <arg name="spatial_min_neighbors" value="$(arg spatial_min_neighbors)"/>
+    <arg name="spatial_kernel_height" value="$(arg spatial_kernel_height)"/>
+    <arg name="spatial_kernel_width" value="$(arg spatial_kernel_width)"/>
+    <arg name="max_culling_range_m" value="$(arg max_culling_range_m)"/>
+    <arg name="neighbor_distance_m" value="$(arg neighbor_distance_m)"/>
+    <arg name="use_filter_field" value="$(arg use_filter_field)"/>
+    <arg name="filter_field" value="$(arg filter_field)"/>
+    <arg name="filter_threshold" value="$(arg filter_threshold)"/>
+    <arg name="keep_organized" value="$(arg keep_organized)"/>
   </include>
 
 </launch>

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -29,7 +29,7 @@
 #include "point_cloud_processor.h"
 #include "laser_scan_processor.h"
 #include "point_cloud_processor_factory.h"
-#include "sparse_neighbor_culling_filter.h"
+#include "sparse_neighbor_culling_config.h"
 #include "telemetry_handler.h"
 
 namespace ouster_ros {
@@ -201,18 +201,7 @@ class OusterCloud : public nodelet::Nodelet {
         if (impl::check_token(tokens, "PCL")) {
             sparse_culling_filter =
                 std::make_unique<SparseNeighborCullingFilter>(
-                    SparseNeighborCullingConfig{
-                        pnh.param("sparse_noise_culling_enable", false),
-                        pnh.param("spatial_min_neighbors", 6),
-                        pnh.param("spatial_kernel_height", 3),
-                        pnh.param("spatial_kernel_width", 3),
-                        pnh.param("max_culling_range_m", 2.0),
-                        pnh.param("neighbor_distance_m", 0.02),
-                        pnh.param("use_filter_field", true),
-                        pnh.param("filter_field",
-                                  std::string{"reflectivity"}),
-                        pnh.param("filter_threshold", 2.0),
-                        pnh.param("keep_organized", true)});
+                    sparse_culling_config::load_config(pnh));
             auto point_type = pnh.param("point_type", std::string{"original"});
             auto organized = pnh.param("organized", true);
             auto destagger = pnh.param("destagger", true);

--- a/src/os_cloud_nodelet.cpp
+++ b/src/os_cloud_nodelet.cpp
@@ -20,6 +20,8 @@
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/PointCloud2.h>
 
+#include <memory>
+
 #include "ouster_ros/PacketMsg.h"
 #include "os_transforms_broadcaster.h"
 #include "imu_packet_handler.h"
@@ -27,6 +29,7 @@
 #include "point_cloud_processor.h"
 #include "laser_scan_processor.h"
 #include "point_cloud_processor_factory.h"
+#include "sparse_neighbor_culling_filter.h"
 #include "telemetry_handler.h"
 
 namespace ouster_ros {
@@ -196,6 +199,20 @@ class OusterCloud : public nodelet::Nodelet {
         std::vector<LidarScanProcessor> processors;
 
         if (impl::check_token(tokens, "PCL")) {
+            sparse_culling_filter =
+                std::make_unique<SparseNeighborCullingFilter>(
+                    SparseNeighborCullingConfig{
+                        pnh.param("sparse_noise_culling_enable", false),
+                        pnh.param("spatial_min_neighbors", 6),
+                        pnh.param("spatial_kernel_height", 3),
+                        pnh.param("spatial_kernel_width", 3),
+                        pnh.param("max_culling_range_m", 2.0),
+                        pnh.param("neighbor_distance_m", 0.02),
+                        pnh.param("use_filter_field", true),
+                        pnh.param("filter_field",
+                                  std::string{"reflectivity"}),
+                        pnh.param("filter_threshold", 2.0),
+                        pnh.param("keep_organized", true)});
             auto point_type = pnh.param("point_type", std::string{"original"});
             auto organized = pnh.param("organized", true);
             auto destagger = pnh.param("destagger", true);
@@ -232,6 +249,7 @@ class OusterCloud : public nodelet::Nodelet {
                         for (size_t i = 0; i < msgs.size(); ++i) {
                             if (msgs[i]->header.stamp > last_msg_ts)
                                 last_msg_ts = msgs[i]->header.stamp;
+                            sparse_culling_filter->filter(*msgs[i]);
                             lidar_pubs[i].publish(*msgs[i]);
                         }
                     }));
@@ -302,6 +320,7 @@ class OusterCloud : public nodelet::Nodelet {
 
     ImuPacketHandler::HandlerType imu_packet_handler;
     LidarPacketHandler::HandlerType lidar_packet_handler;
+    std::unique_ptr<SparseNeighborCullingFilter> sparse_culling_filter;
 
     ros::Timer timer_;
     ros::Time last_msg_ts;

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -27,7 +27,7 @@
 #include "laser_scan_processor.h"
 #include "image_processor.h"
 #include "point_cloud_processor_factory.h"
-#include "sparse_neighbor_culling_filter.h"
+#include "sparse_neighbor_culling_config.h"
 #include "telemetry_handler.h"
 
 using ouster::sdk::core::ImuPacket;
@@ -140,18 +140,7 @@ class OusterDriver : public OusterSensor {
         if (impl::check_token(tokens, "PCL")) {
             sparse_culling_filter =
                 std::make_unique<SparseNeighborCullingFilter>(
-                    SparseNeighborCullingConfig{
-                        pnh.param("sparse_noise_culling_enable", false),
-                        pnh.param("spatial_min_neighbors", 6),
-                        pnh.param("spatial_kernel_height", 3),
-                        pnh.param("spatial_kernel_width", 3),
-                        pnh.param("max_culling_range_m", 2.0),
-                        pnh.param("neighbor_distance_m", 0.02),
-                        pnh.param("use_filter_field", true),
-                        pnh.param("filter_field",
-                                  std::string{"reflectivity"}),
-                        pnh.param("filter_threshold", 2.0),
-                        pnh.param("keep_organized", true)});
+                    sparse_culling_config::load_config(pnh));
             auto point_type = pnh.param("point_type", std::string{"original"});
             auto organized = pnh.param("organized", true);
             auto destagger = pnh.param("destagger", true);

--- a/src/os_driver_nodelet.cpp
+++ b/src/os_driver_nodelet.cpp
@@ -17,6 +17,8 @@
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/PointCloud2.h>
 
+#include <memory>
+
 #include "os_sensor_nodelet.h"
 #include "os_transforms_broadcaster.h"
 #include "imu_packet_handler.h"
@@ -25,6 +27,7 @@
 #include "laser_scan_processor.h"
 #include "image_processor.h"
 #include "point_cloud_processor_factory.h"
+#include "sparse_neighbor_culling_filter.h"
 #include "telemetry_handler.h"
 
 using ouster::sdk::core::ImuPacket;
@@ -135,6 +138,20 @@ class OusterDriver : public OusterSensor {
 
         std::vector<LidarScanProcessor> processors;
         if (impl::check_token(tokens, "PCL")) {
+            sparse_culling_filter =
+                std::make_unique<SparseNeighborCullingFilter>(
+                    SparseNeighborCullingConfig{
+                        pnh.param("sparse_noise_culling_enable", false),
+                        pnh.param("spatial_min_neighbors", 6),
+                        pnh.param("spatial_kernel_height", 3),
+                        pnh.param("spatial_kernel_width", 3),
+                        pnh.param("max_culling_range_m", 2.0),
+                        pnh.param("neighbor_distance_m", 0.02),
+                        pnh.param("use_filter_field", true),
+                        pnh.param("filter_field",
+                                  std::string{"reflectivity"}),
+                        pnh.param("filter_threshold", 2.0),
+                        pnh.param("keep_organized", true)});
             auto point_type = pnh.param("point_type", std::string{"original"});
             auto organized = pnh.param("organized", true);
             auto destagger = pnh.param("destagger", true);
@@ -167,8 +184,10 @@ class OusterDriver : public OusterSensor {
                     tf_bcast.apply_lidar_to_sensor_transform(), organized,
                     destagger, min_range, max_range, v_reduction, mask_path,
                     [this](PointCloudProcessor_OutputType msgs) {
-                        for (size_t i = 0; i < msgs.size(); ++i)
+                        for (size_t i = 0; i < msgs.size(); ++i) {
+                            sparse_culling_filter->filter(*msgs[i]);
                             lidar_pubs[i].publish(*msgs[i]);
+                        }
                     }));
 
             // warn about profile incompatibility
@@ -265,6 +284,7 @@ class OusterDriver : public OusterSensor {
 
     ImuPacketHandler::HandlerType imu_packet_handler;
     LidarPacketHandler::HandlerType lidar_packet_handler;
+    std::unique_ptr<SparseNeighborCullingFilter> sparse_culling_filter;
 
     bool publish_raw = false;
 

--- a/src/sparse_neighbor_culling_config.h
+++ b/src/sparse_neighbor_culling_config.h
@@ -1,0 +1,433 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file sparse_neighbor_culling_config.h
+ * @brief ROS parameter loading for multi-rule point cloud culling.
+ */
+
+#pragma once
+
+#include "sparse_neighbor_culling_filter.h"
+
+#include <ros/node_handle.h>
+#include <xmlrpcpp/XmlRpcValue.h>
+
+#include <algorithm>
+#include <cctype>
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ouster_ros {
+namespace sparse_culling_config {
+
+inline std::runtime_error config_error(const std::string& path,
+                                       const std::string& message) {
+    return std::runtime_error("Invalid point filter configuration at '" + path +
+                              "': " + message);
+}
+
+inline const XmlRpc::XmlRpcValue& require_member(
+    const XmlRpc::XmlRpcValue& value, const std::string& member,
+    const std::string& path) {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
+        throw config_error(path, "expected a mapping");
+    }
+    if (!value.hasMember(member)) {
+        throw config_error(path, "missing required key '" + member + "'");
+    }
+    return value[member];
+}
+
+inline double read_number(const XmlRpc::XmlRpcValue& value,
+                          const std::string& path) {
+    if (value.getType() == XmlRpc::XmlRpcValue::TypeInt) {
+        return static_cast<int>(value);
+    }
+    if (value.getType() == XmlRpc::XmlRpcValue::TypeDouble) {
+        return static_cast<double>(value);
+    }
+    throw config_error(path, "expected a number");
+}
+
+inline int read_int(const XmlRpc::XmlRpcValue& value,
+                    const std::string& path) {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeInt) {
+        throw config_error(path, "expected an integer");
+    }
+    return static_cast<int>(value);
+}
+
+inline std::string read_string(const XmlRpc::XmlRpcValue& value,
+                               const std::string& path) {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeString) {
+        throw config_error(path, "expected a string");
+    }
+    return static_cast<std::string>(value);
+}
+
+inline void validate_allowed_members(
+    const XmlRpc::XmlRpcValue& value,
+    std::initializer_list<const char*> allowed,
+    const std::string& path) {
+    for (const auto& member : value) {
+        const bool known =
+            std::any_of(allowed.begin(), allowed.end(),
+                        [&member](const char* name) {
+                            return member.first == name;
+                        });
+        if (!known) {
+            throw config_error(path,
+                               "unknown setting '" + member.first + "'");
+        }
+    }
+}
+
+inline std::pair<double, double> read_number_pair(
+    const XmlRpc::XmlRpcValue& value, const std::string& path) {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeArray ||
+        value.size() != 2) {
+        throw config_error(path, "expected a two-number list");
+    }
+    return {read_number(value[0], path + "[0]"),
+            read_number(value[1], path + "[1]")};
+}
+
+inline std::pair<int, int> read_int_pair(
+    const XmlRpc::XmlRpcValue& value, const std::string& path) {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeArray ||
+        value.size() != 2) {
+        throw config_error(path, "expected a two-integer list");
+    }
+    return {read_int(value[0], path + "[0]"),
+            read_int(value[1], path + "[1]")};
+}
+
+inline CullingAction parse_action(const std::string& value,
+                                  const std::string& path) {
+    if (value == "direct") return CullingAction::REMOVE;
+    if (value == "sparse") {
+        return CullingAction::SPARSE_NEIGHBOR_CULL;
+    }
+    throw config_error(path,
+                       "unknown culling method '" + value +
+                           "' (expected direct or sparse)");
+}
+
+class ConditionExpressionParser {
+   public:
+    explicit ConditionExpressionParser(std::string expression)
+        : expression_{std::move(expression)} {}
+
+    ConditionNode parse() {
+        auto condition = parse_or();
+        skip_whitespace();
+        if (position_ != expression_.size()) {
+            fail("unexpected text");
+        }
+        return condition;
+    }
+
+   private:
+    ConditionNode parse_or() {
+        auto condition = parse_and();
+        while (match("||")) {
+            condition = combine(ConditionType::OR, std::move(condition),
+                                parse_and());
+        }
+        return condition;
+    }
+
+    ConditionNode parse_and() {
+        auto condition = parse_primary();
+        while (match("&&")) {
+            condition = combine(ConditionType::AND, std::move(condition),
+                                parse_primary());
+        }
+        return condition;
+    }
+
+    ConditionNode parse_primary() {
+        skip_whitespace();
+        if (match("(")) {
+            auto condition = parse_or();
+            if (!match(")")) fail("expected ')'");
+            return condition;
+        }
+        return parse_comparison();
+    }
+
+    ConditionNode parse_comparison() {
+        const std::string field = parse_identifier();
+        const ScalarComparison comparison = parse_operator();
+        const double value = parse_number();
+        ConditionNode result;
+        result.type = ConditionType::COMPARISON;
+        result.comparison = {field, comparison, value};
+        return result;
+    }
+
+    std::string parse_identifier() {
+        skip_whitespace();
+        const size_t start = position_;
+        if (position_ >= expression_.size() ||
+            !(std::isalpha(static_cast<unsigned char>(
+                  expression_[position_])) ||
+              expression_[position_] == '_')) {
+            fail("expected a field name");
+        }
+        ++position_;
+        while (position_ < expression_.size() &&
+               (std::isalnum(static_cast<unsigned char>(
+                    expression_[position_])) ||
+                expression_[position_] == '_')) {
+            ++position_;
+        }
+        return expression_.substr(start, position_ - start);
+    }
+
+    ScalarComparison parse_operator() {
+        skip_whitespace();
+        if (match("<=")) return ScalarComparison::LE;
+        if (match(">=")) return ScalarComparison::GE;
+        if (match("==")) return ScalarComparison::EQ;
+        if (match("!=")) return ScalarComparison::NE;
+        if (match("<")) return ScalarComparison::LT;
+        if (match(">")) return ScalarComparison::GT;
+        fail("expected <, <=, >, >=, ==, or !=");
+    }
+
+    double parse_number() {
+        skip_whitespace();
+        size_t consumed = 0;
+        double value = 0.0;
+        try {
+            value = std::stod(expression_.substr(position_), &consumed);
+        } catch (const std::exception&) {
+            fail("expected a number");
+        }
+        if (consumed == 0) fail("expected a number");
+        position_ += consumed;
+        return value;
+    }
+
+    static ConditionNode combine(ConditionType type, ConditionNode left,
+                                 ConditionNode right) {
+        if (left.type == type) {
+            left.children.push_back(std::move(right));
+            return left;
+        }
+        ConditionNode result;
+        result.type = type;
+        result.children.push_back(std::move(left));
+        result.children.push_back(std::move(right));
+        return result;
+    }
+
+    bool match(const std::string& token) {
+        skip_whitespace();
+        if (expression_.compare(position_, token.size(), token) != 0) {
+            return false;
+        }
+        position_ += token.size();
+        return true;
+    }
+
+    void skip_whitespace() {
+        while (position_ < expression_.size() &&
+               std::isspace(static_cast<unsigned char>(
+                   expression_[position_]))) {
+            ++position_;
+        }
+    }
+
+    [[noreturn]] void fail(const std::string& message) const {
+        throw std::runtime_error(
+            "Invalid point filter expression at position " +
+            std::to_string(position_) + ": " + message + " in '" +
+            expression_ + "'");
+    }
+
+    std::string expression_;
+    size_t position_ = 0;
+};
+
+inline ConditionNode parse_condition_expression(
+    const std::string& expression) {
+    return ConditionExpressionParser{expression}.parse();
+}
+
+inline ConditionNode comparison_condition(
+    const std::string& field, ScalarComparison comparison, double value) {
+    ConditionNode condition;
+    condition.type = ConditionType::COMPARISON;
+    condition.comparison = {field, comparison, value};
+    return condition;
+}
+
+inline ConditionNode parse_strict_condition(
+    const std::string& expression, const std::string& path) {
+    ConditionNode condition;
+    try {
+        condition = parse_condition_expression(expression);
+    } catch (const std::exception& error) {
+        throw config_error(path, error.what());
+    }
+    if (condition.type != ConditionType::COMPARISON) {
+        throw config_error(
+            path, "expected one condition such as 'reflectivity <= 2'");
+    }
+    const auto& field = condition.comparison.field;
+    if (field != "reflectivity" && field != "signal") {
+        throw config_error(
+            path, "field must be reflectivity or signal");
+    }
+    return condition;
+}
+
+inline ConditionNode parse_condition_list(
+    const XmlRpc::XmlRpcValue& value, ConditionType match_type,
+    const std::string& path) {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeArray ||
+        value.size() == 0) {
+        throw config_error(path, "expected a non-empty condition list");
+    }
+
+    std::vector<ConditionNode> conditions;
+    conditions.reserve(value.size());
+    for (int index = 0; index < value.size(); ++index) {
+        const std::string condition_path =
+            path + "[" + std::to_string(index) + "]";
+        conditions.push_back(parse_strict_condition(
+            read_string(value[index], condition_path), condition_path));
+    }
+    if (conditions.size() == 1) return std::move(conditions.front());
+
+    ConditionNode group;
+    group.type = match_type;
+    group.children = std::move(conditions);
+    return group;
+}
+
+inline std::vector<FilterRule> parse_filter_rules(
+    const XmlRpc::XmlRpcValue& rules_value) {
+    if (rules_value.getType() != XmlRpc::XmlRpcValue::TypeStruct ||
+        rules_value.size() == 0) {
+        throw config_error("filter_rules",
+                           "expected a non-empty mapping of named rules");
+    }
+
+    std::vector<FilterRule> rules;
+    rules.reserve(rules_value.size());
+    for (const auto& named_rule : rules_value) {
+        const std::string& name = named_rule.first;
+        const auto& value = named_rule.second;
+        const std::string path = "filter_rules." + name;
+        if (value.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
+            throw config_error(path, "expected a mapping");
+        }
+        validate_allowed_members(
+            value,
+            {"range_m", "culling", "any", "all", "min_neighbors",
+             "kernel", "neighbor_distance_m"},
+            path);
+        if (name.empty()) {
+            throw config_error(path, "rule name must not be empty");
+        }
+
+        FilterRule rule;
+        rule.name = name;
+
+        rule.action = parse_action(
+            read_string(require_member(value, "culling", path),
+                        path + ".culling"),
+            path + ".culling");
+
+        const auto range =
+            read_number_pair(require_member(value, "range_m", path),
+                             path + ".range_m");
+        if (range.first < 0.0 || range.second <= range.first) {
+            throw config_error(
+                path + ".range_m",
+                "minimum must be non-negative and below maximum");
+        }
+
+        const bool has_any = value.hasMember("any");
+        const bool has_all = value.hasMember("all");
+        if (has_any == has_all) {
+            throw config_error(path,
+                               "specify exactly one of any or all");
+        }
+        auto field_conditions = parse_condition_list(
+            value[has_any ? "any" : "all"],
+            has_any ? ConditionType::OR : ConditionType::AND,
+            path + (has_any ? ".any" : ".all"));
+
+        rule.condition.type = ConditionType::AND;
+        rule.condition.children.push_back(comparison_condition(
+            "range", ScalarComparison::GE, range.first));
+        rule.condition.children.push_back(comparison_condition(
+            "range", ScalarComparison::LT, range.second));
+        rule.condition.children.push_back(
+            std::move(field_conditions));
+
+        if (rule.action == CullingAction::SPARSE_NEIGHBOR_CULL) {
+            rule.sparse.min_neighbors = read_int(
+                require_member(value, "min_neighbors", path),
+                path + ".min_neighbors");
+            const auto kernel =
+                read_int_pair(require_member(value, "kernel", path),
+                              path + ".kernel");
+            rule.sparse.kernel_height = kernel.first;
+            rule.sparse.kernel_width = kernel.second;
+            rule.sparse.neighbor_distance_m = read_number(
+                require_member(value, "neighbor_distance_m", path),
+                path + ".neighbor_distance_m");
+        } else if (value.hasMember("min_neighbors") ||
+                   value.hasMember("kernel") ||
+                   value.hasMember("neighbor_distance_m")) {
+            throw config_error(
+                path,
+                "neighbor settings can only be used with culling: sparse");
+        }
+        rules.push_back(std::move(rule));
+    }
+    return rules;
+}
+
+inline SparseNeighborCullingConfig disabled_config() {
+    SparseNeighborCullingConfig config;
+    config.enabled = false;
+    return config;
+}
+
+inline SparseNeighborCullingConfig parse_config(
+    const XmlRpc::XmlRpcValue& value) {
+    if (value.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
+        throw config_error("point_filter_config", "expected a mapping");
+    }
+    validate_allowed_members(value, {"filter_rules"},
+                             "point_filter_config");
+
+    SparseNeighborCullingConfig config;
+    config.enabled = true;
+    config.keep_organized = true;
+    config.rules = parse_filter_rules(require_member(
+        value, "filter_rules", "point_filter_config"));
+    return config;
+}
+
+inline SparseNeighborCullingConfig load_config(
+    const ros::NodeHandle& private_node_handle) {
+    XmlRpc::XmlRpcValue config;
+    if (!private_node_handle.getParam("point_filter_config", config)) {
+        return disabled_config();
+    }
+    return parse_config(config);
+}
+
+}  // namespace sparse_culling_config
+}  // namespace ouster_ros

--- a/src/sparse_neighbor_culling_filter.h
+++ b/src/sparse_neighbor_culling_filter.h
@@ -17,37 +17,66 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace ouster_ros {
 
+enum class ScalarComparison { LT, LE, GT, GE, EQ, NE };
+enum class ConditionType { COMPARISON, AND, OR };
+enum class CullingAction { REMOVE, SPARSE_NEIGHBOR_CULL };
+
+struct FieldPredicate {
+    std::string field;
+    ScalarComparison comparison;
+    double value;
+};
+
+struct ConditionNode {
+    ConditionType type = ConditionType::COMPARISON;
+    FieldPredicate comparison;
+    std::vector<ConditionNode> children;
+};
+
+struct SparseNeighborOptions {
+    int min_neighbors = 6;
+    int kernel_height = 3;
+    int kernel_width = 3;
+    double neighbor_distance_m = 0.02;
+};
+
+struct FilterRule {
+    std::string name;
+    bool enabled = true;
+    ConditionNode condition;
+    CullingAction action = CullingAction::SPARSE_NEIGHBOR_CULL;
+    SparseNeighborOptions sparse;
+};
+
 struct SparseNeighborCullingConfig {
-    bool enabled;
-    int spatial_min_neighbors;
-    int spatial_kernel_height;
-    int spatial_kernel_width;
-    double max_culling_range_m;
-    double neighbor_distance_m;
-    bool use_filter_field;
-    std::string filter_field;
-    double filter_threshold;
-    bool keep_organized;
+    bool enabled = false;
+    bool keep_organized = true;
+    std::vector<FilterRule> rules;
 };
 
 /**
- * Byte-layout-preserving port of the Python sparse noise culler. It changes
+ * Byte-layout-preserving multi-rule point culler. Rules are evaluated against
+ * the original organized cloud and their cull masks are combined. It changes
  * only XYZ values for organized output, or removes complete point records for
  * compact output.
  */
 class SparseNeighborCullingFilter {
    public:
     explicit SparseNeighborCullingFilter(SparseNeighborCullingConfig config)
-        : config_{std::move(config)} {}
+        : config_{std::move(config)} {
+        validate_config(config_);
+    }
 
     void filter(sensor_msgs::PointCloud2& cloud) const {
-        if (!config_.enabled) return;
+        if (!config_.enabled || config_.rules.empty()) return;
 
         if (cloud.height <= 1) {
             ROS_WARN_THROTTLE(
@@ -83,24 +112,9 @@ class SparseNeighborCullingFilter {
             return;
         }
 
-        const sensor_msgs::PointField* filter_field = nullptr;
-        if (config_.use_filter_field) {
-            filter_field = find_field(cloud, config_.filter_field);
-            if (!usable_scalar_field(cloud, filter_field)) {
-                ROS_WARN_THROTTLE(
-                    5.0,
-                    "Input PointCloud2 does not contain a usable '%s' field. "
-                    "Publishing unmodified cloud.",
-                    config_.filter_field.c_str());
-                return;
-            }
-        }
-
         const size_t point_count =
             static_cast<size_t>(cloud.height) * cloud.width;
         std::vector<float> ranges(point_count, 0.0f);
-        std::vector<uint8_t> candidates(point_count, 0);
-        bool any_candidate = false;
 
         for (uint32_t row = 0; row < cloud.height; ++row) {
             for (uint32_t col = 0; col < cloud.width; ++col) {
@@ -123,65 +137,58 @@ class SparseNeighborCullingFilter {
                 const float range = static_cast<float>(
                     std::sqrt(x * x + y * y + z * z));
                 ranges[index] = range;
-                bool candidate =
-                    range > 0.0f && range < config_.max_culling_range_m;
-                if (candidate && filter_field) {
-                    const double value =
-                        read_scalar(point + filter_field->offset,
-                                    filter_field->datatype,
-                                    cloud.is_bigendian);
-                    candidate = std::isfinite(value) &&
-                                value < config_.filter_threshold;
-                }
-                candidates[index] = candidate;
-                any_candidate = any_candidate || candidate;
             }
         }
 
-        if (!any_candidate) return;
-
         std::vector<uint8_t> cull(point_count, 0);
         bool any_culled = false;
-        const int half_width = config_.spatial_kernel_width / 2;
-        const int half_height = config_.spatial_kernel_height / 2;
 
-        for (uint32_t row = 0; row < cloud.height; ++row) {
-            for (uint32_t col = 0; col < cloud.width; ++col) {
-                const size_t index = linear_index(cloud, row, col);
-                if (!candidates[index]) continue;
+        for (const auto& rule : config_.rules) {
+            if (!rule.enabled) continue;
 
-                uint8_t neighbor_count = 0;
-                for (int shift_x = -half_width; shift_x <= half_width;
-                     ++shift_x) {
-                    for (int shift_y = -half_height;
-                         shift_y <= half_height; ++shift_y) {
-                        const int neighbor_row =
-                            static_cast<int>(row) - shift_y;
-                        if (neighbor_row < 0 ||
-                            neighbor_row >= static_cast<int>(cloud.height)) {
-                            continue;
-                        }
-                        int neighbor_col =
-                            (static_cast<int>(col) - shift_x) %
-                            static_cast<int>(cloud.width);
-                        if (neighbor_col < 0) neighbor_col += cloud.width;
+            std::map<std::string, const sensor_msgs::PointField*>
+                condition_fields;
+            std::string missing_field;
+            if (!bind_condition_fields(rule.condition, cloud,
+                                       condition_fields, missing_field)) {
+                ROS_WARN_THROTTLE(
+                    5.0,
+                    "Skipping point filter rule '%s': input PointCloud2 "
+                    "does not contain a usable '%s' field.",
+                    rule.name.c_str(), missing_field.c_str());
+                continue;
+            }
 
-                        const float neighbor_range = ranges[linear_index(
-                            cloud, static_cast<uint32_t>(neighbor_row),
-                            static_cast<uint32_t>(neighbor_col))];
-                        if (neighbor_range > 0.0f &&
-                            std::abs(neighbor_range - ranges[index]) <=
-                                config_.neighbor_distance_m) {
-                            ++neighbor_count;
-                        }
+            std::vector<uint8_t> candidates(point_count, 0);
+            bool any_candidate = false;
+            for (uint32_t row = 0; row < cloud.height; ++row) {
+                for (uint32_t col = 0; col < cloud.width; ++col) {
+                    const size_t index = linear_index(cloud, row, col);
+                    if (!(ranges[index] > 0.0f)) continue;
+                    const uint8_t* point = point_data(cloud, row, col);
+                    if (!condition_matches(
+                            rule.condition, ranges[index], point, cloud,
+                            condition_fields)) {
+                        continue;
                     }
-                }
-
-                if (neighbor_count < config_.spatial_min_neighbors) {
-                    cull[index] = 1;
-                    any_culled = true;
+                    candidates[index] = 1;
+                    any_candidate = true;
                 }
             }
+            if (!any_candidate) continue;
+
+            if (rule.action == CullingAction::REMOVE) {
+                for (size_t i = 0; i < point_count; ++i) {
+                    if (candidates[i]) {
+                        cull[i] = 1;
+                        any_culled = true;
+                    }
+                }
+                continue;
+            }
+
+            apply_sparse_rule(cloud, ranges, candidates, rule, cull,
+                              any_culled);
         }
 
         if (!any_culled) return;
@@ -220,6 +227,196 @@ class SparseNeighborCullingFilter {
     }
 
    private:
+    static void validate_config(const SparseNeighborCullingConfig& config) {
+        for (const auto& rule : config.rules) {
+            if (rule.name.empty()) {
+                throw std::invalid_argument(
+                    "point filter rule name must not be empty");
+            }
+            validate_condition(rule.condition, rule.name);
+            if (rule.action != CullingAction::SPARSE_NEIGHBOR_CULL) {
+                continue;
+            }
+            const auto& sparse = rule.sparse;
+            if (sparse.kernel_height <= 0 || sparse.kernel_width <= 0 ||
+                sparse.kernel_height % 2 == 0 ||
+                sparse.kernel_width % 2 == 0) {
+                throw std::invalid_argument(
+                    "sparse kernel dimensions for point filter rule '" +
+                    rule.name + "' must be positive odd numbers");
+            }
+            const int kernel_points =
+                sparse.kernel_height * sparse.kernel_width;
+            if (sparse.min_neighbors <= 0 ||
+                sparse.min_neighbors > kernel_points) {
+                throw std::invalid_argument(
+                    "min_neighbors for point filter rule '" + rule.name +
+                    "' must be within the sparse kernel area");
+            }
+            if (!std::isfinite(sparse.neighbor_distance_m) ||
+                sparse.neighbor_distance_m < 0.0) {
+                throw std::invalid_argument(
+                    "neighbor_distance_m for point filter rule '" +
+                    rule.name + "' must be non-negative");
+            }
+        }
+    }
+
+    static void validate_condition(const ConditionNode& condition,
+                                   const std::string& rule_name) {
+        if (condition.type == ConditionType::COMPARISON) {
+            if (condition.comparison.field.empty() ||
+                !std::isfinite(condition.comparison.value)) {
+                throw std::invalid_argument(
+                    "invalid comparison in point filter rule '" +
+                    rule_name + "'");
+            }
+            return;
+        }
+        if (condition.children.size() < 2) {
+            throw std::invalid_argument(
+                "logical expression in point filter rule '" + rule_name +
+                "' must have at least two operands");
+        }
+        for (const auto& child : condition.children) {
+            validate_condition(child, rule_name);
+        }
+    }
+
+    static bool compare(double actual, const FieldPredicate& predicate) {
+        if (!std::isfinite(actual)) return false;
+        switch (predicate.comparison) {
+            case ScalarComparison::LT:
+                return actual < predicate.value;
+            case ScalarComparison::LE:
+                return actual <= predicate.value;
+            case ScalarComparison::GT:
+                return actual > predicate.value;
+            case ScalarComparison::GE:
+                return actual >= predicate.value;
+            case ScalarComparison::EQ:
+                return actual == predicate.value;
+            case ScalarComparison::NE:
+                return actual != predicate.value;
+        }
+        return false;
+    }
+
+    static bool bind_condition_fields(
+        const ConditionNode& condition,
+        const sensor_msgs::PointCloud2& cloud,
+        std::map<std::string, const sensor_msgs::PointField*>& fields,
+        std::string& missing_field) {
+        if (condition.type == ConditionType::COMPARISON) {
+            const auto& name = condition.comparison.field;
+            if (name == "range" || fields.count(name) != 0) return true;
+            const auto* field = find_predicate_field(cloud, name);
+            if (!usable_scalar_field(cloud, field)) {
+                missing_field = name;
+                return false;
+            }
+            fields[name] = field;
+            return true;
+        }
+        for (const auto& child : condition.children) {
+            if (!bind_condition_fields(child, cloud, fields,
+                                       missing_field)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool condition_matches(
+        const ConditionNode& condition, double range, const uint8_t* point,
+        const sensor_msgs::PointCloud2& cloud,
+        const std::map<std::string,
+                       const sensor_msgs::PointField*>& fields) {
+        if (condition.type == ConditionType::COMPARISON) {
+            const auto& predicate = condition.comparison;
+            double value = range;
+            if (predicate.field != "range") {
+                const auto* field = fields.at(predicate.field);
+                value =
+                    read_scalar(point + field->offset, field->datatype,
+                                cloud.is_bigendian);
+            }
+            return compare(value, predicate);
+        }
+        if (condition.type == ConditionType::AND) {
+            for (const auto& child : condition.children) {
+                if (!condition_matches(child, range, point, cloud,
+                                       fields)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        for (const auto& child : condition.children) {
+            if (condition_matches(child, range, point, cloud, fields)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static void apply_sparse_rule(
+        const sensor_msgs::PointCloud2& cloud,
+        const std::vector<float>& ranges,
+        const std::vector<uint8_t>& candidates, const FilterRule& rule,
+        std::vector<uint8_t>& cull, bool& any_culled) {
+        const int half_width = rule.sparse.kernel_width / 2;
+        const int half_height = rule.sparse.kernel_height / 2;
+
+        for (uint32_t row = 0; row < cloud.height; ++row) {
+            for (uint32_t col = 0; col < cloud.width; ++col) {
+                const size_t index = linear_index(cloud, row, col);
+                if (!candidates[index]) continue;
+
+                int neighbor_count = 0;
+                for (int shift_x = -half_width; shift_x <= half_width;
+                     ++shift_x) {
+                    for (int shift_y = -half_height;
+                         shift_y <= half_height; ++shift_y) {
+                        const int neighbor_row =
+                            static_cast<int>(row) - shift_y;
+                        if (neighbor_row < 0 ||
+                            neighbor_row >= static_cast<int>(cloud.height)) {
+                            continue;
+                        }
+                        int neighbor_col =
+                            (static_cast<int>(col) - shift_x) %
+                            static_cast<int>(cloud.width);
+                        if (neighbor_col < 0) neighbor_col += cloud.width;
+
+                        const float neighbor_range = ranges[linear_index(
+                            cloud, static_cast<uint32_t>(neighbor_row),
+                            static_cast<uint32_t>(neighbor_col))];
+                        if (neighbor_range > 0.0f &&
+                            std::abs(neighbor_range - ranges[index]) <=
+                                rule.sparse.neighbor_distance_m) {
+                            ++neighbor_count;
+                        }
+                    }
+                }
+
+                if (neighbor_count < rule.sparse.min_neighbors) {
+                    cull[index] = 1;
+                    any_culled = true;
+                }
+            }
+        }
+    }
+
+    static const sensor_msgs::PointField* find_predicate_field(
+        const sensor_msgs::PointCloud2& cloud, const std::string& name) {
+        const auto* field = find_field(cloud, name);
+        if (!field && name == "signal") {
+            field = find_field(cloud, "intensity");
+        }
+        return field;
+    }
+
     static const sensor_msgs::PointField* find_field(
         const sensor_msgs::PointCloud2& cloud, const std::string& name) {
         const auto it = std::find_if(

--- a/src/sparse_neighbor_culling_filter.h
+++ b/src/sparse_neighbor_culling_filter.h
@@ -1,0 +1,348 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file sparse_neighbor_culling_filter.h
+ * @brief Sparse-neighbor culling for organized ROS PointCloud2 messages.
+ */
+
+#pragma once
+
+#include <ros/console.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/PointField.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ouster_ros {
+
+struct SparseNeighborCullingConfig {
+    bool enabled;
+    int spatial_min_neighbors;
+    int spatial_kernel_height;
+    int spatial_kernel_width;
+    double max_culling_range_m;
+    double neighbor_distance_m;
+    bool use_filter_field;
+    std::string filter_field;
+    double filter_threshold;
+    bool keep_organized;
+};
+
+/**
+ * Byte-layout-preserving port of the Python sparse noise culler. It changes
+ * only XYZ values for organized output, or removes complete point records for
+ * compact output.
+ */
+class SparseNeighborCullingFilter {
+   public:
+    explicit SparseNeighborCullingFilter(SparseNeighborCullingConfig config)
+        : config_{std::move(config)} {}
+
+    void filter(sensor_msgs::PointCloud2& cloud) const {
+        if (!config_.enabled) return;
+
+        if (cloud.height <= 1) {
+            ROS_WARN_THROTTLE(
+                5.0,
+                "Input PointCloud2 is not organized (height <= 1). Sparse "
+                "image-based culling needs an organized cloud.");
+            return;
+        }
+
+        const auto* x_field = find_field(cloud, "x");
+        const auto* y_field = find_field(cloud, "y");
+        const auto* z_field = find_field(cloud, "z");
+        if (!usable_xyz_field(cloud, x_field) ||
+            !usable_xyz_field(cloud, y_field) ||
+            !usable_xyz_field(cloud, z_field)) {
+            ROS_WARN_THROTTLE(
+                5.0,
+                "Input PointCloud2 must contain usable scalar floating-point "
+                "x, y, z fields. Publishing unmodified cloud.");
+            return;
+        }
+
+        const uint64_t required_size =
+            static_cast<uint64_t>(cloud.row_step) * cloud.height;
+        const uint64_t minimum_row_size =
+            static_cast<uint64_t>(cloud.point_step) * cloud.width;
+        if (cloud.data.size() < required_size ||
+            cloud.row_step < minimum_row_size) {
+            ROS_WARN_THROTTLE(
+                5.0,
+                "PointCloud2 data buffer or row_step is too small. Publishing "
+                "unmodified cloud.");
+            return;
+        }
+
+        const sensor_msgs::PointField* filter_field = nullptr;
+        if (config_.use_filter_field) {
+            filter_field = find_field(cloud, config_.filter_field);
+            if (!usable_scalar_field(cloud, filter_field)) {
+                ROS_WARN_THROTTLE(
+                    5.0,
+                    "Input PointCloud2 does not contain a usable '%s' field. "
+                    "Publishing unmodified cloud.",
+                    config_.filter_field.c_str());
+                return;
+            }
+        }
+
+        const size_t point_count =
+            static_cast<size_t>(cloud.height) * cloud.width;
+        std::vector<float> ranges(point_count, 0.0f);
+        std::vector<uint8_t> candidates(point_count, 0);
+        bool any_candidate = false;
+
+        for (uint32_t row = 0; row < cloud.height; ++row) {
+            for (uint32_t col = 0; col < cloud.width; ++col) {
+                const size_t index = linear_index(cloud, row, col);
+                const uint8_t* point = point_data(cloud, row, col);
+                const double x = read_scalar(point + x_field->offset,
+                                             x_field->datatype,
+                                             cloud.is_bigendian);
+                const double y = read_scalar(point + y_field->offset,
+                                             y_field->datatype,
+                                             cloud.is_bigendian);
+                const double z = read_scalar(point + z_field->offset,
+                                             z_field->datatype,
+                                             cloud.is_bigendian);
+                if (!std::isfinite(x) || !std::isfinite(y) ||
+                    !std::isfinite(z)) {
+                    continue;
+                }
+
+                const float range = static_cast<float>(
+                    std::sqrt(x * x + y * y + z * z));
+                ranges[index] = range;
+                bool candidate =
+                    range > 0.0f && range < config_.max_culling_range_m;
+                if (candidate && filter_field) {
+                    const double value =
+                        read_scalar(point + filter_field->offset,
+                                    filter_field->datatype,
+                                    cloud.is_bigendian);
+                    candidate = std::isfinite(value) &&
+                                value < config_.filter_threshold;
+                }
+                candidates[index] = candidate;
+                any_candidate = any_candidate || candidate;
+            }
+        }
+
+        if (!any_candidate) return;
+
+        std::vector<uint8_t> cull(point_count, 0);
+        bool any_culled = false;
+        const int half_width = config_.spatial_kernel_width / 2;
+        const int half_height = config_.spatial_kernel_height / 2;
+
+        for (uint32_t row = 0; row < cloud.height; ++row) {
+            for (uint32_t col = 0; col < cloud.width; ++col) {
+                const size_t index = linear_index(cloud, row, col);
+                if (!candidates[index]) continue;
+
+                uint8_t neighbor_count = 0;
+                for (int shift_x = -half_width; shift_x <= half_width;
+                     ++shift_x) {
+                    for (int shift_y = -half_height;
+                         shift_y <= half_height; ++shift_y) {
+                        const int neighbor_row =
+                            static_cast<int>(row) - shift_y;
+                        if (neighbor_row < 0 ||
+                            neighbor_row >= static_cast<int>(cloud.height)) {
+                            continue;
+                        }
+                        int neighbor_col =
+                            (static_cast<int>(col) - shift_x) %
+                            static_cast<int>(cloud.width);
+                        if (neighbor_col < 0) neighbor_col += cloud.width;
+
+                        const float neighbor_range = ranges[linear_index(
+                            cloud, static_cast<uint32_t>(neighbor_row),
+                            static_cast<uint32_t>(neighbor_col))];
+                        if (neighbor_range > 0.0f &&
+                            std::abs(neighbor_range - ranges[index]) <=
+                                config_.neighbor_distance_m) {
+                            ++neighbor_count;
+                        }
+                    }
+                }
+
+                if (neighbor_count < config_.spatial_min_neighbors) {
+                    cull[index] = 1;
+                    any_culled = true;
+                }
+            }
+        }
+
+        if (!any_culled) return;
+
+        if (config_.keep_organized) {
+            for (uint32_t row = 0; row < cloud.height; ++row) {
+                for (uint32_t col = 0; col < cloud.width; ++col) {
+                    if (!cull[linear_index(cloud, row, col)]) continue;
+                    uint8_t* point = point_data(cloud, row, col);
+                    write_nan(point + x_field->offset, x_field->datatype,
+                              cloud.is_bigendian);
+                    write_nan(point + y_field->offset, y_field->datatype,
+                              cloud.is_bigendian);
+                    write_nan(point + z_field->offset, z_field->datatype,
+                              cloud.is_bigendian);
+                }
+            }
+        } else {
+            std::vector<uint8_t> compacted;
+            compacted.reserve(point_count * cloud.point_step);
+            for (uint32_t row = 0; row < cloud.height; ++row) {
+                for (uint32_t col = 0; col < cloud.width; ++col) {
+                    if (cull[linear_index(cloud, row, col)]) continue;
+                    const uint8_t* point = point_data(cloud, row, col);
+                    compacted.insert(compacted.end(), point,
+                                     point + cloud.point_step);
+                }
+            }
+            cloud.height = 1;
+            cloud.width =
+                static_cast<uint32_t>(compacted.size() / cloud.point_step);
+            cloud.row_step = cloud.width * cloud.point_step;
+            cloud.data = std::move(compacted);
+        }
+        cloud.is_dense = false;
+    }
+
+   private:
+    static const sensor_msgs::PointField* find_field(
+        const sensor_msgs::PointCloud2& cloud, const std::string& name) {
+        const auto it = std::find_if(
+            cloud.fields.begin(), cloud.fields.end(),
+            [&name](const sensor_msgs::PointField& field) {
+                return field.name == name;
+            });
+        return it == cloud.fields.end() ? nullptr : &*it;
+    }
+
+    static size_t datatype_size(uint8_t datatype) {
+        switch (datatype) {
+            case sensor_msgs::PointField::INT8:
+            case sensor_msgs::PointField::UINT8:
+                return 1;
+            case sensor_msgs::PointField::INT16:
+            case sensor_msgs::PointField::UINT16:
+                return 2;
+            case sensor_msgs::PointField::INT32:
+            case sensor_msgs::PointField::UINT32:
+            case sensor_msgs::PointField::FLOAT32:
+                return 4;
+            case sensor_msgs::PointField::FLOAT64:
+                return 8;
+            default:
+                return 0;
+        }
+    }
+
+    static bool usable_scalar_field(
+        const sensor_msgs::PointCloud2& cloud,
+        const sensor_msgs::PointField* field) {
+        if (!field || field->count != 1) return false;
+        const size_t size = datatype_size(field->datatype);
+        return size != 0 &&
+               static_cast<uint64_t>(field->offset) + size <= cloud.point_step;
+    }
+
+    static bool usable_xyz_field(const sensor_msgs::PointCloud2& cloud,
+                                 const sensor_msgs::PointField* field) {
+        return usable_scalar_field(cloud, field) &&
+               (field->datatype == sensor_msgs::PointField::FLOAT32 ||
+                field->datatype == sensor_msgs::PointField::FLOAT64);
+    }
+
+    static size_t linear_index(const sensor_msgs::PointCloud2& cloud,
+                               uint32_t row, uint32_t col) {
+        return static_cast<size_t>(row) * cloud.width + col;
+    }
+
+    static const uint8_t* point_data(const sensor_msgs::PointCloud2& cloud,
+                                     uint32_t row, uint32_t col) {
+        return cloud.data.data() + static_cast<size_t>(row) * cloud.row_step +
+               static_cast<size_t>(col) * cloud.point_step;
+    }
+
+    static uint8_t* point_data(sensor_msgs::PointCloud2& cloud, uint32_t row,
+                               uint32_t col) {
+        return cloud.data.data() + static_cast<size_t>(row) * cloud.row_step +
+               static_cast<size_t>(col) * cloud.point_step;
+    }
+
+    static bool host_is_bigendian() {
+        const uint16_t value = 0x0102;
+        return *reinterpret_cast<const uint8_t*>(&value) == 0x01;
+    }
+
+    template <typename T>
+    static T load_value(const uint8_t* data, bool is_bigendian) {
+        T value;
+        std::memcpy(&value, data, sizeof(T));
+        if (is_bigendian != host_is_bigendian()) {
+            auto* bytes = reinterpret_cast<uint8_t*>(&value);
+            std::reverse(bytes, bytes + sizeof(T));
+        }
+        return value;
+    }
+
+    template <typename T>
+    static void store_value(uint8_t* data, T value, bool is_bigendian) {
+        if (is_bigendian != host_is_bigendian()) {
+            auto* bytes = reinterpret_cast<uint8_t*>(&value);
+            std::reverse(bytes, bytes + sizeof(T));
+        }
+        std::memcpy(data, &value, sizeof(T));
+    }
+
+    static double read_scalar(const uint8_t* data, uint8_t datatype,
+                              bool is_bigendian) {
+        switch (datatype) {
+            case sensor_msgs::PointField::INT8:
+                return load_value<int8_t>(data, is_bigendian);
+            case sensor_msgs::PointField::UINT8:
+                return load_value<uint8_t>(data, is_bigendian);
+            case sensor_msgs::PointField::INT16:
+                return load_value<int16_t>(data, is_bigendian);
+            case sensor_msgs::PointField::UINT16:
+                return load_value<uint16_t>(data, is_bigendian);
+            case sensor_msgs::PointField::INT32:
+                return load_value<int32_t>(data, is_bigendian);
+            case sensor_msgs::PointField::UINT32:
+                return load_value<uint32_t>(data, is_bigendian);
+            case sensor_msgs::PointField::FLOAT32:
+                return load_value<float>(data, is_bigendian);
+            case sensor_msgs::PointField::FLOAT64:
+                return load_value<double>(data, is_bigendian);
+            default:
+                return std::numeric_limits<double>::quiet_NaN();
+        }
+    }
+
+    static void write_nan(uint8_t* data, uint8_t datatype,
+                          bool is_bigendian) {
+        if (datatype == sensor_msgs::PointField::FLOAT32) {
+            store_value(data, std::numeric_limits<float>::quiet_NaN(),
+                        is_bigendian);
+        } else {
+            store_value(data, std::numeric_limits<double>::quiet_NaN(),
+                        is_bigendian);
+        }
+    }
+
+    SparseNeighborCullingConfig config_;
+};
+
+}  // namespace ouster_ros


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes

- Adds a configurable multi-rule point filter supporting:
    - direct removal rules and sparse-neighbor culling rules.
- New example config: config/multi_rule_filter.yaml.
- New implementation headers: src/sparse_neighbor_culling_config.h, src/sparse_neighbor_culling_filter.h.
- Nodelet integration: load config and apply filter in src/os_cloud_nodelet.cpp and src/os_driver_nodelet.cpp.
- Launch updates: add filter_rules_file arg to common, driver, sensor, replay, record, replay_pcap, sensor_mtp launches.
- Docs and build: README.md updated with usage; CMakeLists adjusted for macOS PCAP linking.

## Validation
