### PR TITLE
Prototype using OusterSLAM within ouster-ros

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -15,11 +15,15 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(ouster_sensor_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common)
+# 'filters' is needed for pcl::VoxelGrid, used by the SLAM map processor
+# (BUILD_MAPPING); libpcl-all-dev (an existing build dependency) already
+# ships it, so this doesn't add a new system dependency.
+find_package(PCL REQUIRED COMPONENTS common filters)
 find_package(pcl_conversions REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -84,11 +88,22 @@ set(BUILD_SHARED_LIBS OFF)
 
 option(BUILD_VIZ "Turn off building VIZ" OFF)
 option(BUILD_PCAP "Turn off building PCAP" OFF)
-option(BUILD_OSF "Turn off building OSF" OFF)
 option(BUILD_MAPPING "Turn off building MAPPING" OFF)
+# ouster_mapping (the SLAM engine) unconditionally links OusterSDK::ouster_osf.
+if(BUILD_MAPPING)
+  set(BUILD_OSF ON CACHE BOOL "Turn off building OSF" FORCE)
+else()
+  option(BUILD_OSF "Turn off building OSF" OFF)
+endif()
 find_package(OusterSDK REQUIRED)
 
 set(BUILD_SHARED_LIBS ${_SAVE_BUILD_SHARED_LIBS})
+
+if(BUILD_MAPPING)
+  # pulls in ouster/slam_engine.h et al. for the SLAM LidarScanProcessor
+  # (src/slam_processor.h), wired into os_cloud when proc_mask contains SLAM.
+  include_directories(ouster-sdk/ouster_mapping/include)
+endif()
 
 # catkin adds all include dirs to a single variable, don't try to use targets
 include_directories(
@@ -187,12 +202,19 @@ rclcpp_components_register_node(os_replay_component
 # ==== os_cloud_component ====
 create_ros2_component(os_cloud_component
   "src/os_processing_node_base.cpp;src/os_cloud_node.cpp"
-  "tf2_ros"
+  "tf2_ros;nav_msgs"
 )
 rclcpp_components_register_node(os_cloud_component
   PLUGIN "ouster_ros::OusterCloud"
   EXECUTABLE os_cloud
 )
+if(BUILD_MAPPING)
+  # enables os_cloud_node.cpp's "SLAM" proc_mask token (src/slam_processor.h):
+  # lidar odometry, trajectory and an accumulated/downsampled map via the
+  # ouster-sdk SLAMEngine.
+  target_compile_definitions(os_cloud_component PRIVATE OUSTER_ROS_BUILD_MAPPING)
+  target_link_libraries(os_cloud_component OusterSDK::ouster_mapping pcl_filters)
+endif()
 
 # ==== os_image_component ====
 create_ros2_component(os_image_component

--- a/ouster-ros/config/driver_params.yaml
+++ b/ouster-ros/config/driver_params.yaml
@@ -92,8 +92,11 @@ ouster/os_driver:
     # broadcast the TF transforms for the imu/sensor/lidar frames. Prevent the
     # driver from broadcasting TF transforms by setting this parameter to False.
     pub_static_tf: true
-    # proc_mask[optional]: use any combination of the 6 flags IMG, PCL, IMU, SCAN
-    # RAW and TLM to enable or disable their respective messages.
+    # proc_mask[optional]: use any combination of the flags IMG, PCL, IMU, SCAN,
+    # RAW, TLM and SLAM to enable or disable their respective messages. SLAM
+    # requires the driver to have been built with -DBUILD_MAPPING=ON (off by
+    # default) and is not included by default below; see the slam_* and
+    # odom_frame/publish_slam_tf params further down.
     proc_mask: IMU|PCL|SCAN|IMG|RAW|TLM
     # scan_ring[optional]: use this parameter in conjunction with the SCAN flag
     # to select which beam of the LidarScan to use when producing the LaserScan
@@ -185,6 +188,35 @@ ouster/os_driver:
     # mask_path[optional]: path to an image file that will be used to mask parts of the
     # pointcloud.
     mask_path: ''
+    # the following slam_*/odom_frame/publish_slam_tf params only take effect when
+    # proc_mask includes SLAM and the driver was built with -DBUILD_MAPPING=ON.
+    # They feed the ouster-sdk SLAMEngine (kiss backend) to publish lidar
+    # odometry (odom topic), a trajectory path (trajectory topic) and a
+    # downsampled, accumulated map point cloud (map topic).
+    #
+    # odom_frame[optional]: fixed reference frame the odom/trajectory/map
+    # topics and the SLAM TF transform are published in.
+    odom_frame: odom
+    # publish_slam_tf[optional]: broadcast a TF transform from odom_frame to
+    # sensor_frame for every estimated pose.
+    publish_slam_tf: true
+    # slam_min_range/slam_max_range[optional]: range gate (meters) applied to
+    # points used for SLAM registration and map accumulation. Independent of
+    # the PCL processor's own min_range/max_range above.
+    slam_min_range: 0.5
+    slam_max_range: 75.0
+    # slam_voxel_size[optional]: voxel size (meters) used internally by the
+    # SLAM backend for registration; 0.0 lets it auto-estimate from the data.
+    slam_voxel_size: 0.0
+    # slam_deskew_method[optional]: motion-compensation method used by the
+    # SLAM backend; 'auto' lets it choose automatically.
+    slam_deskew_method: auto
+    # slam_map_voxel_size[optional]: leaf size (meters) of the VoxelGrid filter
+    # used to downsample the accumulated map published on the map topic.
+    slam_map_voxel_size: 0.2
+    # slam_map_publish_every_n[optional]: only accumulate/republish the map
+    # every Nth processed scan, to bound the cost of the VoxelGrid filter.
+    slam_map_publish_every_n: 1
     # nmea_in_polarity[optional]: polarity for NMEA UART input; possible values:
     # - ACTIVE_HIGH
     # - ACTIVE_LOW

--- a/ouster-ros/config/viz-reliable.rviz
+++ b/ouster-ros/config/viz-reliable.rviz
@@ -13,6 +13,9 @@ Panels:
         - /nearir1/Topic1
         - /reflec1
         - /signal1
+        - /Odometry1
+        - /Trajectory1
+        - /Map1
       Splitter Ratio: 0.5
     Tree Height: 1185
   - Class: rviz_common/Selection
@@ -167,6 +170,105 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /ouster/signal_image
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz_default_plugins/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 100
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ouster/odom
+      Value: true
+    - Class: rviz_default_plugins/Path
+      Color: 255; 0; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Trajectory
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic:
+        Depth: 1
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ouster/trajectory
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: AxisColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Map
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 2
+      Size (m): 0.05000000074505806
+      Style: Points
+      Topic:
+        Depth: 1
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ouster/map
+      Use Fixed Frame: true
+      Use rainbow: true
       Value: true
   Enabled: true
   Global Options:

--- a/ouster-ros/config/viz.rviz
+++ b/ouster-ros/config/viz.rviz
@@ -15,6 +15,9 @@ Panels:
         - /signal1
         - /LaserScan1
         - /LaserScan1/Topic1
+        - /Odometry1
+        - /Trajectory1
+        - /Map1
       Splitter Ratio: 0.626074492931366
     Tree Height: 1185
   - Class: rviz_common/Selection
@@ -201,6 +204,105 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Best Effort
         Value: /ouster/scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz_default_plugins/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 100
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /ouster/odom
+      Value: true
+    - Class: rviz_default_plugins/Path
+      Color: 255; 0; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Trajectory
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic:
+        Depth: 1
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ouster/trajectory
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: AxisColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Map
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 2
+      Size (m): 0.05000000074505806
+      Style: Points
+      Topic:
+        Depth: 1
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /ouster/map
       Use Fixed Frame: true
       Use rainbow: true
       Value: true

--- a/ouster-ros/launch/record.composite.launch.xml
+++ b/ouster-ros/launch/record.composite.launch.xml
@@ -199,6 +199,31 @@
   <arg name="mask_path" default="" description="path to an image file that will be used to
    mask parts of the pointcloud}"/>
 
+  <!-- the following slam_*/odom_frame/publish_slam_tf args only take effect
+       when proc_mask includes SLAM and ouster_ros was built with
+       -DBUILD_MAPPING=ON; they feed the ouster-sdk SLAMEngine to publish
+       lidar odometry, a trajectory path and an accumulated map -->
+  <arg name="odom_frame" default="odom" description="fixed reference frame
+    the SLAM odom/trajectory/map topics and TF transform are published in"/>
+  <arg name="publish_slam_tf" default="true" description="broadcast a TF
+    transform from odom_frame to sensor_frame for every SLAM pose"/>
+  <arg name="slam_min_range" default="0.5" description="range gate (meters)
+    applied to points used for SLAM registration and map accumulation"/>
+  <arg name="slam_max_range" default="75.0" description="range gate (meters)
+    applied to points used for SLAM registration and map accumulation"/>
+  <arg name="slam_voxel_size" default="0.0" description="voxel size (meters)
+    used internally by the SLAM backend for registration; 0.0 lets it
+    auto-estimate from the data"/>
+  <arg name="slam_deskew_method" default="auto" description="motion-
+    compensation method used by the SLAM backend; 'auto' lets it choose
+    automatically"/>
+  <arg name="slam_map_voxel_size" default="0.2" description="leaf size
+    (meters) of the VoxelGrid filter used to downsample the accumulated map
+    published on the map topic"/>
+  <arg name="slam_map_publish_every_n" default="1" description="only
+    accumulate/republish the map every Nth processed scan, to bound the
+    cost of the VoxelGrid filter"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="os_container" output="screen" namespace="">
@@ -255,6 +280,14 @@
         <param name="v_reduction" value="$(var v_reduction)"/>
         <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
+        <param name="odom_frame" value="$(var odom_frame)"/>
+        <param name="publish_slam_tf" value="$(var publish_slam_tf)"/>
+        <param name="slam_min_range" value="$(var slam_min_range)"/>
+        <param name="slam_max_range" value="$(var slam_max_range)"/>
+        <param name="slam_voxel_size" value="$(var slam_voxel_size)"/>
+        <param name="slam_deskew_method" value="$(var slam_deskew_method)"/>
+        <param name="slam_map_voxel_size" value="$(var slam_map_voxel_size)"/>
+        <param name="slam_map_publish_every_n" value="$(var slam_map_publish_every_n)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/launch/replay.composite.launch.xml
+++ b/ouster-ros/launch/replay.composite.launch.xml
@@ -89,6 +89,31 @@
   <arg name="mask_path" default="" description="path to an image file that will be used to
    mask parts of the pointcloud}"/>
 
+  <!-- the following slam_*/odom_frame/publish_slam_tf args only take effect
+       when proc_mask includes SLAM and ouster_ros was built with
+       -DBUILD_MAPPING=ON; they feed the ouster-sdk SLAMEngine to publish
+       lidar odometry, a trajectory path and an accumulated map -->
+  <arg name="odom_frame" default="odom" description="fixed reference frame
+    the SLAM odom/trajectory/map topics and TF transform are published in"/>
+  <arg name="publish_slam_tf" default="true" description="broadcast a TF
+    transform from odom_frame to sensor_frame for every SLAM pose"/>
+  <arg name="slam_min_range" default="0.5" description="range gate (meters)
+    applied to points used for SLAM registration and map accumulation"/>
+  <arg name="slam_max_range" default="75.0" description="range gate (meters)
+    applied to points used for SLAM registration and map accumulation"/>
+  <arg name="slam_voxel_size" default="0.0" description="voxel size (meters)
+    used internally by the SLAM backend for registration; 0.0 lets it
+    auto-estimate from the data"/>
+  <arg name="slam_deskew_method" default="auto" description="motion-
+    compensation method used by the SLAM backend; 'auto' lets it choose
+    automatically"/>
+  <arg name="slam_map_voxel_size" default="0.2" description="leaf size
+    (meters) of the VoxelGrid filter used to downsample the accumulated map
+    published on the map topic"/>
+  <arg name="slam_map_publish_every_n" default="1" description="only
+    accumulate/republish the map every Nth processed scan, to bound the
+    cost of the VoxelGrid filter"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_replay" name="os_replay" output="screen">
@@ -115,6 +140,14 @@
         <param name="v_reduction" value="$(var v_reduction)"/>
         <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
+        <param name="odom_frame" value="$(var odom_frame)"/>
+        <param name="publish_slam_tf" value="$(var publish_slam_tf)"/>
+        <param name="slam_min_range" value="$(var slam_min_range)"/>
+        <param name="slam_max_range" value="$(var slam_max_range)"/>
+        <param name="slam_voxel_size" value="$(var slam_voxel_size)"/>
+        <param name="slam_deskew_method" value="$(var slam_deskew_method)"/>
+        <param name="slam_map_voxel_size" value="$(var slam_map_voxel_size)"/>
+        <param name="slam_map_publish_every_n" value="$(var slam_map_publish_every_n)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/launch/replay_pcap.launch.xml
+++ b/ouster-ros/launch/replay_pcap.launch.xml
@@ -85,6 +85,31 @@
   <arg name="mask_path" default="" description="path to an image file that will be used to
    mask parts of the pointcloud}"/>
 
+  <!-- the following slam_*/odom_frame/publish_slam_tf args only take effect
+       when proc_mask includes SLAM and ouster_ros was built with
+       -DBUILD_MAPPING=ON; they feed the ouster-sdk SLAMEngine to publish
+       lidar odometry, a trajectory path and an accumulated map -->
+  <arg name="odom_frame" default="odom" description="fixed reference frame
+    the SLAM odom/trajectory/map topics and TF transform are published in"/>
+  <arg name="publish_slam_tf" default="true" description="broadcast a TF
+    transform from odom_frame to sensor_frame for every SLAM pose"/>
+  <arg name="slam_min_range" default="0.5" description="range gate (meters)
+    applied to points used for SLAM registration and map accumulation"/>
+  <arg name="slam_max_range" default="75.0" description="range gate (meters)
+    applied to points used for SLAM registration and map accumulation"/>
+  <arg name="slam_voxel_size" default="0.0" description="voxel size (meters)
+    used internally by the SLAM backend for registration; 0.0 lets it
+    auto-estimate from the data"/>
+  <arg name="slam_deskew_method" default="auto" description="motion-
+    compensation method used by the SLAM backend; 'auto' lets it choose
+    automatically"/>
+  <arg name="slam_map_voxel_size" default="0.2" description="leaf size
+    (meters) of the VoxelGrid filter used to downsample the accumulated map
+    published on the map topic"/>
+  <arg name="slam_map_publish_every_n" default="1" description="only
+    accumulate/republish the map every Nth processed scan, to bound the
+    cost of the VoxelGrid filter"/>
+
   <group>
     <push-ros-namespace namespace="$(var ouster_ns)"/>
     <node if="$(var _use_metadata_file)" pkg="ouster_ros" exec="os_pcap" name="os_pcap"
@@ -115,6 +140,14 @@
         <param name="v_reduction" value="$(var v_reduction)"/>
         <param name="mask_path" value="$(var mask_path)"/>
         <param name="min_scan_valid_columns_ratio" value="$(var min_scan_valid_columns_ratio)"/>
+        <param name="odom_frame" value="$(var odom_frame)"/>
+        <param name="publish_slam_tf" value="$(var publish_slam_tf)"/>
+        <param name="slam_min_range" value="$(var slam_min_range)"/>
+        <param name="slam_max_range" value="$(var slam_max_range)"/>
+        <param name="slam_voxel_size" value="$(var slam_voxel_size)"/>
+        <param name="slam_deskew_method" value="$(var slam_deskew_method)"/>
+        <param name="slam_map_voxel_size" value="$(var slam_map_voxel_size)"/>
+        <param name="slam_map_publish_every_n" value="$(var slam_map_publish_every_n)"/>
       </composable_node>
       <composable_node pkg="ouster_ros" plugin="ouster_ros::OusterImage" name="os_image">
         <param name="use_system_default_qos" value="$(var use_system_default_qos)"/>

--- a/ouster-ros/package.xml
+++ b/ouster-ros/package.xml
@@ -18,6 +18,7 @@
   <depend>ouster_sensor_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
   <depend>pcl_conversions</depend>
@@ -31,6 +32,14 @@
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>libtins-dev</build_depend>
   <build_depend>libzip-dev</build_depend>
+
+  <!-- only needed when building with -DBUILD_MAPPING=ON, which enables the
+       SLAM LidarScanProcessor (src/slam_processor.h, proc_mask=SLAM) -->
+  <build_depend>libceres-dev</build_depend>
+  <build_depend>libflatbuffers-dev</build_depend>
+  <build_depend>libpng-dev</build_depend>
+  <build_depend>zlib1g-dev</build_depend>
+  <build_depend>robin-map-dev</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>launch</exec_depend>

--- a/ouster-ros/src/os_cloud_node.cpp
+++ b/ouster-ros/src/os_cloud_node.cpp
@@ -26,6 +26,12 @@
 #include "laser_scan_processor.h"
 #include "point_cloud_processor_factory.h"
 #include "telemetry_handler.h"
+#ifdef OUSTER_ROS_BUILD_MAPPING
+#include "slam_processor.h"
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <tf2_ros/transform_broadcaster.h>
+#endif
 
 namespace ouster_ros {
 
@@ -69,10 +75,26 @@ class OusterCloud : public OusterProcessingNodeBase {
         declare_parameter("v_reduction", 1);
         declare_parameter("min_scan_valid_columns_ratio", 0.0);
         declare_parameter("mask_path", "");
+#ifdef OUSTER_ROS_BUILD_MAPPING
+        declare_parameter("odom_frame", "odom");
+        declare_parameter("publish_slam_tf", true);
+        declare_parameter("slam_min_range", 0.5);
+        declare_parameter("slam_max_range", 75.0);
+        declare_parameter("slam_voxel_size", 0.0);
+        declare_parameter("slam_deskew_method", "auto");
+        declare_parameter("slam_map_voxel_size", 0.2);
+        declare_parameter("slam_map_publish_every_n", 1);
+#endif
     }
 
     void metadata_handler(
         const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
+        if (metadata_msg->data.empty()) {
+            RCLCPP_WARN(get_logger(),
+                        "OusterCloud: received empty sensor metadata, "
+                        "ignoring");
+            return;
+        }
         RCLCPP_INFO(get_logger(),
                     "OusterCloud: retrieved new sensor metadata!");
         info = ouster::sdk::core::SensorInfo(metadata_msg->data);
@@ -215,7 +237,64 @@ class OusterCloud : public OusterProcessingNodeBase {
                 }));
         }
 
-        if (impl::check_token(tokens, "PCL") || impl::check_token(tokens, "SCAN")) {
+#ifdef OUSTER_ROS_BUILD_MAPPING
+        if (impl::check_token(tokens, "SLAM")) {
+            odom_pub = create_publisher<nav_msgs::msg::Odometry>(
+                "odom", selected_qos);
+            trajectory_pub = create_publisher<nav_msgs::msg::Path>(
+                "trajectory", rclcpp::QoS(rclcpp::KeepLast(1)));
+            map_pub = create_publisher<sensor_msgs::msg::PointCloud2>(
+                "map", rclcpp::QoS(rclcpp::KeepLast(1)));
+
+            auto odom_frame = get_parameter("odom_frame").as_string();
+            auto publish_slam_tf = get_parameter("publish_slam_tf").as_bool();
+            auto slam_min_range = get_parameter("slam_min_range").as_double();
+            auto slam_max_range = get_parameter("slam_max_range").as_double();
+            auto slam_voxel_size = get_parameter("slam_voxel_size").as_double();
+            auto slam_deskew_method =
+                get_parameter("slam_deskew_method").as_string();
+            auto slam_map_voxel_size =
+                get_parameter("slam_map_voxel_size").as_double();
+            auto slam_map_publish_every_n = static_cast<int>(
+                get_parameter("slam_map_publish_every_n").as_int());
+
+            if (publish_slam_tf && !slam_tf_bcast) {
+                slam_tf_bcast =
+                    std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+            }
+
+            processors.push_back(SlamProcessor::create(
+                info, odom_frame, tf_bcast.sensor_frame_id(), slam_min_range,
+                slam_max_range, slam_voxel_size, slam_deskew_method,
+                slam_map_voxel_size, slam_map_publish_every_n,
+                [this, publish_slam_tf](SlamProcessor::OutputType output) {
+                    odom_pub->publish(*output.odom);
+                    trajectory_pub->publish(*output.trajectory);
+                    if (output.map) map_pub->publish(*output.map);
+                    if (publish_slam_tf) {
+                        geometry_msgs::msg::TransformStamped tf_msg;
+                        tf_msg.header = output.odom->header;
+                        tf_msg.child_frame_id = output.odom->child_frame_id;
+                        tf_msg.transform.translation.x =
+                            output.odom->pose.pose.position.x;
+                        tf_msg.transform.translation.y =
+                            output.odom->pose.pose.position.y;
+                        tf_msg.transform.translation.z =
+                            output.odom->pose.pose.position.z;
+                        tf_msg.transform.rotation =
+                            output.odom->pose.pose.orientation;
+                        slam_tf_bcast->sendTransform(tf_msg);
+                    }
+                }));
+        }
+#endif
+
+        if (impl::check_token(tokens, "PCL") ||
+            impl::check_token(tokens, "SCAN")
+#ifdef OUSTER_ROS_BUILD_MAPPING
+            || impl::check_token(tokens, "SLAM")
+#endif
+        ) {
             lidar_packet_handler = LidarPacketHandler::create(
                 info, processors, timestamp_mode,
                 static_cast<int64_t>(ptp_utc_tai_offset * 1e+9),
@@ -233,7 +312,11 @@ class OusterCloud : public OusterProcessingNodeBase {
 
         if (impl::check_token(tokens, "PCL") ||
             impl::check_token(tokens, "SCAN") ||
-            impl::check_token(tokens, "TLM")) {
+            impl::check_token(tokens, "TLM")
+#ifdef OUSTER_ROS_BUILD_MAPPING
+            || impl::check_token(tokens, "SLAM")
+#endif
+        ) {
             lidar_packet_sub = create_subscription<PacketMsg>(
                 "lidar_packets",
                 rclcpp::QoS(selected_qos).keep_last(lidar_packets_per_frame(info)),
@@ -274,6 +357,13 @@ class OusterCloud : public OusterProcessingNodeBase {
 
     rclcpp::Publisher<ouster_sensor_msgs::msg::Telemetry>::SharedPtr telemetry_pub;
     TelemetryHandler::HandlerType telemetry_handler;
+
+#ifdef OUSTER_ROS_BUILD_MAPPING
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub;
+    rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub;
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr map_pub;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> slam_tf_bcast;
+#endif
 };
 
 }  // namespace ouster_ros

--- a/ouster-ros/src/os_image_node.cpp
+++ b/ouster-ros/src/os_image_node.cpp
@@ -51,6 +51,12 @@ class OusterImage : public OusterProcessingNodeBase {
     }
 
     void metadata_handler(const std_msgs::msg::String::ConstSharedPtr& metadata_msg) {
+        if (metadata_msg->data.empty()) {
+            RCLCPP_WARN(get_logger(),
+                        "OusterImage: received empty sensor metadata, "
+                        "ignoring");
+            return;
+        }
         RCLCPP_INFO(get_logger(),
                     "OusterImage: retrieved new sensor metadata!");
         info = ouster::sdk::core::SensorInfo(metadata_msg->data);

--- a/ouster-ros/src/slam_processor.h
+++ b/ouster-ros/src/slam_processor.h
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) 2018-2025, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file slam_processor.h
+ * @brief takes in a lidar scan object, registers it with the ouster-sdk
+ * SLAMEngine and produces odometry, a trajectory path, and a downsampled,
+ * accumulated map point cloud.
+ */
+
+#pragma once
+
+// prevent clang-format from altering the location of "ouster_ros/os_ros.h",
+// the header file needs to be the first include due to PCL_NO_PRECOMPILE
+// clang-format off
+#include "ouster_ros/os_ros.h"
+// clang-format on
+
+#include <ouster/lidar_scan_set.h>
+#include <ouster/slam_engine.h>
+
+#include <pcl/filters/voxel_grid.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+
+#include "impl/cartesian.h"
+
+namespace ouster_ros {
+
+class SlamProcessor {
+   public:
+    struct OutputType {
+        std::shared_ptr<nav_msgs::msg::Odometry> odom;
+        std::shared_ptr<nav_msgs::msg::Path> trajectory;
+        // null unless the accumulated map was refreshed on this update
+        std::shared_ptr<sensor_msgs::msg::PointCloud2> map;
+    };
+    using PostProcessingFn = std::function<void(OutputType)>;
+
+   public:
+    SlamProcessor(const ouster::sdk::core::SensorInfo& info,
+                 const std::string& odom_frame_id,
+                 const std::string& child_frame_id, double min_range,
+                 double max_range, double voxel_size,
+                 const std::string& deskew_method, double map_voxel_size,
+                 int map_publish_every_n, PostProcessingFn func)
+        : odom_frame(odom_frame_id),
+          child_frame(child_frame_id),
+          min_range_mm(impl::ulround(min_range * 1000)),
+          max_range_mm(impl::ulround(max_range * 1000)),
+          map_publish_every_n_(std::max(1, map_publish_every_n)),
+          post_processing_fn(func),
+          sensor_info_(info) {
+        slam_config.backend = "kiss";
+        slam_config.deskew_method = deskew_method;
+        slam_config.min_range = min_range;
+        slam_config.max_range = max_range;
+        slam_config.voxel_size = voxel_size;
+        slam_engine = make_slam_engine();
+
+        // The SlamEngine (kiss backend) always registers scans and reports
+        // poses in the sensor's own extrinsics-applied frame (it builds its
+        // internal LUT via ouster::sdk::core::XYZLut(info, /*use_extrinsics=*/
+        // true), which unconditionally applies lidar_to_sensor_transform).
+        // Build our own LUT the exact same way so map points and poses line
+        // up in the same frame.
+        auto xyz_lut = ouster::sdk::core::make_xyz_lut(info, true);
+        lut_direction = xyz_lut.direction.cast<float>();
+        lut_offset = xyz_lut.offset.cast<float>();
+        points_buffer = ouster::sdk::core::PointCloudXYZf(
+            static_cast<int>(info.format.pixels_per_column *
+                             info.format.columns_per_frame),
+            3);
+
+        map_cloud.reset(new pcl::PointCloud<pcl::PointXYZ>());
+        voxel_filter.setLeafSize(static_cast<float>(map_voxel_size),
+                                 static_cast<float>(map_voxel_size),
+                                 static_cast<float>(map_voxel_size));
+
+        odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
+        odom_msg->header.frame_id = odom_frame;
+        odom_msg->child_frame_id = child_frame;
+
+        trajectory_msg = std::make_shared<nav_msgs::msg::Path>();
+        trajectory_msg->header.frame_id = odom_frame;
+
+        map_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    }
+
+   private:
+    std::unique_ptr<ouster::sdk::mapping::SlamEngine> make_slam_engine() {
+        return std::make_unique<ouster::sdk::mapping::SlamEngine>(
+            std::vector<std::shared_ptr<ouster::sdk::core::SensorInfo>>{
+                std::make_shared<ouster::sdk::core::SensorInfo>(
+                    sensor_info_)},
+            slam_config);
+    }
+
+    // A rosbag replay looping (or any other source of sensor time jumping
+    // backwards) means the next scan no longer follows on from whatever the
+    // SlamEngine and our own accumulated map/trajectory currently think is
+    // the last pose -- registering it against that stale state would at
+    // best corrupt the map, and has been observed to throw out of the
+    // engine's pose interpolation/deskewing outright. Start a fresh SLAM
+    // session instead.
+    void reset_for_new_session() {
+        RCLCPP_WARN(rclcpp::get_logger("os_cloud"),
+                    "SLAM: detected scan timestamps moving backwards (bag "
+                    "loop?); resetting odometry, trajectory and the "
+                    "accumulated map for a new session.");
+
+        slam_engine = make_slam_engine();
+        map_cloud.reset(new pcl::PointCloud<pcl::PointXYZ>());
+        trajectory_msg->poses.clear();
+        have_prev_pose = false;
+        scan_count = 0;
+    }
+
+    void process(const ouster::sdk::core::LidarScan& lidar_scan, uint64_t,
+                const rclcpp::Time&) {
+        const int raw_col = lidar_scan.get_last_valid_column();
+        if (raw_col >= 0) {
+            const uint64_t raw_ts = lidar_scan.timestamp()[raw_col];
+            if (have_last_scan_ts && raw_ts < last_scan_ts_ns) {
+                reset_for_new_session();
+            }
+            last_scan_ts_ns = raw_ts;
+            have_last_scan_ts = true;
+        }
+
+        // SlamEngine::update() mutates the scan in place (writes the
+        // estimated per-column poses back into it); copy it first so the
+        // original scan shared with the other processors (PCL/SCAN/...) is
+        // left untouched.
+        auto scan =
+            std::make_shared<ouster::sdk::core::LidarScan>(lidar_scan);
+        ouster::sdk::core::LidarScanSet scan_set({scan});
+        slam_engine->update(scan_set);
+
+        const auto& updated = scan_set[0];
+        const int col = updated->get_last_valid_column();
+        if (col < 0) return;
+
+        const ouster::sdk::core::Matrix4dR pose =
+            updated->get_column_pose(col);
+        const uint64_t pose_ts = updated->timestamp()[col];
+        const rclcpp::Time stamp(static_cast<int64_t>(pose_ts), RCL_ROS_TIME);
+
+        const Eigen::Vector3d translation = pose.block<3, 1>(0, 3);
+        const Eigen::Matrix3d rotation = pose.block<3, 3>(0, 0);
+        const Eigen::Quaterniond q(rotation);
+
+        odom_msg->header.stamp = stamp;
+        odom_msg->pose.pose.position.x = translation.x();
+        odom_msg->pose.pose.position.y = translation.y();
+        odom_msg->pose.pose.position.z = translation.z();
+        odom_msg->pose.pose.orientation.x = q.x();
+        odom_msg->pose.pose.orientation.y = q.y();
+        odom_msg->pose.pose.orientation.z = q.z();
+        odom_msg->pose.pose.orientation.w = q.w();
+
+        if (have_prev_pose) {
+            const double dt = (stamp - prev_stamp).seconds();
+            if (dt > 1e-6) {
+                // body-frame linear velocity approximated from consecutive
+                // SLAM poses; no independent velocity estimate is available.
+                const Eigen::Vector3d body_v =
+                    prev_rotation.transpose() *
+                    (translation - prev_translation) / dt;
+                odom_msg->twist.twist.linear.x = body_v.x();
+                odom_msg->twist.twist.linear.y = body_v.y();
+                odom_msg->twist.twist.linear.z = body_v.z();
+            }
+        }
+        prev_translation = translation;
+        prev_rotation = rotation;
+        prev_stamp = stamp;
+        have_prev_pose = true;
+
+        geometry_msgs::msg::PoseStamped pose_stamped;
+        pose_stamped.header = odom_msg->header;
+        pose_stamped.pose = odom_msg->pose.pose;
+        trajectory_msg->header.stamp = stamp;
+        trajectory_msg->poses.push_back(pose_stamped);
+
+        OutputType output;
+        output.odom = odom_msg;
+        output.trajectory = trajectory_msg;
+
+        if (++scan_count % static_cast<uint64_t>(map_publish_every_n_) == 0) {
+            accumulate_map(*updated, pose);
+            pcl::toPCLPointCloud2(*map_cloud, staging_pcl_pc2);
+            pcl_conversions::moveFromPCL(staging_pcl_pc2, *map_msg);
+            map_msg->header.frame_id = odom_frame;
+            map_msg->header.stamp = stamp;
+            output.map = map_msg;
+        }
+
+        if (post_processing_fn) post_processing_fn(output);
+    }
+
+    void accumulate_map(const ouster::sdk::core::LidarScan& scan,
+                        const ouster::sdk::core::Matrix4dR& pose) {
+        auto range = scan.field<uint32_t>(ouster::sdk::core::ChanField::RANGE);
+        ouster::cartesianT(points_buffer, range, lut_direction, lut_offset,
+                           min_range_mm, max_range_mm,
+                           std::numeric_limits<float>::quiet_NaN());
+
+        const Eigen::Matrix3d rotation = pose.block<3, 3>(0, 0);
+        const Eigen::Vector3d translation = pose.block<3, 1>(0, 3);
+
+        pcl::PointCloud<pcl::PointXYZ>::Ptr scan_cloud(
+            new pcl::PointCloud<pcl::PointXYZ>());
+        scan_cloud->reserve(static_cast<size_t>(points_buffer.rows()));
+        for (int i = 0; i < points_buffer.rows(); ++i) {
+            const float x = points_buffer(i, 0);
+            const float y = points_buffer(i, 1);
+            const float z = points_buffer(i, 2);
+            if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z))
+                continue;
+            const Eigen::Vector3d world_pt =
+                rotation * Eigen::Vector3d(x, y, z) + translation;
+            scan_cloud->emplace_back(static_cast<float>(world_pt.x()),
+                                     static_cast<float>(world_pt.y()),
+                                     static_cast<float>(world_pt.z()));
+        }
+
+        *map_cloud += *scan_cloud;
+        pcl::PointCloud<pcl::PointXYZ>::Ptr filtered(
+            new pcl::PointCloud<pcl::PointXYZ>());
+        voxel_filter.setInputCloud(map_cloud);
+        voxel_filter.filter(*filtered);
+        map_cloud = filtered;
+    }
+
+   public:
+    static LidarScanProcessor create(
+        const ouster::sdk::core::SensorInfo& info,
+        const std::string& odom_frame_id, const std::string& child_frame_id,
+        double min_range, double max_range, double voxel_size,
+        const std::string& deskew_method, double map_voxel_size,
+        int map_publish_every_n, PostProcessingFn func) {
+        auto handler = std::make_shared<SlamProcessor>(
+            info, odom_frame_id, child_frame_id, min_range, max_range,
+            voxel_size, deskew_method, map_voxel_size, map_publish_every_n,
+            func);
+
+        return [handler](const ouster::sdk::core::LidarScan& lidar_scan,
+                         uint64_t scan_ts, const rclcpp::Time& msg_ts) {
+            handler->process(lidar_scan, scan_ts, msg_ts);
+        };
+    }
+
+   private:
+    std::string odom_frame;
+    std::string child_frame;
+    uint32_t min_range_mm;
+    uint32_t max_range_mm;
+    int map_publish_every_n_;
+    uint64_t scan_count{0};
+    PostProcessingFn post_processing_fn;
+
+    ouster::sdk::core::SensorInfo sensor_info_;
+    ouster::sdk::mapping::SlamConfig slam_config;
+    std::unique_ptr<ouster::sdk::mapping::SlamEngine> slam_engine;
+
+    bool have_last_scan_ts{false};
+    uint64_t last_scan_ts_ns{0};
+
+    ouster::sdk::core::ArrayX3fR lut_direction;
+    ouster::sdk::core::ArrayX3fR lut_offset;
+    ouster::sdk::core::PointCloudXYZf points_buffer;
+
+    pcl::PointCloud<pcl::PointXYZ>::Ptr map_cloud;
+    pcl::VoxelGrid<pcl::PointXYZ> voxel_filter;
+    pcl::PCLPointCloud2 staging_pcl_pc2;
+
+    bool have_prev_pose{false};
+    rclcpp::Time prev_stamp;
+    Eigen::Vector3d prev_translation{Eigen::Vector3d::Zero()};
+    Eigen::Matrix3d prev_rotation{Eigen::Matrix3d::Identity()};
+
+    std::shared_ptr<nav_msgs::msg::Odometry> odom_msg;
+    std::shared_ptr<nav_msgs::msg::Path> trajectory_msg;
+    std::shared_ptr<sensor_msgs::msg::PointCloud2> map_msg;
+};
+
+}  // namespace ouster_ros


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes
Enable SLAM directly from the driver

### TODO(s)
* Publish the motion compensated frame to a separate topic
* The accumulated map should have the same attributes as the raw pointcloud.

## Validation
```bash
ros2 launch ouster_ros replay.launch.xml \
  bag_file:=data/Rev8_ROS2_Webinar_sample_data.bag.bag \
  viz:=true loop:=true proc_mask:="IMU|PCL|SLAM" \
  point_type:=xyzrgb slam_map_voxel_size:=0.1
```

<img width="3054" height="1725" alt="image" src="https://github.com/user-attachments/assets/ff124ab5-b6af-4235-91b5-a26d37d19f90" />
